### PR TITLE
hotfix serp api for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "turbo run test",
     "publish": "turbo run build lint test && yarn workspace langchain npm publish",
     "example": "turbo run start --filter langchain-examples --",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "node ./scripts/postinstall.js"
   },
   "author": "Langchain",
   "license": "MIT",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,19 +1,20 @@
 // postinstall functions to handle any tasks, fixes or hacks that may arise as a result of dependency issues
 
-function postinstall() {
+(function postinstall() {
   // This is a hack to fix a bug in the domexception package
   // replace line 34 of node_modules/domexception/lib/utils.js
   // original: const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
   // replaced: const AsyncIteratorPrototype = Object.getPrototypeOf(async function* () {}).prototype;
     const fs = require('fs');
     const path = require('path');
-    const utilsPath = path.join(__dirname, 'node_modules/domexception/lib/utils.js');
+    const utilsPath = path.join('./node_modules/domexception/lib/utils.js');
     const utils = fs.readFileSync(utilsPath, 'utf8');
     const fixedUtils = utils.replace(
         "const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);",
         "const AsyncIteratorPrototype = Object.getPrototypeOf(async function* () {}).prototype;"
     );
     // save fixedUtils
-    const fixedUtilsPath = path.join(__dirname, 'node_modules/domexception/lib/utils.js');
+    const fixedUtilsPath = path.join('./node_modules/domexception/lib/utils.js');
     fs.writeFileSync(fixedUtilsPath, fixedUtils, 'utf8');
-}
+    console.log('wrote file')
+})()

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,19 @@
+// postinstall functions to handle any tasks, fixes or hacks that may arise as a result of dependency issues
+
+function postinstall() {
+  // This is a hack to fix a bug in the domexception package
+  // replace line 34 of node_modules/domexception/lib/utils.js
+  // original: const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
+  // replaced: const AsyncIteratorPrototype = Object.getPrototypeOf(async function* () {}).prototype;
+    const fs = require('fs');
+    const path = require('path');
+    const utilsPath = path.join(__dirname, 'node_modules/domexception/lib/utils.js');
+    const utils = fs.readFileSync(utilsPath, 'utf8');
+    const fixedUtils = utils.replace(
+        "const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);",
+        "const AsyncIteratorPrototype = Object.getPrototypeOf(async function* () {}).prototype;"
+    );
+    // save fixedUtils
+    const fixedUtilsPath = path.join(__dirname, 'node_modules/domexception/lib/utils.js');
+    fs.writeFileSync(fixedUtilsPath, fixedUtils, 'utf8');
+}


### PR DESCRIPTION
This is a PR to fix the bug https://github.com/hwchase17/langchainjs/issues/3

This is a hotfix to get tests to pass.

After install, a postinstall script is run that edits the jsdomexceptions npm module. SerpApi depends on jsdom, which depends on jsdomexceptions, which is throwing an error when it trying to get the prototype of the prototype of a function. The script edits line 34 of the utils.js script in that module to only unwrap once, ignoring the error. Unless we have deep exceptions occurring, which I doubt, I think it's fine.