### PR TITLE
Implement OpenAI LLM completion streaming

### DIFF
--- a/docs/docs/modules/chains/llm_chain.md
+++ b/docs/docs/modules/chains/llm_chain.md
@@ -33,3 +33,14 @@ console.log({ res });
 ```shell
 { res: { text: '\n\nColorfulCo Sockery.' } }
 ```
+
+LLMChain also supports output streaming by providing both the `streaming: true` parameter and the appropriate `callbackManager.handleNewToken` callback function.
+
+```typescript
+const model = new OpenAI({
+  streaming: true,
+  callbackManager: {
+    handleNewToken: (token) => console.log(token),
+  },
+});
+```

--- a/examples/src/chains/llm_chain_stream.ts
+++ b/examples/src/chains/llm_chain_stream.ts
@@ -1,0 +1,20 @@
+import { OpenAI } from "langchain/llms";
+import { PromptTemplate } from "langchain/prompts";
+import { LLMChain } from "langchain/chains";
+
+export const run = async () => {
+  const model = new OpenAI({
+    temperature: 0.9,
+    streaming: true,
+    callbackManager: {
+      handleNewToken(token) {
+        console.log({ token });
+      },
+    },
+  });
+  const template = "What is a good name for a company that makes {product}?";
+  const prompt = new PromptTemplate({ template, inputVariables: ["product"] });
+  const chain = new LLMChain({ llm: model, prompt });
+  const res = await chain.call({ product: "colorful socks" });
+  console.log({ res });
+};

--- a/langchain/llms/base.ts
+++ b/langchain/llms/base.ts
@@ -55,7 +55,7 @@ export abstract class BaseLLM {
     prompts: string[],
     stop?: string[]
   ): Promise<LLMResult> {
-    this.callbackManager.handleStart(
+    this.callbackManager.handleStart?.(
       { name: this.name },
       prompts,
       this.verbose
@@ -64,11 +64,11 @@ export abstract class BaseLLM {
     try {
       output = await this._generate(prompts, stop);
     } catch (err) {
-      this.callbackManager.handleError(`${err}`, this.verbose);
+      this.callbackManager.handleError?.(`${err}`, this.verbose);
       throw err;
     }
 
-    this.callbackManager.handleEnd(output, this.verbose);
+    this.callbackManager.handleEnd?.(output, this.verbose);
     return output;
   }
 

--- a/langchain/llms/index.ts
+++ b/langchain/llms/index.ts
@@ -4,13 +4,14 @@ export { Cohere } from "./cohere";
 export { loadLLM } from "./load";
 
 export type LLMCallbackManager = {
-  handleStart: (
+  handleStart?: (
     llm: { name: string },
     prompts: string[],
     verbose?: boolean
   ) => void;
-  handleError: (err: string, verbose?: boolean) => void;
-  handleEnd: (output: LLMResult, verbose?: boolean) => void;
+  handleNewToken?: (token: string, verbose?: boolean) => void;
+  handleError?: (err: string, verbose?: boolean) => void;
+  handleEnd?: (output: LLMResult, verbose?: boolean) => void;
 };
 
 /**

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -75,6 +75,7 @@
   },
   "dependencies": {
     "deepcopy": "^2.1.0",
+    "eventsource-parser": "^0.1.0",
     "exponential-backoff": "^3.1.0",
     "expr-eval": "^2.0.2",
     "node-fetch": "2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6660,6 +6660,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eventsource-parser@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "eventsource-parser@npm:0.1.0"
+  checksum: 873c24a4777887f9963945e3b54ec7d12a2031b9eacaa1a2d2cc025c0778fdf4429db9a7cf72aae72211ffbf0da8ef6bfe199846dffee2d7acd4f49394037332
+  languageName: node
+  linkType: hard
+
 "execa@npm:^5.0.0":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
@@ -9355,6 +9362,7 @@ __metadata:
     eslint-config-prettier: ^8.6.0
     eslint-plugin-import: ^2.27.5
     eslint-plugin-prettier: ^4.2.1
+    eventsource-parser: ^0.1.0
     exponential-backoff: ^3.1.0
     expr-eval: ^2.0.2
     hnswlib-node: ^1.2.0


### PR DESCRIPTION
This PR implements streaming of inner completion results via `callbackManager`.

Similar PR to the Python counterpart: https://github.com/hwchase17/langchain/pull/986

*Usage*:
```typescript
const model = new OpenAI({
  streaming: true,
  callbackManager: {
    handleNewToken(token) {
      ...
    },
  },
});
```