### PR TITLE
Update SerpAPI installation instructions

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -162,7 +162,7 @@ In order to load agents, you should understand the following concepts:
 - LLM: The language model powering the agent.
 - Agent: The agent to use. This should be a string that references a support agent class. Because this notebook focuses on the simplest, highest level API, this only covers using the standard supported agents.
 
-For this example, you will also need to install the SerpAPI Python package.
+For this example, you will also need to install the SerpAPI package for JavaScript/TypeScript.
 
 ```bash
 npm i serpapi

--- a/docs/docs/modules/agents/load_from_hub.md
+++ b/docs/docs/modules/agents/load_from_hub.md
@@ -2,7 +2,7 @@
 
 [LangChainHub](https://github.com/hwchase17/langchain-hub) contains a collection of chains which can be loaded directly via LangChain.
 
-For this example, you will also need to install the SerpAPI Python package.
+For this example, you will also need to install the SerpAPI package for JavaScript/TypeScript.
 
 ```bash
 npm i serpapi

--- a/docs/docs/modules/agents/overview.md
+++ b/docs/docs/modules/agents/overview.md
@@ -11,7 +11,7 @@ In order to load agents, you should understand the following concepts:
 - LLM: The language model powering the agent.
 - Agent: The agent to use. This should be a string that references a support agent class. Because this notebook focuses on the simplest, highest level API, this only covers using the standard supported agents.
 
-For this example, you will also need to install the SerpAPI Python package.
+For this example, you will also need to install the SerpAPI package for JavaScript/TypeScript.
 
 ```bash
 npm i serpapi


### PR DESCRIPTION
The docs said to 'install the SerpAPI Python package'. I changed it to 'SerpAPI package for JavaScript/TypeScript' to make the instructions more precise.