### PR TITLE
Add support for Pinecone vectorstore

### DIFF
--- a/docs/docs/modules/indexes/vectorstore.md
+++ b/docs/docs/modules/indexes/vectorstore.md
@@ -14,3 +14,24 @@ const vectorStore = await HNSWLib.fromTexts(
 
 const resultOne = await vectorStore.similaritySearch("hello world", 1);
 ```
+
+## Pinecone vectorstore
+
+Langchain.js accepts [pinecone-client](https://github.com/rileytomasek/pinecone-client) as the client for Pinecone vectorstore. Install the library with `npm install -S pinecone-client`.
+
+```typescript
+import { PineconeStore } from "langchain/vectorstores";
+import { OpenAIEmbeddings } from "langchain/embeddings";
+import { PineconeClient } from "pinecone-client";
+
+const client = new PineconeClient({});
+
+const vectorStore = await PineconeStore.fromTexts(
+  client,
+  ["Hello world", "Bye bye", "hello nice world"],
+  [{ id: 2 }, { id: 1 }, { id: 3 }],
+  new OpenAIEmbeddings()
+);
+
+const resultOne = await vectorStore.similaritySearch("Hello world", 2);
+```

--- a/examples/package.json
+++ b/examples/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "langchain": "workspace:*",
     "openai": "^3.1.0",
+    "pinecone-client": "^1.0.1",
     "serpapi": "^1.1.0"
   },
   "devDependencies": {

--- a/examples/src/indexes/vectorstores_pinecone.ts
+++ b/examples/src/indexes/vectorstores_pinecone.ts
@@ -1,0 +1,20 @@
+import { PineconeStore } from "langchain/vectorstores";
+import { OpenAIEmbeddings } from "langchain/embeddings";
+import { PineconeClient } from "pinecone-client";
+
+export const run = async () => {
+  const client = new PineconeClient({});
+
+  const vectorStore = await PineconeStore.fromTexts(
+    client,
+    ["Hello world", "Bye bye", "hello nice world"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }],
+    new OpenAIEmbeddings()
+  );
+
+  const resultOne = await vectorStore.similaritySearchWithScore(
+    "Hello world",
+    2
+  );
+  console.dir(resultOne, { depth: null });
+};

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -81,6 +81,11 @@
   "peerDependencies": {
     "pinecone-client": "^1.0.1"
   },
+  "peerDependenciesMeta": {
+    "pinecone-client": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "deepcopy": "^2.1.0",
     "eventsource-parser": "^0.1.0",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -54,6 +54,7 @@
     "@jest/globals": "^29.4.2",
     "@tsconfig/recommended": "^1.0.2",
     "@types/node-fetch": "2",
+    "@types/uuid": "^9",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.51.0",
     "babel-jest": "^29.4.2",
@@ -77,12 +78,16 @@
     "typedoc-plugin-missing-exports": "^1.0.0",
     "typescript": "^4.9.5"
   },
+  "peerDependencies": {
+    "pinecone-client": "^1.0.1"
+  },
   "dependencies": {
     "deepcopy": "^2.1.0",
     "eventsource-parser": "^0.1.0",
     "exponential-backoff": "^3.1.0",
     "expr-eval": "^2.0.2",
     "node-fetch": "2",
+    "uuid": "^9.0.0",
     "yaml": "^2.2.1"
   },
   "lint-staged": {

--- a/langchain/vectorstores/base.ts
+++ b/langchain/vectorstores/base.ts
@@ -3,13 +3,15 @@ import { Document } from "../document";
 
 // Temporary until we have a DocStore class
 export interface DocStore {
-  [key: number]: object;
+  [key: number]: Document;
 }
 
 export abstract class VectorStore {
   embeddings: Embeddings;
 
-  docstore: DocStore;
+  constructor(embeddings: Embeddings) {
+    this.embeddings = embeddings;
+  }
 
   abstract addVectors(
     vectors: number[][],
@@ -20,11 +22,6 @@ export abstract class VectorStore {
     query: number[],
     k: number
   ): Promise<[Document, number][]>;
-
-  async addDocuments(documents: Document[]): Promise<void> {
-    const texts = documents.map(({ pageContent }) => pageContent);
-    this.addVectors(await this.embeddings.embedDocuments(texts), documents);
-  }
 
   async similaritySearch(query: string, k = 4): Promise<Document[]> {
     const results = await this.similaritySearchVectorWithScore(

--- a/langchain/vectorstores/hnswlib.ts
+++ b/langchain/vectorstores/hnswlib.ts
@@ -27,6 +27,8 @@ export interface HNSWLibArgs {
 export class HNSWLib extends SaveableVectorStore {
   index?: HierarchicalNSWT;
 
+  docstore: DocStore;
+
   args: HNSWLibArgs;
 
   constructor(
@@ -35,11 +37,16 @@ export class HNSWLib extends SaveableVectorStore {
     docstore: DocStore,
     index?: HierarchicalNSWT
   ) {
-    super();
+    super(embeddings);
     this.index = index;
     this.args = args;
     this.embeddings = embeddings;
     this.docstore = docstore;
+  }
+
+  async addDocuments(documents: Document[]): Promise<void> {
+    const texts = documents.map(({ pageContent }) => pageContent);
+    this.addVectors(await this.embeddings.embedDocuments(texts), documents);
   }
 
   async addVectors(vectors: number[][], documents: Document[]) {

--- a/langchain/vectorstores/index.ts
+++ b/langchain/vectorstores/index.ts
@@ -1,1 +1,2 @@
 export { HNSWLib } from "./hnswlib";
+export { PineconeStore } from "./pinecone";

--- a/langchain/vectorstores/pinecone.ts
+++ b/langchain/vectorstores/pinecone.ts
@@ -1,0 +1,116 @@
+import type { PineconeClient } from "pinecone-client";
+import { v4 as uuidv4 } from "uuid";
+
+import { VectorStore } from "./base";
+import { Embeddings } from "../embeddings/base";
+import { Document } from "../document";
+
+// eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
+type PineconeMetadata = Record<string, any>;
+
+export class PineconeStore extends VectorStore {
+  textKey: string;
+
+  pineconeClient: PineconeClient<PineconeMetadata>;
+
+  constructor(
+    pineconeClient: PineconeClient<PineconeMetadata>,
+    embeddings: Embeddings,
+    textKey = "text"
+  ) {
+    super(embeddings);
+
+    this.pineconeClient = pineconeClient;
+    this.embeddings = embeddings;
+    this.textKey = textKey;
+  }
+
+  async addDocuments(documents: Document[], ids?: string[]): Promise<void> {
+    const texts = documents.map(({ pageContent }) => pageContent);
+    return this.addVectors(
+      await this.embeddings.embedDocuments(texts),
+      documents,
+      ids
+    );
+  }
+
+  async addVectors(vectors: number[][], documents: Document[], ids?: string[]) {
+    const documentIds = ids == null ? documents.map(() => uuidv4()) : ids;
+
+    return this.pineconeClient.upsert({
+      vectors: vectors.map((values, idx) => ({
+        id: documentIds[idx],
+        metadata: {
+          ...documents[idx].metadata,
+          [this.textKey]: documents[idx].pageContent,
+        },
+        values,
+      })),
+    });
+  }
+
+  async similaritySearchVectorWithScore(
+    query: number[],
+    k: number
+  ): Promise<[Document, number][]> {
+    const results = await this.pineconeClient.query({
+      topK: k,
+      includeMetadata: true,
+      vector: query,
+    });
+
+    const result: [Document, number][] = [];
+
+    for (const res of results.matches) {
+      const { [this.textKey]: pageContent, ...metadata } =
+        res.metadata as PineconeMetadata;
+      result.push([new Document({ metadata, pageContent }), res.score]);
+    }
+
+    return result;
+  }
+
+  static async fromTexts(
+    pineconeClient: PineconeClient<PineconeMetadata>,
+    texts: string[],
+    metadatas: object[],
+    embeddings: Embeddings,
+    textKey = "text"
+  ): Promise<PineconeStore> {
+    const docs = [];
+    for (let i = 0; i < texts.length; i += 1) {
+      const newDoc = new Document({
+        pageContent: texts[i],
+        metadata: metadatas[i],
+      });
+      docs.push(newDoc);
+    }
+
+    return PineconeStore.fromDocuments(
+      pineconeClient,
+      docs,
+      embeddings,
+      textKey
+    );
+  }
+
+  static async fromDocuments(
+    pineconeClient: PineconeClient<PineconeMetadata>,
+    docs: Document[],
+    embeddings: Embeddings,
+    textKey = "text"
+  ): Promise<PineconeStore> {
+    const instance = new this(pineconeClient, embeddings, textKey);
+    await instance.addDocuments(docs);
+    return instance;
+  }
+
+  static async fromExistingIndex(
+    pineconeClient: PineconeClient<PineconeMetadata>,
+    embeddings: Embeddings,
+    textKey = "text"
+  ): Promise<PineconeStore> {
+    const instance = new this(pineconeClient, embeddings, textKey);
+    return instance;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9398,6 +9398,9 @@ __metadata:
     yaml: ^2.2.1
   peerDependencies:
     pinecone-client: ^1.0.1
+  peerDependenciesMeta:
+    pinecone-client:
+      optional: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3459,6 +3459,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:^9":
+  version: 9.0.0
+  resolution: "@types/uuid@npm:9.0.0"
+  checksum: 59ae56d9547c8758588659da2a2b4c97cce79c2aae1798c892bb29452ef08e87859dea2ec3a66bfa88d0d2153147520be2b1893be920f9f0bc9c53a3207ea6aa
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:^8.5.1":
   version: 8.5.4
   resolution: "@types/ws@npm:8.5.4"
@@ -9321,6 +9328,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ky@npm:^0.33.1":
+  version: 0.33.2
+  resolution: "ky@npm:0.33.2"
+  checksum: bb5b1685b7d639dad5fc0a41a218f76c2400d2a9189bcf747f541633af13b68a7ef12bb8aa971bc1667087789ec5965cc3728e24b693897a2d0cc539d7593655
+  languageName: node
+  linkType: hard
+
 "langchain-examples@workspace:examples":
   version: 0.0.0-use.local
   resolution: "langchain-examples@workspace:examples"
@@ -9336,6 +9350,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     langchain: "workspace:*"
     openai: ^3.1.0
+    pinecone-client: ^1.0.1
     prettier: ^2.8.3
     serpapi: ^1.1.0
     typescript: ^4.9.5
@@ -9351,6 +9366,7 @@ __metadata:
     "@jest/globals": ^29.4.2
     "@tsconfig/recommended": ^1.0.2
     "@types/node-fetch": 2
+    "@types/uuid": ^9
     "@typescript-eslint/eslint-plugin": ^5.51.0
     "@typescript-eslint/parser": ^5.51.0
     babel-jest: ^29.4.2
@@ -9378,7 +9394,10 @@ __metadata:
     typedoc: ^0.23.25
     typedoc-plugin-missing-exports: ^1.0.0
     typescript: ^4.9.5
+    uuid: ^9.0.0
     yaml: ^2.2.1
+  peerDependencies:
+    pinecone-client: ^1.0.1
   languageName: unknown
   linkType: soft
 
@@ -10759,6 +10778,15 @@ __metadata:
   bin:
     pidtree: bin/pidtree.js
   checksum: 8fbc073ede9209dd15e80d616e65eb674986c93be49f42d9ddde8dbbd141bb53d628a7ca4e58ab5c370bb00383f67d75df59a9a226dede8fa801267a7030c27a
+  languageName: node
+  linkType: hard
+
+"pinecone-client@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "pinecone-client@npm:1.0.1"
+  dependencies:
+    ky: ^0.33.1
+  checksum: ec7cc0f3a2a9f580d1dcb5229b86ee9c120d322b48dd37311875f8a3872128a7999e0bc9af2969d457fd52098c9ec9ca231bd73a9bc08a4b40eefd1f94333fef
   languageName: node
   linkType: hard
 
@@ -13909,6 +13937,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Uses https://github.com/rileytomasek/pinecone-client as the client for Pinecone. 

The [official client](https://github.com/pinecone-io/pinecone-ts-client) is currently marked as `beta` and uses `axios`, which may further prevent us to support Edge runtime etc. 