### PR TITLE
Add implementation of TokenTextSplitter

### DIFF
--- a/docs/docs/modules/indexes/text_splitter.md
+++ b/docs/docs/modules/indexes/text_splitter.md
@@ -51,3 +51,22 @@ const splitter = new CharacterTextSplitter({
 });
 const output = splitter.createDocuments([text]);
 ```
+
+Finally, `TokenTextSplitter` splits a raw text string by first converting the text into BPE tokens, then split these tokens into chunks and convert the tokens within a single chunk back into text.
+
+To utilize the `TokenTextSplitter`, first install the accompanying required library: `npm install -S @dqbd/tiktoken`.
+
+```typescript
+import { Document } from "langchain/document";
+import { TokenTextSplitter } from "langchain/text_splitter";
+
+const text = "foo bar baz 123";
+
+const splitter = new TokenTextSplitter({
+  encodingName: "gpt2",
+  chunkSize: 10,
+  chunkOverlap: 0,
+});
+
+const output = splitter.createDocuments([text]);
+```

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,6 +19,7 @@
   "author": "Langchain",
   "license": "MIT",
   "dependencies": {
+    "@dqbd/tiktoken": "^0.2.1",
     "langchain": "workspace:*",
     "openai": "^3.1.0",
     "pinecone-client": "^1.0.1",

--- a/examples/src/indexes/token_text_splitter.ts
+++ b/examples/src/indexes/token_text_splitter.ts
@@ -1,0 +1,27 @@
+import { Document } from "langchain/document";
+import { TokenTextSplitter } from "langchain/text_splitter";
+import fs from "fs";
+import path from "path";
+
+export const run = async () => {
+  /* Split text */
+  const text = fs.readFileSync(
+    path.resolve(__dirname, "../../state_of_the_union.txt"),
+    "utf8"
+  );
+
+  const splitter = new TokenTextSplitter({
+    encodingName: "r50k_base",
+    chunkSize: 10,
+    chunkOverlap: 0,
+  });
+
+  const output = splitter.createDocuments([text]);
+  console.log({ output });
+
+  const docOutput = splitter.splitDocuments([
+    new Document({ pageContent: text }),
+  ]);
+
+  console.log({ docOutput });
+};

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -79,9 +79,13 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
+    "@dqbd/tiktoken": "^0.2.1",
     "pinecone-client": "^1.0.1"
   },
   "peerDependenciesMeta": {
+    "@dqbd/tiktoken": {
+      "optional": true
+    },
     "pinecone-client": {
       "optional": true
     }

--- a/langchain/tests/text_splitter.test.ts
+++ b/langchain/tests/text_splitter.test.ts
@@ -3,6 +3,7 @@ import { Document } from "../document";
 import {
   CharacterTextSplitter,
   RecursiveCharacterTextSplitter,
+  TokenTextSplitter,
 } from "../text_splitter";
 
 test("Test splitting by character count.", () => {
@@ -135,5 +136,18 @@ Bye!\n\n-H.`;
     "some how.",
     "Bye!\n\n-H.",
   ];
+  expect(output).toEqual(expectedOutput);
+});
+
+test("Token text splitter", () => {
+  const text = "foo bar baz a a";
+  const splitter = new TokenTextSplitter({
+    encodingName: "r50k_base",
+    chunkSize: 3,
+    chunkOverlap: 0,
+  });
+  const output = splitter.splitText(text);
+  const expectedOutput = ["foo bar b", "az a a"];
+
   expect(output).toEqual(expectedOutput);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,6 +2248,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dqbd/tiktoken@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@dqbd/tiktoken@npm:0.2.1"
+  checksum: 1d3fd243112b154ced97985585a439837401614e0498c9798899d925f781de769da9a0918b3f4d4c4dded1e172a546b6ec4713ad988a7990c9e1872d341b7098
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^1.4.1":
   version: 1.4.1
   resolution: "@eslint/eslintrc@npm:1.4.1"
@@ -9339,6 +9346,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "langchain-examples@workspace:examples"
   dependencies:
+    "@dqbd/tiktoken": ^0.2.1
     "@tsconfig/recommended": ^1.0.2
     "@typescript-eslint/eslint-plugin": ^5.51.0
     "@typescript-eslint/parser": ^5.51.0
@@ -9397,8 +9405,11 @@ __metadata:
     uuid: ^9.0.0
     yaml: ^2.2.1
   peerDependencies:
+    "@dqbd/tiktoken": ^0.2.1
     pinecone-client: ^1.0.1
   peerDependenciesMeta:
+    "@dqbd/tiktoken":
+      optional: true
     pinecone-client:
       optional: true
   languageName: unknown


### PR DESCRIPTION
This PR aims to implement TokenTextSplitter by utilising JS-Rust binding of [`openai/tiktoken`](https://github.com/openai/tiktoken): 

Disclaimer: The bindings are maintained in a separate repository https://github.com/dqbd/tiktoken, aiming to upstream the changes back to the official repository. 