### PR TITLE
Add PromptLayer OpenAI wrapper integration

### DIFF
--- a/docs/docs/modules/llms/openai.md
+++ b/docs/docs/modules/llms/openai.md
@@ -11,3 +11,21 @@ const res = await model.call(
 );
 console.log({ res });
 ```
+
+## PromptLayer OpenAI
+
+This library supports PromptLayer for logging and debugging prompts and responses. To add support for PromptLayer:
+
+1. Create a PromptLayer account here: [https://promptlayer.com](https://promptlayer.com).
+2. Create an API token and pass it either as `promptLayerApiKey` argument in the `PromptLayerOpenAI` constructor or in the `PROMPT_LAYER_API_KEY` environment variable.
+
+```typescript
+const model = new PromptLayerOpenAI({ temperature: 0.9 });
+const res = await model.call(
+  "What would be a good company name a company that makes colorful socks?"
+);
+```
+
+The request and the response will be logged in the [PromptLayer dashboard](https://promptlayer.com/home).
+
+Note: In streaming mode PromptLayer will not log the response.

--- a/examples/src/llm_promptlayer.ts
+++ b/examples/src/llm_promptlayer.ts
@@ -1,0 +1,9 @@
+import { PromptLayerOpenAI } from "langchain/llms";
+
+export const run = async () => {
+  const model = new PromptLayerOpenAI({ temperature: 0.9 });
+  const res = await model.call(
+    "What would be a good company name a company that makes colorful socks?"
+  );
+  console.log({ res });
+};

--- a/langchain/llms/index.ts
+++ b/langchain/llms/index.ts
@@ -1,5 +1,5 @@
 export { BaseLLM, LLM, SerializedLLM } from "./base";
-export { OpenAI } from "./openai";
+export { OpenAI, PromptLayerOpenAI } from "./openai";
 export { Cohere } from "./cohere";
 export { loadLLM } from "./load";
 

--- a/langchain/llms/openai.ts
+++ b/langchain/llms/openai.ts
@@ -7,6 +7,7 @@ import type {
 } from "openai";
 import type { IncomingMessage } from "http";
 
+import fetch from "node-fetch";
 import { createParser } from "eventsource-parser";
 import { backOff } from "exponential-backoff";
 import { chunkArray } from "../util";


### PR DESCRIPTION
This PR adds the unofficial PromptLayer integration, which will capture the requests and responses and send them to PromptLayer.

Note: I don't think there is an official support for streaming responses, which is why it is ignored for now.