### PR TITLE
UNTESTED attempt to replace default docusaurus social card image

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -97,7 +97,7 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      image: "img/docusaurus-social-card.jpg",
+      image: "img/docusaurus.png",
       navbar: {
         title: "Langchain",
         logo: {


### PR DESCRIPTION
on a mobile device so i can't test it, and i'm not familiar with docusaurus so i don't know for sure, but this image matches the one that twitter is unfurling the links with. saw @hwchase17 added a placeholder langchain image in the directory, so just slapping that one on as a temporary solution? 🤷 

<img width="578" alt="image" src="https://user-images.githubusercontent.com/3076502/220221828-92205c67-05fc-4335-a31d-6a261c5f4aae.png">
