### PR TITLE
Proposal 2 of 2: Add concurrency control to BaseLLM

### DIFF
--- a/docs/docs/modules/chains/question_answering.md
+++ b/docs/docs/modules/chains/question_answering.md
@@ -28,7 +28,9 @@ import { OpenAI } from "langchain/llms";
 import { loadQAChain } from "langchain/chains";
 import { Document } from "langchain/document";
 
-const model = new OpenAI({});
+// Optionally limit the nr of concurrent requests to the language model,
+// if you have a lot of documents, to avoid rate limiting.
+const model = new OpenAI({ concurrency: 10 });
 const chain = loadQAChain(llm, { type: "map_reduce" });
 const docs = [
   new Document({ pageContent: "harrison went to harvard" }),

--- a/langchain/llms/cohere.ts
+++ b/langchain/llms/cohere.ts
@@ -25,9 +25,16 @@ export class Cohere extends LLM implements CohereInput {
     fields?: Partial<CohereInput> & {
       callbackManager?: LLMCallbackManager;
       verbose?: boolean;
+      concurrency?: number;
+      cache?: boolean;
     }
   ) {
-    super(fields?.callbackManager, fields?.verbose);
+    super(
+      fields?.callbackManager,
+      fields?.verbose,
+      fields?.concurrency,
+      fields?.cache
+    );
 
     this.maxTokens = fields?.maxTokens ?? this.maxTokens;
     this.temperature = fields?.temperature ?? this.temperature;

--- a/langchain/llms/openai.ts
+++ b/langchain/llms/openai.ts
@@ -140,12 +140,19 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
   constructor(
     fields?: Partial<OpenAIInput> & {
       callbackManager?: LLMCallbackManager;
+      concurrency?: number;
+      cache?: boolean;
       verbose?: boolean;
       openAIApiKey?: string;
     },
     configuration?: ConfigurationParameters
   ) {
-    super(fields?.callbackManager, fields?.verbose);
+    super(
+      fields?.callbackManager,
+      fields?.verbose,
+      fields?.concurrency,
+      fields?.cache
+    );
     if (Configuration === null || OpenAIApi === null) {
       throw new Error(
         "Please install openai as a dependency with, e.g. `npm i openai`"

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -144,6 +144,7 @@
     "expr-eval": "^2.0.2",
     "gpt-3-encoder": "^1.1.4",
     "node-fetch": "2",
+    "p-queue": "6",
     "uuid": "^9.0.0",
     "yaml": "^2.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6660,7 +6660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.0":
+"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
@@ -9405,6 +9405,7 @@ __metadata:
     lint-staged: ^13.1.1
     node-fetch: 2
     openai: ^3.1.0
+    p-queue: 6
     pinecone-client: ^1.0.1
     prettier: ^2.8.3
     serpapi: ^1.1.1
@@ -10545,6 +10546,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-finally@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "p-finally@npm:1.0.0"
+  checksum: 93a654c53dc805dd5b5891bab16eb0ea46db8f66c4bfd99336ae929323b1af2b70a8b0654f8f1eae924b2b73d037031366d645f1fd18b3d30cbd15950cc4b1d4
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:^2.0.0, p-limit@npm:^2.2.0":
   version: 2.3.0
   resolution: "p-limit@npm:2.3.0"
@@ -10599,6 +10607,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-queue@npm:6":
+  version: 6.6.2
+  resolution: "p-queue@npm:6.6.2"
+  dependencies:
+    eventemitter3: ^4.0.4
+    p-timeout: ^3.2.0
+  checksum: 832642fcc4ab6477b43e6d7c30209ab10952969ed211c6d6f2931be8a4f9935e3578c72e8cce053dc34f2eb6941a408a2c516a54904e989851a1a209cf19761c
+  languageName: node
+  linkType: hard
+
 "p-retry@npm:^4.5.0":
   version: 4.6.2
   resolution: "p-retry@npm:4.6.2"
@@ -10606,6 +10624,15 @@ __metadata:
     "@types/retry": 0.12.0
     retry: ^0.13.1
   checksum: 45c270bfddaffb4a895cea16cb760dcc72bdecb6cb45fef1971fa6ea2e91ddeafddefe01e444ac73e33b1b3d5d29fb0dd18a7effb294262437221ddc03ce0f2e
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "p-timeout@npm:3.2.0"
+  dependencies:
+    p-finally: ^1.0.0
+  checksum: 3dd0eaa048780a6f23e5855df3dd45c7beacff1f820476c1d0d1bcd6648e3298752ba2c877aa1c92f6453c7dd23faaf13d9f5149fc14c0598a142e2c5e8d649c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See also #90. We only want 1 of these.

Using https://github.com/sindresorhus/p-queue

This enables all LLMs to be soft "rate-limited" with a queue, especially useful when dealing with APIs that are heavily rate-limited, like OpenAI.