### PR TITLE
fix document and metadata loading from query in chroma

### DIFF
--- a/langchain/vectorstores/chroma.ts
+++ b/langchain/vectorstores/chroma.ts
@@ -98,14 +98,20 @@ export class Chroma extends VectorStore {
       );
     }
     const collection = await this.index.getCollection(this.collectionName);
-    const result = await collection.query(query, k);
-    const { ids, distances, documents, metadatas } = result;
 
-    // ids comes back as a list of lists, so we need to flatten it
-    const takeIds = ids[0];
+    // similaritySearchVectorWithScore supports one query vector at a time
+    // chroma supports multiple query vectors at a time
+    const result = await collection.query(query, k);
+    
+    let { ids, distances, documents, metadatas } = result;
+    // get the result data from the first and only query vector
+    ids = ids[0];
+    distances = distances[0];
+    documents = documents[0];
+    metadatas = metadatas[0];
 
     const results: [Document, number][] = [];
-    for (let i = 0; i < takeIds.length; i += 1) {
+    for (let i = 0; i < ids.length; i += 1) {
       results.push([
         new Document({
           pageContent: documents[i],

--- a/langchain/vectorstores/chroma.ts
+++ b/langchain/vectorstores/chroma.ts
@@ -103,21 +103,21 @@ export class Chroma extends VectorStore {
     // chroma supports multiple query vectors at a time
     const result = await collection.query(query, k);
     
-    let { ids, distances, documents, metadatas } = result;
+    const { ids, distances, documents, metadatas } = result;
     // get the result data from the first and only query vector
-    ids = ids[0];
-    distances = distances[0];
-    documents = documents[0];
-    metadatas = metadatas[0];
+    const [firstIds] = ids;
+    const [firstDistances] = distances;
+    const [firstDocuments] = documents;
+    const [firstMetadatas] = metadatas;
 
     const results: [Document, number][] = [];
-    for (let i = 0; i < ids.length; i += 1) {
+    for (let i = 0; i < firstIds.length; i += 1) {
       results.push([
         new Document({
-          pageContent: documents[i],
-          metadata: metadatas[i],
+          pageContent: firstDocuments[i],
+          metadata: firstMetadatas[i],
         }),
-        distances[i],
+        firstDistances[i],
       ]);
     }
     return results;

--- a/langchain/vectorstores/chroma.ts
+++ b/langchain/vectorstores/chroma.ts
@@ -102,7 +102,7 @@ export class Chroma extends VectorStore {
     // similaritySearchVectorWithScore supports one query vector at a time
     // chroma supports multiple query vectors at a time
     const result = await collection.query(query, k);
-    
+
     const { ids, distances, documents, metadatas } = result;
     // get the result data from the first and only query vector
     const [firstIds] = ids;


### PR DESCRIPTION
@nfcampos This fixes the document and metadata loading for chroma similarity search. Comments in the code describe why this change was needed :) 