### PR TITLE
Update pinecone.ts to set a default namespace and make it configurable

### DIFF
--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -10,19 +10,22 @@ type PineconeMetadata = Record<string, any>;
 
 export class PineconeStore extends VectorStore {
   textKey: string;
+  namespace: string;
 
   pineconeClient: VectorOperationsApi;
 
   constructor(
     pineconeClient: VectorOperationsApi,
     embeddings: Embeddings,
-    textKey = "text"
+    textKey = "text",
+    namespace = "embeddings"
   ) {
     super(embeddings);
 
     this.pineconeClient = pineconeClient;
     this.embeddings = embeddings;
     this.textKey = textKey;
+    this.namespace = namespace;
   }
 
   async addDocuments(documents: Document[], ids?: string[]): Promise<void> {
@@ -51,6 +54,7 @@ export class PineconeStore extends VectorStore {
           },
           values,
         })),
+        namespace: this.namespace,
       },
     });
   }
@@ -87,7 +91,8 @@ export class PineconeStore extends VectorStore {
     texts: string[],
     metadatas: object[],
     embeddings: Embeddings,
-    textKey = "text"
+    textKey = "text",
+    namespace = "embeddings"
   ): Promise<PineconeStore> {
     const docs = [];
     for (let i = 0; i < texts.length; i += 1) {
@@ -102,7 +107,8 @@ export class PineconeStore extends VectorStore {
       pineconeClient,
       docs,
       embeddings,
-      textKey
+      textKey,
+      namespace
     );
   }
 
@@ -110,9 +116,10 @@ export class PineconeStore extends VectorStore {
     pineconeClient: VectorOperationsApi,
     docs: Document[],
     embeddings: Embeddings,
-    textKey = "text"
+    textKey = "text",
+    namespace = "embeddings"
   ): Promise<PineconeStore> {
-    const instance = new this(pineconeClient, embeddings, textKey);
+    const instance = new this(pineconeClient, embeddings, textKey, namespace);
     await instance.addDocuments(docs);
     return instance;
   }
@@ -120,9 +127,10 @@ export class PineconeStore extends VectorStore {
   static async fromExistingIndex(
     pineconeClient: VectorOperationsApi,
     embeddings: Embeddings,
-    textKey = "text"
+    textKey = "text",
+    namespace = "embeddings"
   ): Promise<PineconeStore> {
-    const instance = new this(pineconeClient, embeddings, textKey);
+    const instance = new this(pineconeClient, embeddings, textKey, namespace);
     return instance;
   }
 }

--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -11,7 +11,7 @@ type PineconeMetadata = Record<string, any>;
 export class PineconeStore extends VectorStore {
   textKey: string;
 
-  namespace: string;
+  namespace: string | undefined;
 
   pineconeClient: VectorOperationsApi;
 
@@ -19,7 +19,7 @@ export class PineconeStore extends VectorStore {
     pineconeClient: VectorOperationsApi,
     embeddings: Embeddings,
     textKey = "text",
-    namespace = "embeddings"
+    namespace: string | undefined = undefined
   ) {
     super(embeddings);
 
@@ -93,7 +93,7 @@ export class PineconeStore extends VectorStore {
     metadatas: object[],
     embeddings: Embeddings,
     textKey = "text",
-    namespace = "embeddings"
+    namespace: string | undefined = undefined
   ): Promise<PineconeStore> {
     const docs = [];
     for (let i = 0; i < texts.length; i += 1) {
@@ -118,7 +118,7 @@ export class PineconeStore extends VectorStore {
     docs: Document[],
     embeddings: Embeddings,
     textKey = "text",
-    namespace = "embeddings"
+    namespace: string | undefined = undefined
   ): Promise<PineconeStore> {
     const instance = new this(pineconeClient, embeddings, textKey, namespace);
     await instance.addDocuments(docs);
@@ -129,7 +129,7 @@ export class PineconeStore extends VectorStore {
     pineconeClient: VectorOperationsApi,
     embeddings: Embeddings,
     textKey = "text",
-    namespace = "embeddings"
+    namespace: string | undefined = undefined
   ): Promise<PineconeStore> {
     const instance = new this(pineconeClient, embeddings, textKey, namespace);
     return instance;

--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -10,6 +10,7 @@ type PineconeMetadata = Record<string, any>;
 
 export class PineconeStore extends VectorStore {
   textKey: string;
+
   namespace: string;
 
   pineconeClient: VectorOperationsApi;


### PR DESCRIPTION
Pinecone is great (and free!), but they only allow you to run a single pod/single index on the free plan. Namespaces are nice because you can fit more stuff into one Pinecone index. [Here's a blog post on how they work.](https://docs.pinecone.io/docs/namespaces) I added namespaces to pinecone.ts so Langchain users can use them for multi-tenant vector database use-cases. 

An example use case might be if you have 10 users with unique documents. Instead of creating 10 Indexes, you can create 1 Index with 10 namespaces (`user-1`, `user-2`, etc). When you run a similarity search, it will be scoped by namespace.

_I need to test this change still, this is just a PoC._ 

