### PR TITLE
Upgrade openai version to 3.2.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-jsx-a11y": "^6.6.0",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "openai": "^3.1.0",
+    "openai": "^3.2.0",
     "prettier": "^2.7.1",
     "serpapi": "^1.1.1",
     "typedoc": "^0.23.25",

--- a/examples/package.json
+++ b/examples/package.json
@@ -26,7 +26,7 @@
     "chromadb": "^1.3.0",
     "js-yaml": "^4.1.0",
     "langchain": "workspace:*",
-    "openai": "^3.1.0",
+    "openai": "^3.2.0",
     "serpapi": "^1.1.0",
     "sqlite3": "^5.1.4"
   },

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -80,7 +80,7 @@
     "husky": "^8.0.3",
     "jest": "^29.4.2",
     "lint-staged": "^13.1.1",
-    "openai": "^3.1.0",
+    "openai": "^3.2.0",
     "prettier": "^2.8.3",
     "serpapi": "^1.1.1",
     "srt-parser-2": "^1.2.2",
@@ -98,7 +98,7 @@
     "cohere-ai": "^5.0.2",
     "hnswlib-node": "^1.3.0",
     "huggingface": "^1.4.0",
-    "openai": "^3.1.0",
+    "openai": "^3.2.0",
     "serpapi": "^1.1.1",
     "srt-parser-2": "^1.2.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6197,7 +6197,7 @@ __metadata:
     eslint-plugin-jsx-a11y: ^6.6.0
     eslint-plugin-react: ^7.30.1
     eslint-plugin-react-hooks: ^4.6.0
-    openai: ^3.1.0
+    openai: ^3.2.0
     prettier: ^2.7.1
     process: ^0.11.10
     react: ^17.0.2
@@ -9829,7 +9829,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     js-yaml: ^4.1.0
     langchain: "workspace:*"
-    openai: ^3.1.0
+    openai: ^3.2.0
     prettier: ^2.8.3
     serpapi: ^1.1.0
     sqlite3: ^5.1.4
@@ -9872,7 +9872,7 @@ __metadata:
     jest: ^29.4.2
     jsonpointer: ^5.0.1
     lint-staged: ^13.1.1
-    openai: ^3.1.0
+    openai: ^3.2.0
     p-queue: ^7.3.4
     prettier: ^2.8.3
     serpapi: ^1.1.1
@@ -9894,7 +9894,7 @@ __metadata:
     cohere-ai: ^5.0.2
     hnswlib-node: ^1.3.0
     huggingface: ^1.4.0
-    openai: ^3.1.0
+    openai: ^3.2.0
     serpapi: ^1.1.1
     srt-parser-2: ^1.2.2
   peerDependenciesMeta:
@@ -11088,13 +11088,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "openai@npm:3.1.0"
+"openai@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "openai@npm:3.2.0"
   dependencies:
     axios: ^0.26.0
     form-data: ^4.0.0
-  checksum: 2277d9e2b419b0ba17fb5ee7187bcff285a2a90120990c8da9658b8a8c8d4a927c95cec6cdc5503aa33108b4933288ef1f3756cc09033c33700d4bb2025138c0
+  checksum: 590bd37d87d44ebf61189e258499f53c0e3be8ade5b18442a0e7514b974316c8d4cb01f77f10069807d1d112d7b54b86c61c03d3f0f409acf894140308aa3ff1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds support for the long awaited [ChatGPT API backend](https://openai.com/blog/introducing-chatgpt-and-whisper-apis) to be added(!!!)

Per Greg Brockman, it's 10x cheaper, and higher quality. Woo!

https://platform.openai.com/docs/api-reference/chat/create