### PR TITLE
Feat/dynamic max tokens

### DIFF
--- a/langchain/src/llms/calculateMaxTokens.ts
+++ b/langchain/src/llms/calculateMaxTokens.ts
@@ -1,0 +1,44 @@
+import {
+  encoding_for_model, TiktokenModel
+} from "@dqbd/tiktoken";
+
+// https://www.npmjs.com/package/@dqbd/tiktoken
+
+export const getModelContextSize = (modelName: TiktokenModel): number => {
+  switch (modelName) {
+    case "text-davinci-003":
+      return 4097;
+    case "text-curie-001":
+      return 2048;
+    case "text-babbage-001":
+      return 2048;
+    case "text-ada-001":
+      return 2048;
+    case "code-davinci-002":
+      return 8000;
+    case "code-cushman-001":
+      return 2048;
+    default:
+      return 4097;
+  }
+};
+
+type CalculateMaxTokenProps = {
+  prompt: string;
+  modelName: TiktokenModel;
+};
+
+export const calculateMaxTokens = ({
+  prompt,
+  modelName,
+}: CalculateMaxTokenProps) => {
+  const encoding = encoding_for_model(modelName);
+
+  const tokenized = encoding.encode(prompt);
+
+  const numTokens = tokenized.length;
+
+  const maxTokens = getModelContextSize(modelName);
+
+  return maxTokens - numTokens;
+};

--- a/langchain/src/llms/calculateMaxTokens.ts
+++ b/langchain/src/llms/calculateMaxTokens.ts
@@ -1,6 +1,4 @@
-import {
-  encoding_for_model, TiktokenModel
-} from "@dqbd/tiktoken";
+import { encoding_for_model, TiktokenModel } from "@dqbd/tiktoken";
 
 // https://www.npmjs.com/package/@dqbd/tiktoken
 

--- a/langchain/src/llms/cohere.ts
+++ b/langchain/src/llms/cohere.ts
@@ -5,8 +5,7 @@ interface CohereInput {
   temperature: number;
 
   /**
-   * Maximum number of tokens to generate in the completion. -1 returns as many
-   * tokens as possible given the prompt and the model's maximum context size.
+   * Maximum number of tokens to generate in the completion.
    */
   maxTokens: number;
 

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -54,7 +54,7 @@ interface ModelParams {
  */
 interface OpenAIInput extends ModelParams {
   /** Model name to use */
-  modelName: TiktokenModel;
+  modelName: string;
 
   /** Holds any additional parameters that are valid to pass to {@link
    * https://platform.openai.com/docs/api-reference/completions/create |
@@ -113,7 +113,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
 
   logitBias?: Record<string, number>;
 
-  modelName: TiktokenModel = "text-davinci-003";
+  modelName = "text-davinci-003";
 
   modelKwargs?: Kwargs;
 
@@ -256,7 +256,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
       }
       params.max_tokens = calculateMaxTokens({
         prompt: prompts[0],
-        modelName: this.modelName,
+        modelName: this.modelName as TiktokenModel,
       });
     }
 

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -256,6 +256,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
       }
       params.max_tokens = calculateMaxTokens({
         prompt: prompts[0],
+        // Cast here to allow for other models that may not fit the union
         modelName: this.modelName as TiktokenModel,
       });
     }


### PR DESCRIPTION
References https://github.com/hwchase17/langchain/blob/master/langchain/llms/openai.py#L321 to implement the missing logic described in the comment. Passing -1 will calculate the max tokens dynamically.

Only done for 

There may be a problem with strongly typing the model name as a `TiktokenModel` as it would not let other models to be passed in if the API supports new ones but the type isn't updated. Therefore I cast it.