### PR TITLE
Update pinecone.ts to fix undefined metadata in similaritySearchVectorWithScore function

### DIFF
--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -77,7 +77,8 @@ export class PineconeStore extends VectorStore {
 
     if (results.matches) {
       for (const res of results.matches) {
-        const { [this.textKey]: pageContent, ...metadata } = (res.metadata ?? {}) as PineconeMetadata;
+        const { [this.textKey]: pageContent, ...metadata } = (res.metadata ??
+          {}) as PineconeMetadata;
         if (res.score) {
           result.push([new Document({ metadata, pageContent }), res.score]);
         }

--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -69,6 +69,7 @@ export class PineconeStore extends VectorStore {
         topK: k,
         includeMetadata: true,
         vector: query,
+        namespace: this.namespace,
       },
     });
 

--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -77,8 +77,7 @@ export class PineconeStore extends VectorStore {
 
     if (results.matches) {
       for (const res of results.matches) {
-        const { [this.textKey]: pageContent, ...metadata } =
-          res.metadata as PineconeMetadata;
+        const { [this.textKey]: pageContent, ...metadata } = (res.metadata ?? {}) as PineconeMetadata;
         if (res.score) {
           result.push([new Document({ metadata, pageContent }), res.score]);
         }


### PR DESCRIPTION
This is a fix to the Pinecone similarity search function [issue](https://github.com/hwchase17/langchainjs/issues/160) discussed and resolved with @nfcampos. 

In essence the `similaritySearchVectorWithScore` function threw the error below because the `namespace` property was missing in the `queryRequest`. Pinecone vectors have namespaces that need to be specified in the query, otherwise the metadata will be undefined. 

error: `error TypeError: Cannot destructure 'res.metadata' as it is undefined. at PineconeStore.similaritySearchVectorWithScore`

A defensive handle was also applied in the case `res.metadata` is undefined, an empty object is returned.

`const { [this.textKey]: pageContent, ...metadata } = (res.metadata ?? {}) as PineconeMetadata;`

These changes have been tested locally.
