### PR TITLE
Allow prompt customization for initializeAgentExecutor

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -228,11 +228,11 @@ import { SerpAPI, Calculator } from "langchain/tools";
 const model = new OpenAI({ temperature: 0 });
 const tools = [new SerpAPI(), new Calculator()];
 
-const executor = await initializeAgentExecutor(
+const executor = await initializeAgentExecutor({
   tools,
-  model,
-  "zero-shot-react-description"
-);
+  model, 
+  agentType: "zero-shot-react-description"
+});
 console.log("Loaded agent.");
 
 const input =

--- a/docs/docs/modules/agents/agents_with_vectorstores.md
+++ b/docs/docs/modules/agents/agents_with_vectorstores.md
@@ -20,7 +20,7 @@ import * as fs from "fs";
 Next, you want to create the vectorstore with your data, and then the QA chain to interact with that vectorstore.
 
 ```typescript
-const model = new OpenAI({ temperature: 0 });
+const llm = new OpenAI({ temperature: 0 });
 /* Load in the file we want to do question answering over */
 const text = fs.readFileSync("state_of_the_union.txt", "utf8");
 /* Split the text into chunks */
@@ -29,7 +29,7 @@ const docs = textSplitter.createDocuments([text]);
 /* Create the vectorstore */
 const vectorStore = await HNSWLib.fromDocuments(docs, new OpenAIEmbeddings());
 /* Create the chain */
-const chain = VectorDBQAChain.fromLLM(model, vectorStore);
+const chain = VectorDBQAChain.fromLLM(llm, vectorStore);
 ```
 
 Now that you have that chain, you can create a tool to use that chain. Note that you should update the name and description to be specific to your QA chain.
@@ -48,11 +48,11 @@ Now we can go about constructing and using the tool as we would any other tool!
 ```typescript
 const tools = [new SerpAPI(), new Calculator(), qaTool];
 
-const executor = await initializeAgentExecutor(
+const executor = await initializeAgentExecutor({
   tools,
-  model,
-  "zero-shot-react-description"
-);
+  llm,
+  agentType: "zero-shot-react-description",
+});
 console.log("Loaded agent.");
 
 const input = `What did biden say about ketanji brown jackson is the state of the union address?`;

--- a/docs/docs/modules/agents/custom_tool.md
+++ b/docs/docs/modules/agents/custom_tool.md
@@ -28,11 +28,11 @@ export const run = async () => {
     }),
   ];
 
-  const executor = await initializeAgentExecutor(
+  const executor = await initializeAgentExecutor({
     tools,
-    model,
-    "zero-shot-react-description"
-  );
+    llm,
+    agentType: "zero-shot-react-description",
+  });
 
   console.log("Loaded agent.");
 

--- a/docs/docs/modules/agents/overview.md
+++ b/docs/docs/modules/agents/overview.md
@@ -33,14 +33,14 @@ import { OpenAI } from "langchain";
 import { initializeAgentExecutor } from "langchain/agents";
 import { SerpAPI, Calculator } from "langchain/tools";
 
-const model = new OpenAI({ temperature: 0 });
+const llm = new OpenAI({ temperature: 0 });
 const tools = [new SerpAPI(), new Calculator()];
 
-const executor = await initializeAgentExecutor(
+const executor = await initializeAgentExecutor({
   tools,
-  model,
-  "zero-shot-react-description"
-);
+  llm,
+  agent: "zero-shot-react-description",
+});
 console.log("Loaded agent.");
 
 const input =

--- a/examples/src/agents/custom_tool.ts
+++ b/examples/src/agents/custom_tool.ts
@@ -3,7 +3,7 @@ import { initializeAgentExecutor } from "langchain/agents";
 import { DynamicTool } from "langchain/tools";
 
 export const run = async () => {
-  const model = new OpenAI({ temperature: 0 });
+  const llm = new OpenAI({ temperature: 0 });
   const tools = [
     new DynamicTool({
       name: "FOO",
@@ -25,11 +25,11 @@ export const run = async () => {
     }),
   ];
 
-  const executor = await initializeAgentExecutor(
+  const executor = await initializeAgentExecutor({
     tools,
-    model,
-    "zero-shot-react-description"
-  );
+    llm,
+    agentType: "zero-shot-react-description",
+  });
 
   console.log("Loaded agent.");
 

--- a/examples/src/agents/mrkl.ts
+++ b/examples/src/agents/mrkl.ts
@@ -1,16 +1,19 @@
 import { OpenAI } from "langchain";
 import { initializeAgentExecutor } from "langchain/agents";
-import { SerpAPI, Calculator } from "langchain/tools";
+import {
+  Calculator,
+  SerpAPI,
+} from "langchain/tools";
 
 export const run = async () => {
-  const model = new OpenAI({ temperature: 0 });
+  const llm = new OpenAI({ temperature: 0 });
   const tools = [new SerpAPI(), new Calculator()];
 
-  const executor = await initializeAgentExecutor(
+  const executor = await initializeAgentExecutor({
     tools,
-    model,
-    "zero-shot-react-description"
-  );
+    llm,
+    agentType: "zero-shot-react-description",
+  });
   console.log("Loaded agent.");
 
   const input = `Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?`;

--- a/langchain/src/agents/initialize.ts
+++ b/langchain/src/agents/initialize.ts
@@ -1,17 +1,25 @@
-import { Tool } from "./tools/index.js";
 import { BaseLLM } from "../llms/index.js";
 import { AgentExecutor } from "./executor.js";
-import { ZeroShotAgent } from "./mrkl/index.js";
+import {
+  CreatePromptArgs,
+  ZeroShotAgent,
+} from "./mrkl/index.js";
+import { Tool } from "./tools/index.js";
 
-export const initializeAgentExecutor = async (
-  tools: Tool[],
-  llm: BaseLLM,
-  agentType = "zero-shot-react-description"
-): Promise<AgentExecutor> => {
+export interface InitializeAgentExecutorOptions {
+  tools: Tool[];
+  llm: BaseLLM;
+  agentType?: "zero-shot-react-description";
+  promptArgs?: CreatePromptArgs;
+}
+
+export const initializeAgentExecutor = async ({ tools, llm, agentType, promptArgs }: InitializeAgentExecutorOptions): Promise<AgentExecutor> => {
+  agentType = agentType || "zero-shot-react-description";
+
   switch (agentType) {
     case "zero-shot-react-description":
       return AgentExecutor.fromAgentAndTools({
-        agent: ZeroShotAgent.fromLLMAndTools(llm, tools),
+        agent: ZeroShotAgent.fromLLMAndTools(llm, tools, promptArgs),
         tools,
         returnIntermediateSteps: true,
       });

--- a/langchain/src/agents/initialize.ts
+++ b/langchain/src/agents/initialize.ts
@@ -21,7 +21,7 @@ export const initializeAgentExecutor = async ({
 }: InitializeAgentExecutorOptions): Promise<AgentExecutor> => {
   const agentType = _agentType || "zero-shot-react-description";
 
-  switch (_agentType) {
+  switch (agentType) {
     case "zero-shot-react-description":
       return AgentExecutor.fromAgentAndTools({
         agent: ZeroShotAgent.fromLLMAndTools(llm, tools, promptArgs),

--- a/langchain/src/agents/initialize.ts
+++ b/langchain/src/agents/initialize.ts
@@ -1,9 +1,6 @@
 import { BaseLLM } from "../llms/index.js";
 import { AgentExecutor } from "./executor.js";
-import {
-  CreatePromptArgs,
-  ZeroShotAgent,
-} from "./mrkl/index.js";
+import { CreatePromptArgs, ZeroShotAgent } from "./mrkl/index.js";
 import { Tool } from "./tools/index.js";
 
 export interface InitializeAgentExecutorOptions {

--- a/langchain/src/agents/initialize.ts
+++ b/langchain/src/agents/initialize.ts
@@ -1,6 +1,9 @@
 import { BaseLLM } from "../llms/index.js";
 import { AgentExecutor } from "./executor.js";
-import { CreatePromptArgs, ZeroShotAgent } from "./mrkl/index.js";
+import {
+  CreatePromptArgs,
+  ZeroShotAgent,
+} from "./mrkl/index.js";
 import { Tool } from "./tools/index.js";
 
 export interface InitializeAgentExecutorOptions {
@@ -13,12 +16,12 @@ export interface InitializeAgentExecutorOptions {
 export const initializeAgentExecutor = async ({
   tools,
   llm,
-  agentType,
+  agentType: _agentType,
   promptArgs,
 }: InitializeAgentExecutorOptions): Promise<AgentExecutor> => {
-  agentType = agentType || "zero-shot-react-description";
+  const agentType = _agentType || "zero-shot-react-description";
 
-  switch (agentType) {
+  switch (_agentType) {
     case "zero-shot-react-description":
       return AgentExecutor.fromAgentAndTools({
         agent: ZeroShotAgent.fromLLMAndTools(llm, tools, promptArgs),

--- a/langchain/src/agents/initialize.ts
+++ b/langchain/src/agents/initialize.ts
@@ -1,9 +1,6 @@
 import { BaseLLM } from "../llms/index.js";
 import { AgentExecutor } from "./executor.js";
-import {
-  CreatePromptArgs,
-  ZeroShotAgent,
-} from "./mrkl/index.js";
+import { CreatePromptArgs, ZeroShotAgent } from "./mrkl/index.js";
 import { Tool } from "./tools/index.js";
 
 export interface InitializeAgentExecutorOptions {
@@ -13,7 +10,12 @@ export interface InitializeAgentExecutorOptions {
   promptArgs?: CreatePromptArgs;
 }
 
-export const initializeAgentExecutor = async ({ tools, llm, agentType, promptArgs }: InitializeAgentExecutorOptions): Promise<AgentExecutor> => {
+export const initializeAgentExecutor = async ({
+  tools,
+  llm,
+  agentType,
+  promptArgs,
+}: InitializeAgentExecutorOptions): Promise<AgentExecutor> => {
   agentType = agentType || "zero-shot-react-description";
 
   switch (agentType) {

--- a/langchain/src/agents/tests/agent.int.test.ts
+++ b/langchain/src/agents/tests/agent.int.test.ts
@@ -1,10 +1,7 @@
 import { test } from "@jest/globals";
 
 import { OpenAI } from "../../llms/openai.js";
-import {
-  AgentExecutor,
-  Tool,
-} from "../index.js";
+import { AgentExecutor, Tool } from "../index.js";
 import { initializeAgentExecutor } from "../initialize.js";
 import { loadAgent } from "../load.js";
 import { Calculator } from "../tools/calculator.js";
@@ -36,7 +33,7 @@ test("Run agent locally", async () => {
   const executor = await initializeAgentExecutor({
     tools,
     llm: model,
-    agentType: "zero-shot-react-description"
+    agentType: "zero-shot-react-description",
   });
   console.log("Loaded agent.");
 

--- a/langchain/src/agents/tests/agent.int.test.ts
+++ b/langchain/src/agents/tests/agent.int.test.ts
@@ -1,10 +1,14 @@
 import { test } from "@jest/globals";
+
 import { OpenAI } from "../../llms/openai.js";
-import { loadAgent } from "../load.js";
-import { AgentExecutor, Tool } from "../index.js";
-import { SerpAPI } from "../tools/serpapi.js";
-import { Calculator } from "../tools/calculator.js";
+import {
+  AgentExecutor,
+  Tool,
+} from "../index.js";
 import { initializeAgentExecutor } from "../initialize.js";
+import { loadAgent } from "../load.js";
+import { Calculator } from "../tools/calculator.js";
+import { SerpAPI } from "../tools/serpapi.js";
 
 test("Run agent from hub", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-babbage-001" });
@@ -29,11 +33,11 @@ test("Run agent locally", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-babbage-001" });
   const tools = [new SerpAPI(), new Calculator()];
 
-  const executor = await initializeAgentExecutor(
+  const executor = await initializeAgentExecutor({
     tools,
-    model,
-    "zero-shot-react-description"
-  );
+    llm: model,
+    agentType: "zero-shot-react-description"
+  });
   console.log("Loaded agent.");
 
   const input = `Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?`;


### PR DESCRIPTION
My agent has been issues with using tools that it shouldn't... so the ability to customize the prompt that is passed to the agent executor would be very helpful, since that seems to be the preferred wrapper for getting an agent executor.

- Added ability for `promptArgs` to be passed in
- Moved `initializeAgentExecutor` to object parameters for better self-documentation