### PR TITLE
Add missing await in Summarization Chain example (docs)

### DIFF
--- a/docs/docs/modules/chains/summarization.md
+++ b/docs/docs/modules/chains/summarization.md
@@ -37,7 +37,7 @@ const text = fs.readFileSync("state_of_the_union.txt", "utf8");
 const model = new OpenAI({ temperature: 0 });
 /* Split the text into chunks. */
 const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
-const docs = textSplitter.createDocuments([text]);
+const docs = await textSplitter.createDocuments([text]);
 /** Call the summarization chain. */
 const chain = loadSummarizationChain(model);
 const res = await chain.call({


### PR DESCRIPTION
I was scratching my head for a while not knowing why the Summarization Chain example was not working for me, turns out I was not awaiting for the promise returned from this line of code which was missing in docs:

```typescript
const docs = textSplitter.createDocuments([text]);
```