### PR TITLE
agents: remove unsed allowedTools

### DIFF
--- a/docs/docs/modules/agents/custom_agent.md
+++ b/docs/docs/modules/agents/custom_agent.md
@@ -60,7 +60,6 @@ Now we create an agent and agent executor with that custom prompt.
 ```typescript
 const agent = new ZeroShotAgent({
   llmChain: llmChain,
-  allowedTools: ["search", "calculator"],
 });
 const agentExecutor = AgentExecutor.fromAgentAndTools({ agent, tools });
 console.log("Loaded agent.");

--- a/examples/src/agents/custom_agent.ts
+++ b/examples/src/agents/custom_agent.ts
@@ -26,7 +26,6 @@ Question: {input}
   const llmChain = new LLMChain({ llm: model, prompt });
   const agent = new ZeroShotAgent({
     llmChain,
-    allowedTools: ["search", "calculator"],
   });
   const agentExecutor = AgentExecutor.fromAgentAndTools({ agent, tools });
   console.log("Loaded agent.");

--- a/langchain/src/agents/agent.ts
+++ b/langchain/src/agents/agent.ts
@@ -50,7 +50,6 @@ type SerializedAgent = SerializedZeroShotAgent;
 
 export interface AgentInput {
   llmChain: LLMChain;
-  allowedTools?: string[];
 }
 
 /**
@@ -63,8 +62,6 @@ export interface AgentInput {
 export abstract class Agent {
   llmChain: LLMChain;
 
-  allowedTools?: string[] = undefined;
-
   returnValues = ["output"];
 
   get inputKeys(): string[] {
@@ -73,7 +70,6 @@ export abstract class Agent {
 
   constructor(input: AgentInput) {
     this.llmChain = input.llmChain;
-    this.allowedTools = input.allowedTools;
   }
 
   /**

--- a/langchain/src/agents/agent_toolkits/json/json.ts
+++ b/langchain/src/agents/agent_toolkits/json/json.ts
@@ -42,7 +42,6 @@ export function createJsonAgent(
   const chain = new LLMChain({ prompt, llm });
   const agent = new ZeroShotAgent({
     llmChain: chain,
-    allowedTools: tools.map((t) => t.name),
   });
   return AgentExecutor.fromAgentAndTools({
     agent,

--- a/langchain/src/agents/agent_toolkits/openapi/openapi.ts
+++ b/langchain/src/agents/agent_toolkits/openapi/openapi.ts
@@ -66,8 +66,7 @@ export function createOpenApiAgent(
     prompt,
     llm,
   });
-  const toolNames = tools.map((tool) => tool.name);
-  const agent = new ZeroShotAgent({ llmChain: chain, allowedTools: toolNames });
+  const agent = new ZeroShotAgent({ llmChain: chain });
   return AgentExecutor.fromAgentAndTools({
     agent,
     tools,

--- a/langchain/src/agents/agent_toolkits/sql/sql.ts
+++ b/langchain/src/agents/agent_toolkits/sql/sql.ts
@@ -62,7 +62,6 @@ export function createSqlAgent(
   const chain = new LLMChain({ prompt, llm });
   const agent = new ZeroShotAgent({
     llmChain: chain,
-    allowedTools: tools.map((t) => t.name),
   });
   return AgentExecutor.fromAgentAndTools({
     agent,

--- a/langchain/src/agents/agent_toolkits/vectorstore/vectorstore.ts
+++ b/langchain/src/agents/agent_toolkits/vectorstore/vectorstore.ts
@@ -78,7 +78,6 @@ export function createVectorStoreAgent(
   const chain = new LLMChain({ prompt, llm });
   const agent = new ZeroShotAgent({
     llmChain: chain,
-    allowedTools: tools.map((t) => t.name),
   });
   return AgentExecutor.fromAgentAndTools({
     agent,
@@ -106,7 +105,6 @@ export function createVectorStoreRouterAgent(
   const chain = new LLMChain({ prompt, llm });
   const agent = new ZeroShotAgent({
     llmChain: chain,
-    allowedTools: tools.map((t) => t.name),
   });
   return AgentExecutor.fromAgentAndTools({
     agent,

--- a/langchain/src/agents/mrkl/index.ts
+++ b/langchain/src/agents/mrkl/index.ts
@@ -104,7 +104,6 @@ export class ZeroShotAgent extends Agent {
     const chain = new LLMChain({ prompt, llm });
     return new ZeroShotAgent({
       llmChain: chain,
-      allowedTools: tools.map((t) => t.name),
     });
   }
 


### PR DESCRIPTION
Maybe I'm crazy, I dont think allowedTools is used, and it duplicates the tool.name anyway. Probably was refactored out at some point? 
Or If Im off base, feel free to close this