### PR TITLE
fix: Generated follow-up questions not being used

### DIFF
--- a/langchain/src/chains/chat_vector_db_chain.ts
+++ b/langchain/src/chains/chat_vector_db_chain.ts
@@ -121,7 +121,7 @@ export class ChatVectorDBQAChain
     }
     const docs = await this.vectorstore.similaritySearch(newQuestion, this.k);
     const inputs = {
-      question,
+      question: newQuestion,
       input_documents: docs,
       chat_history: chatHistory,
     };


### PR DESCRIPTION
Follow-up questions are generated when `chat_history` is specified in `ChatVectorDBQAChain` , but it appears that it is not being used.

I have fixed that issue.