### PR TITLE
fix: await createDocuments() promise

### DIFF
--- a/docs/docs/modules/chains/chat_vector_db_qa.md
+++ b/docs/docs/modules/chains/chat_vector_db_qa.md
@@ -20,7 +20,7 @@ const model = new OpenAI({});
 const text = fs.readFileSync("state_of_the_union.txt", "utf8");
 /* Split the text into chunks */
 const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
-const docs = textSplitter.createDocuments([text]);
+const docs = await textSplitter.createDocuments([text]);
 /* Create the vectorstore */
 const vectorStore = await HNSWLib.fromDocuments(docs, new OpenAIEmbeddings());
 /* Create the chain */


### PR DESCRIPTION
## Description
Small update to Chat Vector DB & QA chain docs. `textSplitter.createDocuments([text])` returns a promise and should be awaited. 