### PR TITLE
feat: add logic to override default prompts and method to get default…

### DIFF
--- a/docs/docs/modules/chains/chat_vector_db_qa.md
+++ b/docs/docs/modules/chains/chat_vector_db_qa.md
@@ -37,3 +37,25 @@ const followUpRes = await chain.call({
 });
 console.log(followUpRes);
 ```
+
+In this code snippet, the fromLLM method of the ChatVectorDBQAChain class has the following signature:
+
+```typescript
+static fromLLM(
+    llm: BaseLLM,
+    vectorstore: VectorStore,
+    options?: {
+      questionGeneratorTemplate?: string;
+      qaTemplate?: string;
+      returnSourceDocuments?: boolean;
+    }
+  ): ChatVectorDBQAChain
+```
+
+Here's an explanation of each of the attributes of the options object:
+
+- `questionGeneratorTemplate`: A string that specifies a question generation template. If provided, the ChatVectorDBQAChain will use this template to generate a question from the conversation context, instead of using the question provided in the question parameter. This can be useful if the original question does not contain enough information to retrieve a suitable answer.
+- `qaTemplate`: A string that specifies a response template. If provided, the ChatVectorDBQAChain will use this template to format a response before returning the result. This can be useful if you want to customize the way the response is presented to the end user.
+- `returnSourceDocuments`: A boolean value that indicates whether the ChatVectorDBQAChain should return the source documents that were used to retrieve the answer. If set to true, the documents will be included in the result returned by the call() method. This can be useful if you want to allow the user to see the sources used to generate the answer. If not set, the default value will be false.
+
+In summary, the `questionGeneratorTemplate`, `qaTemplate`, and `returnSourceDocuments` options allow the user to customize the behavior of the `ChatVectorDBQAChain`

--- a/docs/docs/modules/chains/chat_vector_db_qa.md
+++ b/docs/docs/modules/chains/chat_vector_db_qa.md
@@ -48,6 +48,7 @@ static fromLLM(
       questionGeneratorTemplate?: string;
       qaTemplate?: string;
       returnSourceDocuments?: boolean;
+      k?: number;
     }
   ): ChatVectorDBQAChain
 ```
@@ -57,5 +58,6 @@ Here's an explanation of each of the attributes of the options object:
 - `questionGeneratorTemplate`: A string that specifies a question generation template. If provided, the ChatVectorDBQAChain will use this template to generate a question from the conversation context, instead of using the question provided in the question parameter. This can be useful if the original question does not contain enough information to retrieve a suitable answer.
 - `qaTemplate`: A string that specifies a response template. If provided, the ChatVectorDBQAChain will use this template to format a response before returning the result. This can be useful if you want to customize the way the response is presented to the end user.
 - `returnSourceDocuments`: A boolean value that indicates whether the ChatVectorDBQAChain should return the source documents that were used to retrieve the answer. If set to true, the documents will be included in the result returned by the call() method. This can be useful if you want to allow the user to see the sources used to generate the answer. If not set, the default value will be false.
+- `k`: An integer that specifies the number of documents to retrieve from the vector store. If not set, the default value will be 4.
 
 In summary, the `questionGeneratorTemplate`, `qaTemplate`, and `returnSourceDocuments` options allow the user to customize the behavior of the `ChatVectorDBQAChain`

--- a/langchain/src/chains/tests/chat_vector_db_qa_chain.int.test.ts
+++ b/langchain/src/chains/tests/chat_vector_db_qa_chain.int.test.ts
@@ -1,4 +1,4 @@
-import { test } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 import { OpenAI } from "../../llms/openai.js";
 import { PromptTemplate } from "../../prompts/index.js";
 import { LLMChain } from "../llm_chain.js";
@@ -65,5 +65,56 @@ test("Test ChatVectorDBQAChain from LLM", async () => {
   );
   const chain = ChatVectorDBQAChain.fromLLM(model, vectorStore);
   const res = await chain.call({ question: "foo", chat_history: "bar" });
+  console.log({ res });
+});
+test("Test ChatVectorDBQAChain from LLM with flag option to return source", async () => {
+  const model = new OpenAI({ modelName: "text-ada-001" });
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new OpenAIEmbeddings()
+  );
+  const chain = ChatVectorDBQAChain.fromLLM(model, vectorStore, {
+    returnSourceDocuments: true,
+  });
+  const res = await chain.call({ question: "foo", chat_history: "bar" });
+
+  expect(res).toEqual(
+    expect.objectContaining({
+      text: expect.any(String),
+      sourceDocuments: expect.arrayContaining([
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            id: expect.any(Number),
+          }),
+          pageContent: expect.any(String),
+        }),
+      ]),
+    })
+  );
+});
+
+test("Test ChatVectorDBQAChain from LLM with override default prompts", async () => {
+  const model = new OpenAI({ modelName: "text-ada-001" });
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new OpenAIEmbeddings()
+  );
+
+  const qa_template = `Use the following pieces of context to answer the question at the end. If you don't know the answer, just say "Sorry I dont know, I am learning from Aliens", don't try to make up an answer.
+  {context}
+
+  Question: {question}
+  Helpful Answer:`;
+
+  const chain = ChatVectorDBQAChain.fromLLM(model, vectorStore, {
+    qaTemplate: qa_template,
+  });
+  const res = await chain.call({
+    question: "What is better programming Language Python or Javascript ",
+    chat_history: "bar",
+  });
+  expect(res.text).toContain("I am learning from Aliens");
   console.log({ res });
 });


### PR DESCRIPTION
# Adding Options to the `fromLLM` Method in `ChatVectorDBQAChain`
The `ChatVectorDBQAChain` class provides a powerful mechanism for doing question answering over a large corpus of text documents. Given a question and a chat history, it first combines them into a standalone question, then looks up relevant documents from a vector database, and finally passes those documents and the question to a question answering chain to return a response. This process can be customized in a variety of ways to suit the specific needs of the user.

In a recent update to the library, the fromLLM method in the `ChatVectorDBQAChain` class has been enhanced to allow for additional options to be passed in during instantiation. These options provide a way for the user to customize the behavior of the `ChatVectorDBQAChain` object in various ways.

## Available Options
The following options are now available when creating a new ChatVectorDBQAChain instance using the fromLLM method:

`questionGeneratorTemplate`: A string that specifies a question generation template. If provided, the `ChatVectorDBQAChain` will use this template to generate a question from the conversation context, instead of using the question provided in the question parameter. This can be useful if the original question does not contain enough information to retrieve a suitable answer.
`qaTemplate`: A string that specifies a response template. If provided, the `ChatVectorDBQAChain` will use this template to format a response before returning the result. This can be useful if you want to customize the way the response is presented to the end user.
`returnSourceDocuments`: A boolean value that indicates whether the `ChatVectorDBQAChain` should return the source documents that were used to retrieve the answer. If set to true, the documents will be included in the result returned by the `call()` method. This can be useful if you want to allow the user to see the sources used to generate the answer. If not set, the default value will be false.

# Benefits of the Options
The addition of these options to the `fromLLM` method in the `ChatVectorDBQAChain` class provides a way for users to further customize the question answering process to their specific needs. By allowing for the customization of the question generation and response formatting steps, users can ensure that the `ChatVectorDBQAChain` object returns answers that are tailored to their requirements. Additionally, the `returnSourceDocuments` option provides users with greater transparency into the question answering process, allowing them to see the sources used to generate the answer and to perform additional analysis if necessary. Overall, the addition of these options enhances the flexibility and utility of the `ChatVectorDBQAChain` class, making it an even more powerful tool for doing question answering over large collections of text documents.

