### PR TITLE
Feature/add notion loader for markdown files

### DIFF
--- a/langchain/package.json
+++ b/langchain/package.json
@@ -84,6 +84,7 @@
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
+    "glob": "^9.2.1",
     "hnswlib-node": "^1.3.0",
     "husky": "^8.0.3",
     "jest": "^29.4.2",

--- a/langchain/src/document_loaders/index.ts
+++ b/langchain/src/document_loaders/index.ts
@@ -16,3 +16,4 @@ export { TextLoader } from "./text.js";
 export { JSONLoader } from "./json.js";
 export { JSONLinesLoader } from "./jsonl.js";
 export { CSVLoader } from "./csv.js";
+export {NotionLoader} from "./notion_markdown.js"

--- a/langchain/src/document_loaders/notion_markdown.ts
+++ b/langchain/src/document_loaders/notion_markdown.ts
@@ -1,0 +1,52 @@
+import { Document } from "../document.js";
+import type { readFile as ReadFileT } from "fs/promises";
+import { getEnv } from "../util/env.js";
+import { BaseDocumentLoader } from "./base.js";
+import type { DocumentLoader } from "./base.js";
+import glob from "glob";
+import path from "path";
+
+
+export class NotionLoader extends BaseDocumentLoader implements DocumentLoader {
+  constructor(public directoryPath: string) {
+    super();
+  }
+
+  public async load(): Promise<Document[]> {
+    const { readFile } = await NotionLoader.imports();
+    try {
+      const fileNames = await glob("**/*.md", { cwd: this.directoryPath });
+      const docs: Document[] = [];
+      for (const fileName of fileNames) {
+        const filePath = path.join(this.directoryPath, fileName);
+        const text = await readFile(filePath, {
+          encoding: "utf-8",
+        });
+        const metadata = { source: fileName };
+        docs.push(
+          new Document({
+            pageContent: text,
+            metadata,
+          })
+        );
+      }
+      return docs;
+    } catch (error) {
+      throw new Error(`Could not read directory path ${this.directoryPath} `);
+    }
+  }
+
+  static async imports(): Promise<{
+    readFile: typeof ReadFileT;
+  }> {
+    try {
+      const { readFile } = await import("fs/promises");
+      return { readFile };
+    } catch (e) {
+      console.error(e);
+      throw new Error(
+        `Failed to load fs/promises. NotionLoader available only on environment 'node'. It appears you are running environment '${getEnv()}'. See https://<link to docs> for alternatives.`
+      );
+    }
+  }
+}

--- a/langchain/src/document_loaders/tests/example_data/notion.md
+++ b/langchain/src/document_loaders/tests/example_data/notion.md
@@ -1,0 +1,41 @@
+# Testing the notion markdownloader
+
+# 🦜️🔗 LangChain.js
+
+⚡ Building applications with LLMs through composability ⚡
+
+**Production Support:** As you move your LangChains into production, we'd love to offer more comprehensive support.
+Please fill out [this form](https://forms.gle/57d8AmXBYp8PP8tZA) and we'll set up a dedicated support Slack channel.
+
+## Quick Install
+
+`yarn add langchain`
+
+```typescript
+import { OpenAI } from "langchain/llms";
+```
+
+## 🤔 What is this?
+
+Large language models (LLMs) are emerging as a transformative technology, enabling
+developers to build applications that they previously could not.
+But using these LLMs in isolation is often not enough to
+create a truly powerful app - the real power comes when you can combine them with other sources of computation or knowledge.
+
+This library is aimed at assisting in the development of those types of applications.
+
+## Relationship with Python LangChain
+
+This is built to integrate as seamlessly as possible with the [LangChain Python package](https://github.com/hwchase17/langchain). Specifically, this means all objects (prompts, LLMs, chains, etc) are designed in a way where they can be serialized and shared between languages.
+
+The [LangChainHub](https://github.com/hwchase17/langchain-hub) is a central place for the serialized versions of these prompts, chains, and agents.
+
+## 📖 Documentation
+
+For full documentation of prompts, chains, agents and more, please see [here](https://hwchase17.github.io/langchainjs/docs/overview).
+
+## 💁 Contributing
+
+As an open source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infra, or better documentation.
+
+Check out [our contributing guidelines](CONTRIBUTING.md) for instructions on how to contribute.

--- a/langchain/src/document_loaders/tests/notion_markdown.test.ts
+++ b/langchain/src/document_loaders/tests/notion_markdown.test.ts
@@ -1,0 +1,9 @@
+import { test } from "@jest/globals";
+import { NotionLoader } from "document_loaders/notion_markdown.js";
+
+test("Test Notion Loader", async () => {
+  const loader = new NotionLoader(
+    "../examples/src/document_loaders/example_data/notion.md"
+  );
+  await loader.load();
+});


### PR DESCRIPTION
@nfcampos similar to @hwchase17 [notionqa](https://github.com/hwchase17/notion-qa) in python, I have created a similar typescript notion loader for exported markdown files to be 'ingested.'

I have tested the functionality both locally and in the recent LangChain/Notion tutorial [here](https://github.com/mayooear/notion-chat-langchain).

Await your feedback