### PR TITLE
supabase: refactor to expose constructor options

### DIFF
--- a/examples/src/chains/chat_vector_db_chroma.ts
+++ b/examples/src/chains/chat_vector_db_chroma.ts
@@ -16,11 +16,9 @@ export const run = async () => {
   const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
   const docs = await textSplitter.createDocuments([text]);
   /* Create the vectorstore */
-  const vectorStore = await Chroma.fromDocuments(
-    docs,
-    new OpenAIEmbeddings(),
-    "state_of_the_union"
-  );
+  const vectorStore = await Chroma.fromDocuments(docs, new OpenAIEmbeddings(), {
+    collectionName: "state_of_the_union",
+  });
   /* Create the chain */
   const chain = ChatVectorDBQAChain.fromLLM(model, vectorStore);
   /* Ask it a question */

--- a/examples/src/indexes/vector_stores/supabase.ts
+++ b/examples/src/indexes/vector_stores/supabase.ts
@@ -3,7 +3,7 @@ import { OpenAIEmbeddings } from "langchain/embeddings";
 import { createClient } from "@supabase/supabase-js";
 
 export const run = async () => {
-  const supabaseClient = createClient(
+  const client = createClient(
     process.env.SUPABASE_URL || "",
     process.env.SUPABASE_PRIVATE_KEY || ""
   );
@@ -13,7 +13,9 @@ export const run = async () => {
     [{ id: 2 }, { id: 1 }, { id: 3 }],
     new OpenAIEmbeddings(),
     {
-      client: supabaseClient,
+      client,
+      tableName: "documents",
+      queryName: "match_documents"
     }
   );
 

--- a/examples/src/indexes/vector_stores/supabase.ts
+++ b/examples/src/indexes/vector_stores/supabase.ts
@@ -15,7 +15,7 @@ export const run = async () => {
     {
       client,
       tableName: "documents",
-      queryName: "match_documents"
+      queryName: "match_documents",
     }
   );
 

--- a/langchain/src/vectorstores/base.ts
+++ b/langchain/src/vectorstores/base.ts
@@ -50,6 +50,17 @@ export abstract class VectorStore {
       "the Langchain vectorstore implementation you are using forgot to override this, please report a bug"
     );
   }
+
+  static fromDocuments(
+    _docs: Document[],
+    _embeddings: Embeddings,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _dbConfig: Record<string, any>
+  ): Promise<VectorStore> {
+    throw new Error(
+      "the Langchain vectorstore implementation you are using forgot to override this, please report a bug"
+    );
+  }
 }
 
 export abstract class SaveableVectorStore extends VectorStore {

--- a/langchain/src/vectorstores/supabase.ts
+++ b/langchain/src/vectorstores/supabase.ts
@@ -16,21 +16,23 @@ interface SearchEmbeddingsResponse {
 }
 
 export class SupabaseVectorStore extends VectorStore {
+  client: SupabaseClient;
+
   tableName: string;
 
   queryName: string;
 
   constructor(
-    public client: SupabaseClient,
     embeddings: Embeddings,
     options: {
+      client: SupabaseClient;
       tableName?: string;
       queryName?: string;
-      withMetadata?: boolean;
-    } = {}
+    }
   ) {
     super(embeddings);
 
+    this.client = options.client;
     this.tableName = options.tableName || "documents";
     this.queryName = options.queryName || "match_documents";
   }
@@ -100,10 +102,10 @@ export class SupabaseVectorStore extends VectorStore {
     texts: string[],
     metadatas: object[],
     embeddings: Embeddings,
-    {
-      client,
-    }: {
+    dbConfig: {
       client: SupabaseClient;
+      tableName?: string;
+      queryName?: string;
     }
   ): Promise<SupabaseVectorStore> {
     const docs = [];
@@ -114,24 +116,32 @@ export class SupabaseVectorStore extends VectorStore {
       });
       docs.push(newDoc);
     }
-    return SupabaseVectorStore.fromDocuments(client, docs, embeddings);
+    return SupabaseVectorStore.fromDocuments(docs, embeddings, dbConfig);
   }
 
   static async fromDocuments(
-    client: SupabaseClient,
     docs: Document[],
-    embeddings: Embeddings
+    embeddings: Embeddings,
+    dbConfig: {
+      client: SupabaseClient;
+      tableName?: string;
+      queryName?: string;
+    }
   ): Promise<SupabaseVectorStore> {
-    const instance = new this(client, embeddings);
+    const instance = new this(embeddings, dbConfig);
     await instance.addDocuments(docs);
     return instance;
   }
 
   static async fromExistingIndex(
-    client: SupabaseClient,
-    embeddings: Embeddings
+    embeddings: Embeddings,
+    dbConfig: {
+      client: SupabaseClient;
+      tableName?: string;
+      queryName?: string;
+    }
   ): Promise<SupabaseVectorStore> {
-    const instance = new this(client, embeddings);
+    const instance = new this(embeddings, dbConfig);
     return instance;
   }
 }

--- a/langchain/src/vectorstores/supabase.ts
+++ b/langchain/src/vectorstores/supabase.ts
@@ -15,6 +15,12 @@ interface SearchEmbeddingsResponse {
   similarity: number;
 }
 
+export interface SupabaseLibArgs {
+  client: SupabaseClient;
+  tableName?: string;
+  queryName?: string;
+}
+
 export class SupabaseVectorStore extends VectorStore {
   client: SupabaseClient;
 
@@ -22,19 +28,12 @@ export class SupabaseVectorStore extends VectorStore {
 
   queryName: string;
 
-  constructor(
-    embeddings: Embeddings,
-    options: {
-      client: SupabaseClient;
-      tableName?: string;
-      queryName?: string;
-    }
-  ) {
+  constructor(embeddings: Embeddings, args: SupabaseLibArgs) {
     super(embeddings);
 
-    this.client = options.client;
-    this.tableName = options.tableName || "documents";
-    this.queryName = options.queryName || "match_documents";
+    this.client = args.client;
+    this.tableName = args.tableName || "documents";
+    this.queryName = args.queryName || "match_documents";
   }
 
   async addDocuments(documents: Document[]): Promise<void> {
@@ -102,11 +101,7 @@ export class SupabaseVectorStore extends VectorStore {
     texts: string[],
     metadatas: object[],
     embeddings: Embeddings,
-    dbConfig: {
-      client: SupabaseClient;
-      tableName?: string;
-      queryName?: string;
-    }
+    dbConfig: SupabaseLibArgs
   ): Promise<SupabaseVectorStore> {
     const docs = [];
     for (let i = 0; i < texts.length; i += 1) {
@@ -122,11 +117,7 @@ export class SupabaseVectorStore extends VectorStore {
   static async fromDocuments(
     docs: Document[],
     embeddings: Embeddings,
-    dbConfig: {
-      client: SupabaseClient;
-      tableName?: string;
-      queryName?: string;
-    }
+    dbConfig: SupabaseLibArgs
   ): Promise<SupabaseVectorStore> {
     const instance = new this(embeddings, dbConfig);
     await instance.addDocuments(docs);
@@ -135,11 +126,7 @@ export class SupabaseVectorStore extends VectorStore {
 
   static async fromExistingIndex(
     embeddings: Embeddings,
-    dbConfig: {
-      client: SupabaseClient;
-      tableName?: string;
-      queryName?: string;
-    }
+    dbConfig: SupabaseLibArgs
   ): Promise<SupabaseVectorStore> {
     const instance = new this(embeddings, dbConfig);
     return instance;

--- a/langchain/src/vectorstores/tests/pinecone.int.test.ts
+++ b/langchain/src/vectorstores/tests/pinecone.int.test.ts
@@ -14,11 +14,11 @@ test("PineconeStore with external ids", async () => {
     apiKey: process.env.PINECONE_API_KEY!,
   });
 
-  const index = client.Index(process.env.PINECONE_INDEX!);
+  const pineconeIndex = client.Index(process.env.PINECONE_INDEX!);
 
   const embeddings = new OpenAIEmbeddings();
 
-  const store = new PineconeStore(index, embeddings);
+  const store = new PineconeStore(embeddings, { pineconeIndex });
 
   expect(store).toBeDefined();
 
@@ -44,11 +44,11 @@ test("PineconeStore with generated ids", async () => {
     apiKey: process.env.PINECONE_API_KEY!,
   });
 
-  const index = client.Index(process.env.PINECONE_INDEX!);
+  const pineconeIndex = client.Index(process.env.PINECONE_INDEX!);
 
   const embeddings = new OpenAIEmbeddings();
 
-  const store = new PineconeStore(index, embeddings);
+  const store = new PineconeStore(embeddings, { pineconeIndex });
 
   expect(store).toBeDefined();
 

--- a/langchain/src/vectorstores/tests/pinecone.test.ts
+++ b/langchain/src/vectorstores/tests/pinecone.test.ts
@@ -13,7 +13,7 @@ test("PineconeStore with external ids", async () => {
   };
   const embeddings = new FakeEmbeddings();
 
-  const store = new PineconeStore(client as any, embeddings);
+  const store = new PineconeStore(embeddings, { pineconeIndex: client as any });
 
   expect(store).toBeDefined();
 
@@ -38,7 +38,7 @@ test("PineconeStore with generated ids", async () => {
   };
   const embeddings = new FakeEmbeddings();
 
-  const store = new PineconeStore(client as any, embeddings);
+  const store = new PineconeStore(embeddings, { pineconeIndex: client as any });
 
   expect(store).toBeDefined();
 

--- a/langchain/src/vectorstores/tests/supabase.int.test.ts
+++ b/langchain/src/vectorstores/tests/supabase.int.test.ts
@@ -14,7 +14,7 @@ test("SupabaseVectorStore with external ids", async () => {
 
   const embeddings = new OpenAIEmbeddings();
 
-  const store = new SupabaseVectorStore(client, embeddings);
+  const store = new SupabaseVectorStore(embeddings, { client });
 
   expect(store).toBeDefined();
 

--- a/test-exports/index.cjs
+++ b/test-exports/index.cjs
@@ -14,15 +14,12 @@ async function test() {
   // Test dynamic imports of peer dependencies
   const { HierarchicalNSW } = await HNSWLib.imports();
 
-  const vs = new HNSWLib(
-    {
-      space: "ip",
-      numDimensions: 3,
-    },
-    new OpenAIEmbeddings({ openAIApiKey: "sk-XXXX" }),
-    new InMemoryDocstore(),
-    new HierarchicalNSW("ip", 3)
-  );
+  const vs = new HNSWLib(new OpenAIEmbeddings({ openAIApiKey: "sk-XXXX" }), {
+    space: "ip",
+    numDimensions: 3,
+    docstore: new InMemoryDocstore(),
+    index: new HierarchicalNSW("ip", 3),
+  });
 
   await vs.addVectors(
     [

--- a/test-exports/index.mjs
+++ b/test-exports/index.mjs
@@ -13,15 +13,12 @@ assert(typeof HNSWLib === "function");
 // Test dynamic imports of peer dependencies
 const { HierarchicalNSW } = await HNSWLib.imports();
 
-const vs = new HNSWLib(
-  {
-    space: "ip",
-    numDimensions: 3,
-  },
-  new OpenAIEmbeddings({ openAIApiKey: "sk-XXXX" }),
-  new InMemoryDocstore(),
-  new HierarchicalNSW("ip", 3)
-);
+const vs = new HNSWLib(new OpenAIEmbeddings({ openAIApiKey: "sk-XXXX" }), {
+  space: "ip",
+  numDimensions: 3,
+  docstore: new InMemoryDocstore(),
+  index: new HierarchicalNSW("ip", 3),
+});
 
 await vs.addVectors(
   [


### PR DESCRIPTION
Closes #282

I hate to churn this, but in the refactor that got merged, the constructor options weren't exposed from `fromDocuments` or `fromTexts` or `fromExisting`
And a recent pr added an options struct for `fromDocuments` and moved the client into there

So why not always take client in the options at the same time?