### PR TITLE
docs: Added regular search

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/preset-classic": "2.3.1",
     "@docusaurus/remark-plugin-npm2yarn": "^2.3.1",
     "@mdx-js/react": "^1.6.22",
-    "@mendable/search": "^0.0.40",
+    "@mendable/search": "^0.0.44",
     "clsx": "^1.2.1",
     "process": "^0.11.10",
     "raw-loader": "^4.0.2",

--- a/docs/src/theme/SearchBar.js
+++ b/docs/src/theme/SearchBar.js
@@ -21,6 +21,7 @@ export default function SearchBarWrapper() {
         style={{ accentColor: "#4F956C", darkMode: false }}
         placeholder="Search..."
         dialogPlaceholder="How do I use a LLM Chain?"
+        showSimpleSearch
       />
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2921,15 +2921,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mendable/search@npm:^0.0.40":
-  version: 0.0.40
-  resolution: "@mendable/search@npm:0.0.40"
+"@mendable/search@npm:^0.0.44":
+  version: 0.0.44
+  resolution: "@mendable/search@npm:0.0.44"
   dependencies:
     posthog-js: ^1.45.1
   peerDependencies:
     react: ^17.x || ^18.x
     react-dom: ^17.x || ^18.x
-  checksum: 7e2d235afabb97a2efe75054c2d806d9e9be64255ba2fea894edb4ba9469946eb591d75dcf2d7958c3132ef1ddd1661466ced38f30a36aaa5c6949b9471c9332
+  checksum: 93863cfe6c899b4ec40a566ceb6777a32aa56fa6d9246acb26f71c4ffe2195b0fa1328d19fed0a4e1a282371d4c3be703c523f7ebab665cd514995da5be6e896
   languageName: node
   linkType: hard
 
@@ -6488,7 +6488,7 @@ __metadata:
     "@docusaurus/preset-classic": 2.3.1
     "@docusaurus/remark-plugin-npm2yarn": ^2.3.1
     "@mdx-js/react": ^1.6.22
-    "@mendable/search": ^0.0.40
+    "@mendable/search": ^0.0.44
     clsx: ^1.2.1
     docusaurus-plugin-typedoc: ^0.18.0
     eslint: ^8.19.0


### PR DESCRIPTION
Mendable now has 2 types of search on the component: Mendable Chat and the Normal Search Bar. CMD K will trigger the mendable component and on the top right, there are 2 tabs that you can toggle between the different types of search.

Shoutout to @calebpeffer and @ericciarla for implementing regular keyword search.

@hwchase17 + team, let us know if you have any additional feedback. We will continue to improve it.

