### PR TITLE
Implement BaseLanguageModelParams interface that subclasses should extend

### DIFF
--- a/docs/docs/tracing.md
+++ b/docs/docs/tracing.md
@@ -1,0 +1,113 @@
+# Tracing
+
+Similar to the python `langchain` package, `langchain.js` support tracing.
+
+You can view an overview of tracing [here.](https://langchain.readthedocs.io/en/latest/tracing.html)
+To spin up the tracing backend, run `docker compose up` (or `docker-compose up` if on using an older version of `docker`) in the `langchain` directory.
+You can also use the `langchain-server` command if you have the python `langchain` package installed.
+
+Here's an example of how to use tracing in `langchain.js`. All that needs to be done is setting the `LANGCHAIN_HANDLER` environment variable to `langchain`.
+
+```typescript
+import { OpenAI } from "langchain";
+import { initializeAgentExecutor } from "langchain/agents";
+import { SerpAPI, Calculator } from "langchain/tools";
+import process from "process";
+
+export const run = async () => {
+  process.env.LANGCHAIN_HANDLER = "langchain";
+  const model = new OpenAI({ temperature: 0 });
+  const tools = [new SerpAPI(), new Calculator()];
+
+  const executor = await initializeAgentExecutor(
+    tools,
+    model,
+    "zero-shot-react-description",
+    true
+  );
+  console.log("Loaded agent.");
+
+  const input = `Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?`;
+
+  console.log(`Executing with input "${input}"...`);
+
+  const result = await executor.call({ input });
+
+  console.log(`Got output ${result.output}`);
+};
+```
+
+We are actively working on improving tracing to work better with concurrency. For now, the best way to use tracing with concurrency is to follow the below example:
+
+```typescript
+import { OpenAI } from "langchain";
+import { initializeAgentExecutor } from "langchain/agents";
+import { SerpAPI, Calculator } from "langchain/tools";
+import process from "process";
+import {
+  CallbackManager,
+  LangChainTracer,
+  ConsoleCallbackHandler,
+} from "langchain/callbacks";
+
+export const run = async () => {
+  process.env.LANGCHAIN_HANDLER = "langchain";
+  const model = new OpenAI({ temperature: 0 });
+  const tools = [new SerpAPI(), new Calculator()];
+
+  const executor = await initializeAgentExecutor(
+    tools,
+    model,
+    "zero-shot-react-description",
+    true
+  );
+  console.log("Loaded agent.");
+
+  const input = `Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?`;
+
+  console.log(`Executing with input "${input}"...`);
+
+  // This will result in a lot of errors, because the shared Tracer is not concurrency-safe.
+  const [resultA, resultB, resultC] = await Promise.all([
+    executor.call({ input }),
+    executor.call({ input }),
+    executor.call({ input }),
+  ]);
+
+  console.log(`Got output ${resultA.output}`);
+  console.log(`Got output ${resultB.output}`);
+  console.log(`Got output ${resultC.output}`);
+
+  // This will work, because each executor has its own Tracer, avoiding concurrency issues.
+  console.log("---Now with concurrency-safe tracing---");
+
+  const executors = [];
+  for (let i = 0; i < 3; i += 1) {
+    const callbackManager = new CallbackManager();
+    callbackManager.addHandler(new ConsoleCallbackHandler());
+    callbackManager.addHandler(new LangChainTracer());
+
+    const model = new OpenAI({ temperature: 0, callbackManager });
+    const tools = [new SerpAPI(), new Calculator()];
+    for (const tool of tools) {
+      tool.callbackManager = callbackManager;
+    }
+    const executor = await initializeAgentExecutor(
+      tools,
+      model,
+      "zero-shot-react-description",
+      true,
+      callbackManager
+    );
+    executor.agent.llmChain.callbackManager = callbackManager;
+    executors.push(executor);
+  }
+
+  const results = await Promise.all(
+    executors.map((executor) => executor.call({ input }))
+  );
+  for (const result of results) {
+    console.log(`Got output ${result.output}`);
+  }
+};
+```

--- a/examples/src/agents/chat_mrkl_with_tracing.ts
+++ b/examples/src/agents/chat_mrkl_with_tracing.ts
@@ -1,15 +1,16 @@
-import { OpenAI } from "langchain";
+import { ChatOpenAI } from "langchain/chat_models";
 import { initializeAgentExecutor } from "langchain/agents";
 import { SerpAPI, Calculator } from "langchain/tools";
 
 export const run = async () => {
-  const model = new OpenAI({ temperature: 0 });
+  process.env.LANGCHAIN_HANDLER = "langchain";
+  const model = new ChatOpenAI({ temperature: 0 });
   const tools = [new SerpAPI(), new Calculator()];
 
   const executor = await initializeAgentExecutor(
     tools,
     model,
-    "zero-shot-react-description",
+    "chat-zero-shot-react-description",
     true
   );
   console.log("Loaded agent.");
@@ -21,4 +22,12 @@ export const run = async () => {
   const result = await executor.call({ input });
 
   console.log(`Got output ${result.output}`);
+
+  console.log(
+    `Got intermediate steps ${JSON.stringify(
+      result.intermediateSteps,
+      null,
+      2
+    )}`
+  );
 };

--- a/examples/src/agents/concurrent_mrkl.ts
+++ b/examples/src/agents/concurrent_mrkl.ts
@@ -1,0 +1,70 @@
+import { OpenAI } from "langchain";
+import { initializeAgentExecutor } from "langchain/agents";
+import { SerpAPI, Calculator } from "langchain/tools";
+import process from "process";
+import {
+  CallbackManager,
+  LangChainTracer,
+  ConsoleCallbackHandler,
+} from "langchain/callbacks";
+
+export const run = async () => {
+  process.env.LANGCHAIN_HANDLER = "langchain";
+  const model = new OpenAI({ temperature: 0 });
+  const tools = [new SerpAPI(), new Calculator()];
+
+  const executor = await initializeAgentExecutor(
+    tools,
+    model,
+    "zero-shot-react-description",
+    true
+  );
+  console.log("Loaded agent.");
+
+  const input = `Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?`;
+
+  console.log(`Executing with input "${input}"...`);
+
+  // This will result in a lot of errors, because the shared Tracer is not concurrency-safe.
+  const [resultA, resultB, resultC] = await Promise.all([
+    executor.call({ input }),
+    executor.call({ input }),
+    executor.call({ input }),
+  ]);
+
+  console.log(`Got output ${resultA.output}`);
+  console.log(`Got output ${resultB.output}`);
+  console.log(`Got output ${resultC.output}`);
+
+  // This will work, because each executor has its own Tracer, avoiding concurrency issues.
+  console.log("---Now with concurrency-safe tracing---");
+
+  const executors = [];
+  for (let i = 0; i < 3; i += 1) {
+    const callbackManager = new CallbackManager();
+    callbackManager.addHandler(new ConsoleCallbackHandler());
+    callbackManager.addHandler(new LangChainTracer());
+
+    const model = new OpenAI({ temperature: 0, callbackManager });
+    const tools = [new SerpAPI(), new Calculator()];
+    for (const tool of tools) {
+      tool.callbackManager = callbackManager;
+    }
+    const executor = await initializeAgentExecutor(
+      tools,
+      model,
+      "zero-shot-react-description",
+      true,
+      callbackManager
+    );
+    executor.agent.llmChain.callbackManager = callbackManager;
+    executors.push(executor);
+  }
+
+  const results = await Promise.all(
+    executors.map((executor) => executor.call({ input }))
+  );
+  for (const result of results) {
+    console.log(`Got output ${result.output}`);
+  }
+};

--- a/examples/src/agents/mrkl_with_tracing.ts
+++ b/examples/src/agents/mrkl_with_tracing.ts
@@ -1,8 +1,10 @@
 import { OpenAI } from "langchain";
 import { initializeAgentExecutor } from "langchain/agents";
 import { SerpAPI, Calculator } from "langchain/tools";
+import process from "process";
 
 export const run = async () => {
+  process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new OpenAI({ temperature: 0 });
   const tools = [new SerpAPI(), new Calculator()];
 

--- a/examples/src/chains/llm_chain_stream.ts
+++ b/examples/src/chains/llm_chain_stream.ts
@@ -1,16 +1,18 @@
 import { OpenAI } from "langchain/llms";
 import { PromptTemplate } from "langchain/prompts";
 import { LLMChain } from "langchain/chains";
+import { CallbackManager } from "langchain/callbacks";
 
 export const run = async () => {
+  const manager = CallbackManager.fromHandlers({
+    async handleLLMNewToken(token: string): Promise<void> {
+      console.log({ token });
+    },
+  });
   const model = new OpenAI({
     temperature: 0.9,
     streaming: true,
-    callbackManager: {
-      handleNewToken(token) {
-        console.log({ token });
-      },
-    },
+    callbackManager: manager,
   });
   const template = "What is a good name for a company that makes {product}?";
   const prompt = new PromptTemplate({ template, inputVariables: ["product"] });

--- a/examples/src/chat/streaming.ts
+++ b/examples/src/chat/streaming.ts
@@ -1,14 +1,15 @@
+import { CallbackManager } from "langchain/callbacks";
 import { ChatOpenAI } from "langchain/chat_models";
 import { HumanChatMessage } from "langchain/schema";
 
 export const run = async () => {
   const chat = new ChatOpenAI({
     streaming: true,
-    callbackManager: {
-      handleNewToken(token) {
-        console.log(token);
+    callbackManager: CallbackManager.fromHandlers({
+      async handleLLMNewToken(token: string): Promise<void> {
+        console.log({ token });
       },
-    },
+    }),
   });
 
   const response = await chat.call([

--- a/examples/src/llm_with_tracing.ts
+++ b/examples/src/llm_with_tracing.ts
@@ -1,0 +1,19 @@
+import { OpenAI } from "langchain/llms";
+import { ChatOpenAI } from "langchain/chat_models";
+import { SystemChatMessage, HumanChatMessage } from "langchain/schema";
+import * as process from "process";
+
+export const run = async () => {
+  process.env.LANGCHAIN_HANDLER = "langchain";
+  const model = new OpenAI({ temperature: 0.9 });
+  const resA = await model.call(
+    "What would be a good company name a company that makes colorful socks?"
+  );
+  console.log({ resA });
+
+  const chat = new ChatOpenAI({ temperature: 0 });
+  const system_message = new SystemChatMessage("You are to chat with a user.");
+  const message = new HumanChatMessage("Hello!");
+  const resB = await chat.call([system_message, message]);
+  console.log({ resB });
+};

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -28,5 +28,7 @@ schema.js
 schema.d.ts
 sql_db.js
 sql_db.d.ts
+callbacks.js
+callbacks.d.ts
 index.js
 index.d.ts

--- a/langchain/create-entrypoints.js
+++ b/langchain/create-entrypoints.js
@@ -18,6 +18,7 @@ const entrypoints = {
   chat_models: "chat_models/index",
   schema: "schema/index",
   sql_db: "sql_db",
+  callbacks: "callbacks/index",
 };
 
 const updateJsonFile = (relativePath, updateFunction) => {

--- a/langchain/docker-compose.yaml
+++ b/langchain/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  langchain-frontend:
+    image: notlangchain/langchainplus-frontend:latest
+    ports:
+      - 4173:4173
+    environment:
+      - BACKEND_URL=http://langchain-backend:8000
+      - PUBLIC_BASE_URL=http://localhost:8000
+      - PUBLIC_DEV_MODE=true
+    depends_on:
+      - langchain-backend
+  langchain-backend:
+    image: notlangchain/langchainplus:latest
+    environment:
+      - PORT=8000
+      - LANGCHAIN_ENV=local
+    ports:
+      - 8000:8000
+    depends_on:
+      - langchain-db
+  langchain-db:
+    image: postgres:14.1
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+    ports:
+      - 5432:5432

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -37,6 +37,8 @@
     "schema.d.ts",
     "sql_db.js",
     "sql_db.d.ts",
+    "callbacks.js",
+    "callbacks.d.ts",
     "index.js",
     "index.d.ts"
   ],
@@ -257,6 +259,10 @@
     "./sql_db": {
       "types": "./sql_db.d.ts",
       "import": "./sql_db.js"
+    },
+    "./callbacks": {
+      "types": "./callbacks.d.ts",
+      "import": "./callbacks.js"
     }
   }
 }

--- a/langchain/src/agents/agent.ts
+++ b/langchain/src/agents/agent.ts
@@ -1,16 +1,18 @@
-import { ChainValues } from "../chains/index.js";
 import {
   ZeroShotAgent,
   SerializedZeroShotAgent,
-  AgentAction,
-  AgentFinish,
-  AgentStep,
   StoppingMethod,
   Tool,
 } from "./index.js";
 import { BaseLLM } from "../llms/index.js";
 import { LLMChain } from "../chains/llm_chain.js";
 import { BasePromptTemplate } from "../prompts/index.js";
+import {
+  AgentAction,
+  AgentFinish,
+  AgentStep,
+  ChainValues,
+} from "../schema/index.js";
 
 class ParseError extends Error {
   output: string;

--- a/langchain/src/agents/chat/index.ts
+++ b/langchain/src/agents/chat/index.ts
@@ -1,4 +1,3 @@
-import { BaseLanguageModel } from "../../schema/index.js";
 import { LLMChain } from "../../chains/index.js";
 import {
   Agent,
@@ -6,7 +5,6 @@ import {
   AgentInput,
   StaticAgent,
   staticImplements,
-  AgentStep,
 } from "../index.js";
 import {
   SystemMessagePromptTemplate,
@@ -14,6 +12,8 @@ import {
   ChatPromptTemplate,
 } from "../../prompts/index.js";
 import { PREFIX, SUFFIX, FORMAT_INSTRUCTIONS } from "./prompt.js";
+import { BaseLanguageModel } from "../../base_language/index.js";
+import { AgentStep } from "../../schema/index.js";
 
 const FINAL_ANSWER_ACTION = "Final Answer:";
 

--- a/langchain/src/agents/executor.ts
+++ b/langchain/src/agents/executor.ts
@@ -1,12 +1,8 @@
-import { ChainValues, BaseChain } from "../chains/index.js";
-import {
-  Agent,
-  Tool,
-  StoppingMethod,
-  AgentStep,
-  AgentFinish,
-} from "./index.js";
+import { BaseChain } from "../chains/index.js";
+import { Agent, Tool, StoppingMethod } from "./index.js";
 import { SerializedLLMChain } from "../chains/llm_chain.js";
+import { AgentFinish, AgentStep, ChainValues } from "../schema/index.js";
+import { CallbackManager } from "../callbacks/index.js";
 
 type AgentExecutorInput = {
   agent: Agent;
@@ -14,6 +10,9 @@ type AgentExecutorInput = {
   returnIntermediateSteps?: boolean;
   maxIterations?: number;
   earlyStoppingMethod?: StoppingMethod;
+
+  verbose?: boolean;
+  callbackManager?: CallbackManager;
 };
 
 /**
@@ -44,6 +43,8 @@ export class AgentExecutor extends BaseChain {
     this.maxIterations = input.maxIterations ?? this.maxIterations;
     this.earlyStoppingMethod =
       input.earlyStoppingMethod ?? this.earlyStoppingMethod;
+    this.verbose = input.verbose ?? this.verbose;
+    this.callbackManager = input.callbackManager ?? this.callbackManager;
   }
 
   /** Create from agent and a list of tools. */
@@ -69,11 +70,12 @@ export class AgentExecutor extends BaseChain {
     const steps: AgentStep[] = [];
     let iterations = 0;
 
-    const getOutput = (finishStep: AgentFinish) => {
+    const getOutput = async (finishStep: AgentFinish) => {
       const { returnValues } = finishStep;
       if (this.returnIntermediateSteps) {
         return { ...returnValues, intermediateSteps: steps };
       }
+      await this.callbackManager.handleAgentEnd(finishStep, this.verbose);
       return returnValues;
     };
 
@@ -82,10 +84,11 @@ export class AgentExecutor extends BaseChain {
       if ("returnValues" in action) {
         return getOutput(action);
       }
+      await this.callbackManager.handleAgentAction(action, this.verbose);
 
       const tool = toolsByName[action.tool.toLowerCase()];
       const observation = tool
-        ? await tool.call(action.toolInput)
+        ? await tool.call(action.toolInput, this.verbose)
         : `${action.tool} is not a valid tool, try another one.`;
       steps.push({ action, observation });
       if (tool?.returnDirect) {

--- a/langchain/src/agents/helpers.ts
+++ b/langchain/src/agents/helpers.ts
@@ -1,8 +1,8 @@
 import type { SerializedAgentT, AgentInput } from "./index.js";
 import { Tool } from "./tools/index.js";
-import { BaseLanguageModel } from "../schema/index.js";
 import { SerializedLLMChain, LLMChain } from "../chains/index.js";
 import { resolveConfigFromFile } from "../util/index.js";
+import { BaseLanguageModel } from "../base_language/index.js";
 
 export const deserializeHelper = async <
   T extends string,

--- a/langchain/src/agents/index.ts
+++ b/langchain/src/agents/index.ts
@@ -1,10 +1,4 @@
-export {
-  AgentAction,
-  AgentFinish,
-  AgentStep,
-  StoppingMethod,
-  SerializedAgentT,
-} from "./types.js";
+export { StoppingMethod, SerializedAgentT } from "./types.js";
 export { Agent, StaticAgent, staticImplements, AgentInput } from "./agent.js";
 export { AgentExecutor } from "./executor.js";
 export { ZeroShotAgent, SerializedZeroShotAgent } from "./mrkl/index.js";

--- a/langchain/src/agents/initialize.ts
+++ b/langchain/src/agents/initialize.ts
@@ -1,13 +1,16 @@
 import { Tool } from "./tools/index.js";
-import { BaseLanguageModel } from "../schema/index.js";
 import { AgentExecutor } from "./executor.js";
 import { ZeroShotAgent } from "./mrkl/index.js";
 import { ChatAgent } from "./chat/index.js";
+import { BaseLanguageModel } from "../base_language/index.js";
+import { CallbackManager, getCallbackManager } from "../callbacks/index.js";
 
 export const initializeAgentExecutor = async (
   tools: Tool[],
   llm: BaseLanguageModel,
-  agentType = "zero-shot-react-description"
+  agentType = "zero-shot-react-description",
+  verbose = false,
+  callbackManager: CallbackManager = getCallbackManager()
 ): Promise<AgentExecutor> => {
   switch (agentType) {
     case "zero-shot-react-description":
@@ -15,12 +18,16 @@ export const initializeAgentExecutor = async (
         agent: ZeroShotAgent.fromLLMAndTools(llm, tools),
         tools,
         returnIntermediateSteps: true,
+        verbose,
+        callbackManager,
       });
     case "chat-zero-shot-react-description":
       return AgentExecutor.fromAgentAndTools({
         agent: ChatAgent.fromLLMAndTools(llm, tools),
         tools,
         returnIntermediateSteps: true,
+        verbose,
+        callbackManager,
       });
     default:
       throw new Error("Unknown agent type");

--- a/langchain/src/agents/mrkl/index.ts
+++ b/langchain/src/agents/mrkl/index.ts
@@ -1,4 +1,3 @@
-import { BaseLanguageModel } from "../../schema/index.js";
 import { LLMChain } from "../../chains/index.js";
 import {
   Agent,
@@ -11,6 +10,7 @@ import {
 import { PromptTemplate } from "../../prompts/index.js";
 import { PREFIX, SUFFIX, formatInstructions } from "./prompt.js";
 import { deserializeHelper } from "../helpers.js";
+import { BaseLanguageModel } from "../../base_language/index.js";
 
 const FINAL_ANSWER_ACTION = "Final Answer:";
 

--- a/langchain/src/agents/tools/IFTTTWebhook.ts
+++ b/langchain/src/agents/tools/IFTTTWebhook.ts
@@ -48,7 +48,7 @@ export class IFTTTWebhook extends Tool {
     this.description = description;
   }
 
-  async call(input: string): Promise<string> {
+  async _call(input: string): Promise<string> {
     const headers = { "Content-Type": "application/json" };
     const body = JSON.stringify({ this: input });
 

--- a/langchain/src/agents/tools/base.ts
+++ b/langchain/src/agents/tools/base.ts
@@ -1,5 +1,41 @@
+import { CallbackManager, getCallbackManager } from "../../callbacks/index.js";
+
+const getVerbosity = () => false;
+
+export interface ToolParams {
+  verbose?: boolean;
+  callbackManager?: CallbackManager;
+}
+
 export abstract class Tool {
-  abstract call(arg: string): Promise<string>;
+  verbose: boolean;
+
+  callbackManager: CallbackManager;
+
+  constructor(verbose?: boolean, callbackManager?: CallbackManager) {
+    this.verbose = verbose ?? getVerbosity();
+    this.callbackManager = callbackManager ?? getCallbackManager();
+  }
+
+  protected abstract _call(arg: string): Promise<string>;
+
+  async call(arg: string, verbose?: boolean): Promise<string> {
+    const _verbose = verbose ?? this.verbose;
+    await this.callbackManager.handleToolStart(
+      { name: this.name },
+      arg,
+      _verbose
+    );
+    let result;
+    try {
+      result = await this._call(arg);
+    } catch (e) {
+      await this.callbackManager.handleToolError(e, _verbose);
+      throw e;
+    }
+    await this.callbackManager.handleToolEnd(result, _verbose);
+    return result;
+  }
 
   abstract name: string;
 

--- a/langchain/src/agents/tools/bingserpapi.ts
+++ b/langchain/src/agents/tools/bingserpapi.ts
@@ -26,7 +26,7 @@ class BingSerpAPI extends Tool {
     this.params = params;
   }
 
-  async call(input: string): Promise<string> {
+  async _call(input: string): Promise<string> {
     const headers = { "Ocp-Apim-Subscription-Key": this.key };
     const params = { q: input, textDecorations: "true", textFormat: "HTML" };
     const searchUrl = new URL("https://api.bing.microsoft.com/v7.0/search");

--- a/langchain/src/agents/tools/calculator.ts
+++ b/langchain/src/agents/tools/calculator.ts
@@ -5,7 +5,7 @@ import { Tool } from "./base.js";
 export class Calculator extends Tool {
   name = "calculator";
 
-  async call(input: string) {
+  async _call(input: string) {
     try {
       return Parser.evaluate(input).toString();
     } catch (error) {

--- a/langchain/src/agents/tools/chain.ts
+++ b/langchain/src/agents/tools/chain.ts
@@ -23,7 +23,7 @@ export class ChainTool extends Tool {
     this.returnDirect = fields.returnDirect ?? this.returnDirect;
   }
 
-  async call(input: string): Promise<string> {
+  async _call(input: string): Promise<string> {
     return this.chain.run(input);
   }
 }

--- a/langchain/src/agents/tools/dadjokeapi.ts
+++ b/langchain/src/agents/tools/dadjokeapi.ts
@@ -12,7 +12,7 @@ class DadJokeAPI extends Tool {
       "a dad joke generator. get a dad joke about a specific topic. input should be a search term.";
   }
 
-  async call(input: string): Promise<string> {
+  async _call(input: string): Promise<string> {
     const headers = { Accept: "application/json" };
     const searchUrl = `https://icanhazdadjoke.com/search?term=${input}`;
 

--- a/langchain/src/agents/tools/dynamic.ts
+++ b/langchain/src/agents/tools/dynamic.ts
@@ -18,7 +18,7 @@ export class DynamicTool extends Tool {
     this.func = fields.func;
   }
 
-  async call(input: string): Promise<string> {
+  async _call(input: string): Promise<string> {
     return this.func(input);
   }
 }

--- a/langchain/src/agents/tools/json.ts
+++ b/langchain/src/agents/tools/json.ts
@@ -64,7 +64,7 @@ export class JsonListKeysTool extends Tool {
     super();
   }
 
-  async call(input: string) {
+  async _call(input: string) {
     try {
       return this.jsonSpec.getKeys(input);
     } catch (error) {
@@ -84,7 +84,7 @@ export class JsonGetValueTool extends Tool {
     super();
   }
 
-  async call(input: string) {
+  async _call(input: string) {
     try {
       return this.jsonSpec.getValue(input);
     } catch (error) {

--- a/langchain/src/agents/tools/requests.ts
+++ b/langchain/src/agents/tools/requests.ts
@@ -15,7 +15,7 @@ export class RequestsGetTool extends Tool implements RequestTool {
     super();
   }
 
-  async call(input: string) {
+  async _call(input: string) {
     const res = await fetch(input, {
       headers: this.headers,
     });
@@ -33,7 +33,7 @@ export class RequestsPostTool extends Tool implements RequestTool {
     super();
   }
 
-  async call(input: string) {
+  async _call(input: string) {
     try {
       const { url, data } = JSON.parse(input);
       const res = await fetch(url, {

--- a/langchain/src/agents/tools/serpapi.ts
+++ b/langchain/src/agents/tools/serpapi.ts
@@ -33,7 +33,7 @@ export class SerpAPI extends Tool {
   /**
    * Run query through SerpAPI and parse result
    */
-  async call(input: string) {
+  async _call(input: string) {
     const { getJson } = await SerpAPI.imports();
     const res = await getJson("google", {
       ...this.params,

--- a/langchain/src/agents/tools/sql.ts
+++ b/langchain/src/agents/tools/sql.ts
@@ -19,7 +19,7 @@ export class QuerySqlTool extends Tool implements SqlTool {
     this.db = db;
   }
 
-  async call(input: string) {
+  async _call(input: string) {
     try {
       return await this.db.run(input);
     } catch (error) {
@@ -43,7 +43,7 @@ export class InfoSqlTool extends Tool implements SqlTool {
   }
 
   // get the table names for a comma separated list of tables, return error message in strong format
-  async call(input: string) {
+  async _call(input: string) {
     try {
       const tables = input.split(",").map((table) => table.trim());
       return await this.db.getTableInfo(tables);
@@ -68,7 +68,7 @@ export class ListTablesSqlTool extends Tool implements SqlTool {
     this.db = db;
   }
 
-  async call(_: string) {
+  async _call(_: string) {
     try {
       const tables = this.db.allTables.map(
         (table: SqlTable) => table.tableName
@@ -115,7 +115,7 @@ If there are any of the above mistakes, rewrite the query. If there are no mista
     }
   }
 
-  async call(input: string) {
+  async _call(input: string) {
     return this.llmChain.predict({ query: input });
   }
 

--- a/langchain/src/agents/tools/vectorstore.ts
+++ b/langchain/src/agents/tools/vectorstore.ts
@@ -32,7 +32,7 @@ export class VectorStoreQATool extends Tool implements VectorStoreTool {
     return `Useful for when you need to answer questions about ${name}. Whenever you need information about ${description} you should ALWAYS use this. Input should be a fully formed question.`;
   }
 
-  async call(input: string) {
+  async _call(input: string) {
     return this.chain.run(input);
   }
 }

--- a/langchain/src/agents/types.ts
+++ b/langchain/src/agents/types.ts
@@ -1,23 +1,6 @@
 import { SerializedLLMChain } from "../chains/index.js";
 import type { AgentInput } from "./index.js";
 
-export type AgentAction = {
-  tool: string;
-  toolInput: string;
-  log: string;
-};
-
-export type AgentFinish = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  returnValues: Record<string, any>;
-  log: string;
-};
-
-export type AgentStep = {
-  action: AgentAction;
-  observation: string;
-};
-
 export type StoppingMethod = "force" | "generate";
 
 export type SerializedAgentT<

--- a/langchain/src/base_language/index.ts
+++ b/langchain/src/base_language/index.ts
@@ -1,0 +1,40 @@
+import { BasePromptValue, LLMResult } from "../schema/index.js";
+import { CallbackManager, getCallbackManager } from "../callbacks/index.js";
+
+const getVerbosity = () => false;
+
+/**
+ * Base interface for language model parameters.
+ * A subclass of {@link BaseLanguageModel} should have a constructor that
+ * takes in a parameter that extends this interface.
+ */
+export interface BaseLanguageModelParams {
+  verbose?: boolean;
+  callbackManager?: CallbackManager;
+}
+
+/**
+ * Base class for language models.
+ */
+export abstract class BaseLanguageModel implements BaseLanguageModelParams {
+  /**
+   * Whether to print out response text.
+   */
+  verbose: boolean;
+
+  callbackManager: CallbackManager;
+
+  protected constructor(params: BaseLanguageModelParams) {
+    this.verbose = params.verbose ?? getVerbosity();
+    this.callbackManager = params.callbackManager ?? getCallbackManager();
+  }
+
+  abstract generatePrompt(
+    promptValues: BasePromptValue[],
+    stop?: string[]
+  ): Promise<LLMResult>;
+
+  abstract _modelType(): string;
+
+  abstract getNumTokens(text: string): number;
+}

--- a/langchain/src/callbacks/base.ts
+++ b/langchain/src/callbacks/base.ts
@@ -1,0 +1,358 @@
+import {
+  AgentAction,
+  AgentFinish,
+  ChainValues,
+  LLMResult,
+} from "../schema/index.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Error = any;
+
+export interface BaseCallbackHandlerInput {
+  alwaysVerbose?: boolean;
+  ignoreLLM?: boolean;
+  ignoreChain?: boolean;
+  ignoreAgent?: boolean;
+}
+
+abstract class BaseCallbackHandlerMethods {
+  handleLLMStart?(
+    llm: { name: string },
+    prompts: string[],
+    verbose?: boolean
+  ): Promise<void>;
+
+  handleLLMNewToken?(token: string, verbose?: boolean): Promise<void>;
+
+  handleLLMError?(err: Error, verbose?: boolean): Promise<void>;
+
+  handleLLMEnd?(output: LLMResult, verbose?: boolean): Promise<void>;
+
+  handleChainStart?(
+    chain: { name: string },
+    inputs: ChainValues,
+    verbose?: boolean
+  ): Promise<void>;
+
+  handleChainError?(err: Error, verbose?: boolean): Promise<void>;
+
+  handleChainEnd?(outputs: ChainValues, verbose?: boolean): Promise<void>;
+
+  handleToolStart?(
+    tool: { name: string },
+    input: string,
+    verbose?: boolean
+  ): Promise<void>;
+
+  handleToolError?(err: Error, verbose?: boolean): Promise<void>;
+
+  handleToolEnd?(output: string, verbose?: boolean): Promise<void>;
+
+  handleText?(text: string, verbose?: boolean): Promise<void>;
+
+  handleAgentAction?(action: AgentAction, verbose?: boolean): Promise<void>;
+
+  handleAgentEnd?(action: AgentFinish, verbose?: boolean): Promise<void>;
+}
+
+export abstract class BaseCallbackHandler
+  extends BaseCallbackHandlerMethods
+  implements BaseCallbackHandlerInput
+{
+  alwaysVerbose = false;
+
+  ignoreLLM = false;
+
+  ignoreChain = false;
+
+  ignoreAgent = false;
+
+  constructor(input?: BaseCallbackHandlerInput) {
+    super();
+    if (input) {
+      this.alwaysVerbose = input.alwaysVerbose ?? this.alwaysVerbose;
+      this.ignoreLLM = input.ignoreLLM ?? this.ignoreLLM;
+      this.ignoreChain = input.ignoreChain ?? this.ignoreChain;
+      this.ignoreAgent = input.ignoreAgent ?? this.ignoreAgent;
+    }
+  }
+}
+
+export abstract class BaseCallbackManager extends BaseCallbackHandler {
+  abstract addHandler(handler: BaseCallbackHandler): void;
+
+  abstract removeHandler(handler: BaseCallbackHandler): void;
+
+  abstract setHandlers(handlers: BaseCallbackHandler[]): void;
+
+  setHandler(handler: BaseCallbackHandler): void {
+    return this.setHandlers([handler]);
+  }
+}
+
+export class CallbackManager extends BaseCallbackManager {
+  handlers: BaseCallbackHandler[];
+
+  constructor() {
+    super();
+    this.handlers = [];
+  }
+
+  async handleLLMStart(
+    llm: { name: string },
+    prompts: string[],
+    verbose?: boolean
+  ): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleLLMStart?.(llm, prompts);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleLLMStart: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleLLMNewToken(token: string, verbose?: boolean): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleLLMNewToken?.(token);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleLLMNewToken: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleLLMError(err: Error, verbose?: boolean): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleLLMError?.(err);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleLLMError: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleLLMEnd(output: LLMResult, verbose?: boolean): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleLLMEnd?.(output);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleLLMEnd: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleChainStart(
+    chain: { name: string },
+    inputs: ChainValues,
+    verbose?: boolean
+  ): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleChainStart?.(chain, inputs);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleChainStart: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleChainError(err: Error, verbose?: boolean): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleChainError?.(err);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleChainError: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleChainEnd(output: ChainValues, verbose?: boolean): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleChainEnd?.(output);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleChainEnd: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleToolStart(
+    tool: { name: string },
+    input: string,
+    verbose?: boolean
+  ): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleToolStart?.(tool, input);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleToolStart: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleToolError(err: Error, verbose?: boolean): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleToolError?.(err);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleToolError: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleToolEnd(output: string, verbose?: boolean): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleToolEnd?.(output);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleToolEnd: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleText(text: string, verbose?: boolean): Promise<void> {
+    for (const handler of this.handlers) {
+      if (verbose || handler.alwaysVerbose) {
+        try {
+          await handler.handleText?.(text);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleText: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleAgentAction(
+    action: AgentAction,
+    verbose?: boolean
+  ): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleAgentAction?.(action);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleAgentAction: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  async handleAgentEnd(action: AgentFinish, verbose?: boolean): Promise<void> {
+    for (const handler of this.handlers) {
+      if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
+        try {
+          await handler.handleAgentEnd?.(action);
+        } catch (err) {
+          console.error(
+            `Error in handler ${handler.constructor.name}, handleAgentEnd: ${err}`
+          );
+        }
+      }
+    }
+  }
+
+  addHandler(handler: BaseCallbackHandler): void {
+    this.handlers.push(handler);
+  }
+
+  removeHandler(handler: BaseCallbackHandler): void {
+    this.handlers = this.handlers.filter((_handler) => _handler !== handler);
+  }
+
+  setHandlers(handlers: BaseCallbackHandler[]): void {
+    this.handlers = handlers;
+  }
+
+  static fromHandlers(handlers: BaseCallbackHandlerMethods) {
+    class Handler extends BaseCallbackHandler {
+      constructor() {
+        super();
+        Object.assign(this, handlers);
+      }
+    }
+
+    const manager = new this();
+    manager.addHandler(new Handler());
+    return manager;
+  }
+}
+
+export class ConsoleCallbackHandler extends BaseCallbackHandler {
+  async handleChainStart(
+    chain: { name: string },
+    _inputs: ChainValues,
+    _verbose?: boolean
+  ): Promise<void> {
+    console.log(`Entering new ${chain.name} chain...`);
+  }
+
+  async handleChainEnd(
+    _output: ChainValues,
+    _verbose?: boolean
+  ): Promise<void> {
+    console.log("Finished chain.");
+  }
+
+  async handleAgentAction(
+    action: AgentAction,
+    _verbose?: boolean
+  ): Promise<void> {
+    console.log(action.log);
+  }
+
+  async handleToolEnd(output: string, _verbose?: boolean): Promise<void> {
+    console.log(output);
+  }
+
+  async handleText(text: string, _verbose?: boolean): Promise<void> {
+    console.log(text);
+  }
+
+  async handleAgentEnd(action: AgentFinish, _verbose?: boolean): Promise<void> {
+    console.log(action.log);
+  }
+}

--- a/langchain/src/callbacks/index.ts
+++ b/langchain/src/callbacks/index.ts
@@ -1,0 +1,9 @@
+export {
+  CallbackManager,
+  ConsoleCallbackHandler,
+  BaseCallbackHandler,
+} from "./base.js";
+
+export { LangChainTracer } from "./tracers.js";
+
+export { getCallbackManager, setTracerSession } from "./utils.js";

--- a/langchain/src/callbacks/tests/callbacks.test.ts
+++ b/langchain/src/callbacks/tests/callbacks.test.ts
@@ -1,0 +1,271 @@
+import { test, expect } from "@jest/globals";
+import {
+  CallbackManager,
+  BaseCallbackHandler,
+  BaseCallbackHandlerInput,
+} from "../base.js";
+import {
+  AgentAction,
+  AgentFinish,
+  ChainValues,
+  LLMResult,
+} from "../../schema/index.js";
+
+class FakeCallbackHandler extends BaseCallbackHandler {
+  starts = 0;
+
+  ends = 0;
+
+  errors = 0;
+
+  chainStarts = 0;
+
+  chainEnds = 0;
+
+  llmStarts = 0;
+
+  llmEnds = 0;
+
+  llmStreams = 0;
+
+  toolStarts = 0;
+
+  toolEnds = 0;
+
+  agentEnds = 0;
+
+  texts = 0;
+
+  constructor(inputs?: BaseCallbackHandlerInput) {
+    super(inputs);
+  }
+
+  async handleLLMStart(
+    _llm: { name: string },
+    _prompts: string[]
+  ): Promise<void> {
+    this.starts += 1;
+    this.llmStarts += 1;
+  }
+
+  async handleLLMEnd(_output: LLMResult): Promise<void> {
+    this.ends += 1;
+    this.llmEnds += 1;
+  }
+
+  async handleLLMNewToken(_token: string): Promise<void> {
+    this.llmStreams += 1;
+  }
+
+  async handleLLMError(_err: Error): Promise<void> {
+    this.errors += 1;
+  }
+
+  async handleChainStart(
+    _chain: { name: string },
+    _inputs: ChainValues
+  ): Promise<void> {
+    this.starts += 1;
+    this.chainStarts += 1;
+  }
+
+  async handleChainEnd(_outputs: ChainValues): Promise<void> {
+    this.ends += 1;
+    this.chainEnds += 1;
+  }
+
+  async handleChainError(_err: Error): Promise<void> {
+    this.errors += 1;
+  }
+
+  async handleToolStart(
+    _tool: { name: string },
+    _input: string
+  ): Promise<void> {
+    this.starts += 1;
+    this.toolStarts += 1;
+  }
+
+  async handleToolEnd(_output: string): Promise<void> {
+    this.ends += 1;
+    this.toolEnds += 1;
+  }
+
+  async handleToolError(_err: Error, _verbose?: boolean): Promise<void> {
+    this.errors += 1;
+  }
+
+  async handleText(_text: string, _verbose?: boolean): Promise<void> {
+    this.texts += 1;
+  }
+
+  async handleAgentAction(
+    _action: AgentAction,
+    _verbose?: boolean
+  ): Promise<void> {
+    this.starts += 1;
+    this.toolStarts += 1;
+  }
+
+  async handleAgentEnd(
+    _action: AgentFinish,
+    _verbose?: boolean
+  ): Promise<void> {
+    this.ends += 1;
+    this.agentEnds += 1;
+  }
+}
+
+test("CallbackManager", async () => {
+  const manager = new CallbackManager();
+  const handler1 = new FakeCallbackHandler({ alwaysVerbose: true });
+  const handler2 = new FakeCallbackHandler({ alwaysVerbose: false });
+  manager.addHandler(handler1);
+  manager.addHandler(handler2);
+
+  await manager.handleLLMStart({ name: "test" }, ["test"]);
+  await manager.handleLLMEnd({ generations: [] });
+  await manager.handleLLMNewToken("test");
+  await manager.handleLLMError(new Error("test"));
+  await manager.handleChainStart({ name: "test" }, { test: "test" });
+  await manager.handleChainEnd({ test: "test" });
+  await manager.handleChainError(new Error("test"));
+  await manager.handleToolStart({ name: "test" }, "test");
+  await manager.handleToolEnd("test");
+  await manager.handleToolError(new Error("test"));
+  await manager.handleText("test");
+  await manager.handleAgentAction({
+    tool: "test",
+    toolInput: "test",
+    log: "test",
+  });
+  await manager.handleAgentEnd({ returnValues: { test: "test" }, log: "test" });
+
+  expect(handler1.starts).toBe(4);
+  expect(handler1.ends).toBe(4);
+  expect(handler1.errors).toBe(3);
+  expect(handler1.llmStarts).toBe(1);
+  expect(handler1.llmEnds).toBe(1);
+  expect(handler1.llmStreams).toBe(1);
+  expect(handler1.chainStarts).toBe(1);
+  expect(handler1.chainEnds).toBe(1);
+  expect(handler1.toolStarts).toBe(2);
+  expect(handler1.toolEnds).toBe(1);
+  expect(handler1.agentEnds).toBe(1);
+  expect(handler1.texts).toBe(1);
+
+  expect(handler2.starts).toBe(0);
+  expect(handler2.ends).toBe(0);
+  expect(handler2.errors).toBe(0);
+  expect(handler2.llmStarts).toBe(0);
+  expect(handler2.llmEnds).toBe(0);
+  expect(handler2.llmStreams).toBe(0);
+  expect(handler2.chainStarts).toBe(0);
+  expect(handler2.chainEnds).toBe(0);
+  expect(handler2.toolStarts).toBe(0);
+  expect(handler2.toolEnds).toBe(0);
+  expect(handler2.agentEnds).toBe(0);
+  expect(handler2.texts).toBe(0);
+});
+
+test("CallbackManager with verbose passed in", async () => {
+  const manager = new CallbackManager();
+  const handler = new FakeCallbackHandler({ alwaysVerbose: false });
+  manager.addHandler(handler);
+
+  await manager.handleLLMStart({ name: "test" }, ["test"], true);
+  await manager.handleLLMEnd({ generations: [] }, true);
+  await manager.handleLLMNewToken("test", true);
+  await manager.handleLLMError(new Error("test"), true);
+  await manager.handleChainStart({ name: "test" }, { test: "test" }, true);
+  await manager.handleChainEnd({ test: "test" }, true);
+  await manager.handleChainError(new Error("test"), true);
+  await manager.handleToolStart({ name: "test" }, "test", true);
+  await manager.handleToolEnd("test", true);
+  await manager.handleToolError(new Error("test"), true);
+  await manager.handleText("test", true);
+  await manager.handleAgentAction(
+    { tool: "test", toolInput: "test", log: "test" },
+    true
+  );
+  await manager.handleAgentEnd(
+    { returnValues: { test: "test" }, log: "test" },
+    true
+  );
+
+  expect(handler.starts).toBe(4);
+  expect(handler.ends).toBe(4);
+  expect(handler.errors).toBe(3);
+  expect(handler.llmStarts).toBe(1);
+  expect(handler.llmEnds).toBe(1);
+  expect(handler.llmStreams).toBe(1);
+  expect(handler.chainStarts).toBe(1);
+  expect(handler.chainEnds).toBe(1);
+  expect(handler.toolStarts).toBe(2);
+  expect(handler.toolEnds).toBe(1);
+  expect(handler.agentEnds).toBe(1);
+  expect(handler.texts).toBe(1);
+});
+
+test("CallbackHandler with ignoreLLM", async () => {
+  const handler = new FakeCallbackHandler({
+    alwaysVerbose: true,
+    ignoreLLM: true,
+  });
+  const manager = new CallbackManager();
+  manager.addHandler(handler);
+  await manager.handleLLMStart({ name: "test" }, ["test"]);
+  await manager.handleLLMEnd({ generations: [] });
+  await manager.handleLLMNewToken("test");
+  await manager.handleLLMError(new Error("test"));
+
+  expect(handler.starts).toBe(0);
+  expect(handler.ends).toBe(0);
+  expect(handler.errors).toBe(0);
+  expect(handler.llmStarts).toBe(0);
+  expect(handler.llmEnds).toBe(0);
+  expect(handler.llmStreams).toBe(0);
+});
+
+test("CallbackHandler with ignoreChain", async () => {
+  const handler = new FakeCallbackHandler({
+    alwaysVerbose: true,
+    ignoreChain: true,
+  });
+  const manager = new CallbackManager();
+  manager.addHandler(handler);
+  await manager.handleChainStart({ name: "test" }, { test: "test" });
+  await manager.handleChainEnd({ test: "test" });
+  await manager.handleChainError(new Error("test"));
+
+  expect(handler.starts).toBe(0);
+  expect(handler.ends).toBe(0);
+  expect(handler.errors).toBe(0);
+  expect(handler.chainStarts).toBe(0);
+  expect(handler.chainEnds).toBe(0);
+});
+
+test("CallbackHandler with ignoreAgent", async () => {
+  const handler = new FakeCallbackHandler({
+    alwaysVerbose: true,
+    ignoreAgent: true,
+  });
+  const manager = new CallbackManager();
+  manager.addHandler(handler);
+  await manager.handleToolStart({ name: "test" }, "test");
+  await manager.handleToolEnd("test");
+  await manager.handleToolError(new Error("test"));
+  await manager.handleAgentAction({
+    tool: "test",
+    toolInput: "test",
+    log: "test",
+  });
+  await manager.handleAgentEnd({ returnValues: { test: "test" }, log: "test" });
+
+  expect(handler.starts).toBe(0);
+  expect(handler.ends).toBe(0);
+  expect(handler.errors).toBe(0);
+  expect(handler.toolStarts).toBe(0);
+  expect(handler.toolEnds).toBe(0);
+  expect(handler.agentEnds).toBe(0);
+});

--- a/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
+++ b/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@jest/globals";
+
+import { LangChainTracer } from "../tracers.js";
+import { OpenAI } from "../../llms/index.js";
+import { Calculator, SerpAPI } from "../../agents/tools/index.js";
+import { initializeAgentExecutor } from "../../agents/index.js";
+
+test("Test LangChain tracer", async () => {
+  const tracer = new LangChainTracer();
+  expect(tracer.alwaysVerbose).toBe(true);
+
+  await tracer.handleChainStart({ name: "test" }, { foo: "bar" });
+  await tracer.handleToolStart({ name: "test" }, "test");
+  await tracer.handleLLMStart({ name: "test" }, ["test"]);
+  await tracer.handleLLMEnd({ generations: [[]] });
+  await tracer.handleToolEnd("output");
+  await tracer.handleLLMStart({ name: "test2" }, ["test"]);
+  await tracer.handleLLMEnd({ generations: [[]] });
+  await tracer.handleChainEnd({ foo: "bar" });
+
+  await tracer.handleLLMStart({ name: "test" }, ["test"]);
+  await tracer.handleLLMEnd({ generations: [[]] });
+});
+
+test("Test Traced Agent with concurrency", async () => {
+  process.env.LANGCHAIN_HANDLER = "langchain";
+  const model = new OpenAI({ temperature: 0 });
+  const tools = [new SerpAPI(), new Calculator()];
+
+  const executor = await initializeAgentExecutor(
+    tools,
+    model,
+    "zero-shot-react-description",
+    true
+  );
+
+  const input = `Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?`;
+
+  console.log(`Executing with input "${input}"...`);
+
+  const [resultA, resultB, resultC] = await Promise.all([
+    executor.call({ input }),
+    executor.call({ input }),
+    executor.call({ input }),
+  ]);
+
+  console.log(`Got output ${resultA.output}`);
+  console.log(`Got output ${resultB.output}`);
+  console.log(`Got output ${resultC.output}`);
+});

--- a/langchain/src/callbacks/tests/tracer.test.ts
+++ b/langchain/src/callbacks/tests/tracer.test.ts
@@ -1,0 +1,213 @@
+import { test, expect, jest } from "@jest/globals";
+import {
+  BaseTracer,
+  LLMRun,
+  ChainRun,
+  ToolRun,
+  TracerSession,
+  TracerSessionCreate,
+} from "../tracers.js";
+
+const TEST_SESSION_ID = 2023;
+const _DATE = 1620000000000;
+
+Date.now = jest.fn(() => _DATE);
+
+class FakeTracer extends BaseTracer {
+  runs: (LLMRun | ChainRun | ToolRun)[] = [];
+
+  constructor() {
+    super();
+  }
+
+  protected persistRun(run: LLMRun | ChainRun | ToolRun): Promise<void> {
+    this.runs.push(run);
+    return Promise.resolve();
+  }
+
+  protected persistSession(
+    session: TracerSessionCreate
+  ): Promise<TracerSession> {
+    return Promise.resolve({
+      id: TEST_SESSION_ID,
+      ...session,
+    });
+  }
+
+  async loadSession(sessionName: string): Promise<TracerSession> {
+    return Promise.resolve({
+      id: TEST_SESSION_ID,
+      name: sessionName,
+      start_time: _DATE,
+    });
+  }
+
+  async loadDefaultSession(): Promise<TracerSession> {
+    return Promise.resolve({
+      id: TEST_SESSION_ID,
+      name: "default",
+      start_time: _DATE,
+    });
+  }
+}
+
+test("Test LLMRun", async () => {
+  const compareRun: LLMRun = {
+    start_time: _DATE,
+    end_time: _DATE,
+    execution_order: 1,
+    serialized: { name: "test" },
+    session_id: TEST_SESSION_ID,
+    prompts: ["test"],
+    type: "llm",
+    response: { generations: [] },
+  };
+  const tracer = new FakeTracer();
+  await tracer.newSession();
+  await tracer.handleLLMStart({ name: "test" }, ["test"]);
+  await tracer.handleLLMEnd({ generations: [] });
+  expect(tracer.runs.length).toBe(1);
+  const run = tracer.runs[0];
+  expect(run).toEqual(compareRun);
+});
+
+test("Test LLM Run no start", async () => {
+  const tracer = new FakeTracer();
+  await tracer.newSession();
+  await expect(tracer.handleLLMEnd({ generations: [] })).rejects.toThrow(
+    "No LLM run to end"
+  );
+});
+
+test("Test Chain Run", async () => {
+  const compareRun: ChainRun = {
+    start_time: _DATE,
+    end_time: _DATE,
+    execution_order: 1,
+    serialized: { name: "test" },
+    session_id: TEST_SESSION_ID,
+    inputs: { foo: "bar" },
+    outputs: { foo: "bar" },
+    type: "chain",
+    child_llm_runs: [],
+    child_chain_runs: [],
+    child_tool_runs: [],
+  };
+  const tracer = new FakeTracer();
+  await tracer.newSession();
+  await tracer.handleChainStart({ name: "test" }, { foo: "bar" });
+  await tracer.handleChainEnd({ foo: "bar" });
+  expect(tracer.runs.length).toBe(1);
+  const run = tracer.runs[0];
+  expect(run).toEqual(compareRun);
+});
+
+test("Test Tool Run", async () => {
+  const compareRun: ToolRun = {
+    start_time: _DATE,
+    end_time: _DATE,
+    execution_order: 1,
+    serialized: { name: "test" },
+    session_id: TEST_SESSION_ID,
+    tool_input: "test",
+    output: "output",
+    type: "tool",
+    action: JSON.stringify({ name: "test" }),
+    child_llm_runs: [],
+    child_chain_runs: [],
+    child_tool_runs: [],
+  };
+  const tracer = new FakeTracer();
+  await tracer.newSession();
+  await tracer.handleToolStart({ name: "test" }, "test");
+  await tracer.handleToolEnd("output");
+  expect(tracer.runs.length).toBe(1);
+  const run = tracer.runs[0];
+  expect(run).toEqual(compareRun);
+});
+
+test("Test nested runs", async () => {
+  const compareRun: ChainRun = {
+    child_chain_runs: [],
+    child_llm_runs: [
+      {
+        end_time: 1620000000000,
+        execution_order: 4,
+        prompts: ["test"],
+        response: {
+          generations: [[]],
+        },
+        serialized: {
+          name: "test2",
+        },
+        session_id: 2023,
+        start_time: 1620000000000,
+        type: "llm",
+      },
+    ],
+    child_tool_runs: [
+      {
+        action: '{"name":"test"}',
+        child_chain_runs: [],
+        child_llm_runs: [
+          {
+            end_time: 1620000000000,
+            execution_order: 3,
+            prompts: ["test"],
+            response: {
+              generations: [[]],
+            },
+            serialized: {
+              name: "test",
+            },
+            session_id: 2023,
+            start_time: 1620000000000,
+            type: "llm",
+          },
+        ],
+        child_tool_runs: [],
+        end_time: 1620000000000,
+        execution_order: 2,
+        output: "output",
+        serialized: {
+          name: "test",
+        },
+        session_id: 2023,
+        start_time: 1620000000000,
+        tool_input: "test",
+        type: "tool",
+      },
+    ],
+    end_time: 1620000000000,
+    execution_order: 1,
+    inputs: {
+      foo: "bar",
+    },
+    outputs: {
+      foo: "bar",
+    },
+    serialized: {
+      name: "test",
+    },
+    session_id: 2023,
+    start_time: 1620000000000,
+    type: "chain",
+  };
+
+  const tracer = new FakeTracer();
+  await tracer.newSession();
+  await tracer.handleChainStart({ name: "test" }, { foo: "bar" });
+  await tracer.handleToolStart({ name: "test" }, "test");
+  await tracer.handleLLMStart({ name: "test" }, ["test"]);
+  await tracer.handleLLMEnd({ generations: [[]] });
+  await tracer.handleToolEnd("output");
+  await tracer.handleLLMStart({ name: "test2" }, ["test"]);
+  await tracer.handleLLMEnd({ generations: [[]] });
+  await tracer.handleChainEnd({ foo: "bar" });
+  expect(tracer.runs.length).toBe(1);
+  expect(tracer.runs[0]).toEqual(compareRun);
+
+  await tracer.handleLLMStart({ name: "test" }, ["test"]);
+  await tracer.handleLLMEnd({ generations: [[]] });
+  expect(tracer.runs.length).toBe(2);
+});

--- a/langchain/src/callbacks/tracers.ts
+++ b/langchain/src/callbacks/tracers.ts
@@ -1,0 +1,361 @@
+import * as process from "process";
+import { ChainValues, LLMResult } from "../schema/index.js";
+import { BaseCallbackHandler } from "./base.js";
+
+export type RunType = "llm" | "chain" | "tool";
+
+export interface BaseTracerSession {
+  start_time: number;
+  name?: string;
+}
+
+export type TracerSessionCreate = BaseTracerSession;
+
+export interface TracerSession extends BaseTracerSession {
+  id: number;
+}
+
+export interface BaseRun {
+  id?: number;
+  start_time: number;
+  end_time: number;
+  execution_order: number;
+  serialized: { name: string };
+  session_id: number;
+  error?: string;
+  type: RunType;
+}
+
+export interface LLMRun extends BaseRun {
+  prompts: string[];
+  response?: LLMResult;
+}
+
+export interface ChainRun extends BaseRun {
+  inputs: ChainValues;
+  outputs?: ChainValues;
+  child_llm_runs: LLMRun[];
+  child_chain_runs: ChainRun[];
+  child_tool_runs: ToolRun[];
+}
+
+export interface ToolRun extends BaseRun {
+  tool_input: string;
+  output?: string;
+  action: string;
+  child_llm_runs: LLMRun[];
+  child_chain_runs: ChainRun[];
+  child_tool_runs: ToolRun[];
+}
+
+export abstract class BaseTracer extends BaseCallbackHandler {
+  protected session?: TracerSession;
+
+  protected stack: (LLMRun | ChainRun | ToolRun)[] = [];
+
+  protected executionOrder = 1;
+
+  protected constructor() {
+    super();
+    this.alwaysVerbose = true;
+  }
+
+  abstract loadSession(sessionName: string): Promise<TracerSession>;
+
+  abstract loadDefaultSession(): Promise<TracerSession>;
+
+  protected abstract persistRun(
+    run: LLMRun | ChainRun | ToolRun
+  ): Promise<void>;
+
+  protected abstract persistSession(
+    session: TracerSessionCreate
+  ): Promise<TracerSession>;
+
+  async newSession(sessionName?: string): Promise<TracerSession> {
+    const sessionCreate: TracerSessionCreate = {
+      start_time: Date.now(),
+      name: sessionName,
+    };
+    const session = await this.persistSession(sessionCreate);
+    this.session = session;
+    return session;
+  }
+
+  protected _addChildRun(
+    parentRun: ChainRun | ToolRun,
+    childRun: LLMRun | ChainRun | ToolRun
+  ) {
+    if (childRun.type === "llm") {
+      parentRun.child_llm_runs.push(childRun as LLMRun);
+    } else if (childRun.type === "chain") {
+      parentRun.child_chain_runs.push(childRun as ChainRun);
+    } else if (childRun.type === "tool") {
+      parentRun.child_tool_runs.push(childRun as ToolRun);
+    } else {
+      throw new Error("Invalid run type");
+    }
+  }
+
+  protected _startTrace(run: LLMRun | ChainRun | ToolRun) {
+    this.executionOrder += 1;
+
+    if (this.stack.length > 0) {
+      if (
+        !(
+          this.stack.at(-1)?.type === "tool" ||
+          this.stack.at(-1)?.type === "chain"
+        )
+      ) {
+        throw new Error("Nested run can only be logged for tool or chain");
+      }
+      const parentRun = this.stack.at(-1) as ChainRun | ToolRun;
+      this._addChildRun(parentRun, run);
+    }
+    this.stack.push(run);
+  }
+
+  protected async _endTrace() {
+    const run = this.stack.pop();
+    if (this.stack.length === 0 && run) {
+      this.executionOrder = 1;
+      await this.persistRun(run);
+    }
+  }
+
+  async handleLLMStart(
+    llm: { name: string },
+    prompts: string[],
+    _verbose?: boolean
+  ): Promise<void> {
+    if (this.session === undefined) {
+      this.session = await this.loadDefaultSession();
+    }
+    const run: LLMRun = {
+      start_time: Date.now(),
+      end_time: 0,
+      serialized: llm,
+      prompts,
+      session_id: this.session.id,
+      execution_order: this.executionOrder,
+      type: "llm",
+    };
+
+    this._startTrace(run);
+  }
+
+  async handleLLMEnd(output: LLMResult, _verbose?: boolean): Promise<void> {
+    if (this.stack.length === 0 || this.stack.at(-1)?.type !== "llm") {
+      throw new Error("No LLM run to end.");
+    }
+    const run = this.stack.at(-1) as LLMRun;
+    run.end_time = Date.now();
+    run.response = output;
+    await this._endTrace();
+  }
+
+  async handleLLMError(error: Error, _verbose?: boolean): Promise<void> {
+    if (this.stack.length === 0 || this.stack.at(-1)?.type !== "llm") {
+      throw new Error("No LLM run to end.");
+    }
+    const run = this.stack.at(-1) as LLMRun;
+    run.end_time = Date.now();
+    run.error = error.message;
+    await this._endTrace();
+  }
+
+  async handleChainStart(
+    chain: { name: string },
+    inputs: ChainValues,
+    _verbose?: boolean
+  ): Promise<void> {
+    if (this.session === undefined) {
+      this.session = await this.loadDefaultSession();
+    }
+    const run: ChainRun = {
+      start_time: Date.now(),
+      end_time: 0,
+      serialized: chain,
+      inputs,
+      session_id: this.session.id,
+      execution_order: this.executionOrder,
+      type: "chain",
+      child_llm_runs: [],
+      child_chain_runs: [],
+      child_tool_runs: [],
+    };
+
+    this._startTrace(run);
+  }
+
+  async handleChainEnd(
+    outputs: ChainValues,
+    _verbose?: boolean
+  ): Promise<void> {
+    if (this.stack.length === 0 || this.stack.at(-1)?.type !== "chain") {
+      throw new Error("No chain run to end.");
+    }
+    const run = this.stack.at(-1) as ChainRun;
+    run.end_time = Date.now();
+    run.outputs = outputs;
+    await this._endTrace();
+  }
+
+  async handleChainError(error: Error, _verbose?: boolean): Promise<void> {
+    if (this.stack.length === 0 || this.stack.at(-1)?.type !== "chain") {
+      throw new Error("No chain run to end.");
+    }
+    const run = this.stack.at(-1) as ChainRun;
+    run.end_time = Date.now();
+    run.error = error.message;
+    await this._endTrace();
+  }
+
+  async handleToolStart(
+    tool: { name: string },
+    input: string,
+    _verbose?: boolean
+  ): Promise<void> {
+    if (this.session === undefined) {
+      this.session = await this.loadDefaultSession();
+    }
+    const run: ToolRun = {
+      start_time: Date.now(),
+      end_time: 0,
+      serialized: tool,
+      tool_input: input,
+      session_id: this.session.id,
+      execution_order: this.executionOrder,
+      type: "tool",
+      action: JSON.stringify(tool), // TODO: this is duplicate info, not needed
+      child_llm_runs: [],
+      child_chain_runs: [],
+      child_tool_runs: [],
+    };
+
+    this._startTrace(run);
+  }
+
+  async handleToolEnd(output: string, _verbose?: boolean): Promise<void> {
+    if (this.stack.length === 0 || this.stack.at(-1)?.type !== "tool") {
+      throw new Error("No tool run to end");
+    }
+    const run = this.stack.at(-1) as ToolRun;
+    run.end_time = Date.now();
+    run.output = output;
+    await this._endTrace();
+  }
+
+  async handleToolError(error: Error, _verbose?: boolean): Promise<void> {
+    if (this.stack.length === 0 || this.stack.at(-1)?.type !== "tool") {
+      throw new Error("No tool run to end.");
+    }
+    const run = this.stack.at(-1) as ToolRun;
+    run.end_time = Date.now();
+    run.error = error.message;
+    await this._endTrace();
+  }
+}
+
+export class LangChainTracer extends BaseTracer {
+  protected endpoint =
+    process.env.LANGCHAIN_ENDPOINT || "http://localhost:8000";
+
+  protected headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  constructor() {
+    super();
+    if (process.env.LANGCHAIN_API_KEY) {
+      this.headers["x-api-key"] = process.env.LANGCHAIN_API_KEY;
+    }
+  }
+
+  protected async persistRun(run: LLMRun | ChainRun | ToolRun): Promise<void> {
+    let endpoint;
+    if (run.type === "llm") {
+      endpoint = `${this.endpoint}/llm-runs`;
+    } else if (run.type === "chain") {
+      endpoint = `${this.endpoint}/chain-runs`;
+    } else {
+      endpoint = `${this.endpoint}/tool-runs`;
+    }
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify(run),
+    });
+    if (!response.ok) {
+      console.error(
+        `Failed to persist run: ${response.status} ${response.statusText}`
+      );
+    }
+  }
+
+  protected async persistSession(
+    sessionCreate: TracerSessionCreate
+  ): Promise<TracerSession> {
+    const endpoint = `${this.endpoint}/sessions`;
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: this.headers,
+      body: JSON.stringify(sessionCreate),
+    });
+    if (!response.ok) {
+      console.error(
+        `Failed to persist session: ${response.status} ${response.statusText}, using default session.`
+      );
+      return {
+        id: 1,
+        ...sessionCreate,
+      };
+    }
+    return {
+      id: (await response.json()).id,
+      ...sessionCreate,
+    };
+  }
+
+  async loadSession(sessionName: string): Promise<TracerSession> {
+    const endpoint = `${this.endpoint}/sessions?name=${sessionName}`;
+    return this._handleSessionResponse(endpoint);
+  }
+
+  async loadDefaultSession(): Promise<TracerSession> {
+    const endpoint = `${this.endpoint}/sessions?name=default`;
+    return this._handleSessionResponse(endpoint);
+  }
+
+  private async _handleSessionResponse(endpoint: string) {
+    const response = await fetch(endpoint, {
+      method: "GET",
+      headers: this.headers,
+    });
+    let tracerSession: TracerSession;
+    if (!response.ok) {
+      console.error(
+        `Failed to load session: ${response.status} ${response.statusText}`
+      );
+      tracerSession = {
+        id: 1,
+        start_time: Date.now(),
+      };
+      this.session = tracerSession;
+      return tracerSession;
+    }
+    const resp = (await response.json()) as TracerSession[];
+    if (resp.length === 0) {
+      tracerSession = {
+        id: 1,
+        start_time: Date.now(),
+      };
+      this.session = tracerSession;
+      return tracerSession;
+    }
+    [tracerSession] = resp;
+    this.session = tracerSession;
+    return tracerSession;
+  }
+}

--- a/langchain/src/callbacks/utils.ts
+++ b/langchain/src/callbacks/utils.ts
@@ -1,0 +1,49 @@
+import * as process from "process";
+import { LangChainTracer } from "./tracers.js";
+import { CallbackManager, ConsoleCallbackHandler } from "./base.js";
+
+export class SingletonCallbackManager extends CallbackManager {
+  private static instance: SingletonCallbackManager;
+
+  private constructor() {
+    super();
+  }
+
+  static getInstance(): SingletonCallbackManager {
+    if (!SingletonCallbackManager.instance) {
+      SingletonCallbackManager.instance = new SingletonCallbackManager();
+      SingletonCallbackManager.instance.addHandler(
+        new ConsoleCallbackHandler()
+      );
+      if (process.env.LANGCHAIN_HANDLER === "langchain") {
+        SingletonCallbackManager.instance.addHandler(new LangChainTracer());
+      }
+    }
+
+    return SingletonCallbackManager.instance;
+  }
+}
+
+export function getCallbackManager(): CallbackManager {
+  return SingletonCallbackManager.getInstance();
+}
+
+export interface TracerOptions {
+  sessionName?: string;
+}
+
+export async function setTracerSession(
+  options?: TracerOptions,
+  callbackManager: CallbackManager = getCallbackManager()
+) {
+  for (const handler of callbackManager.handlers) {
+    if (handler instanceof LangChainTracer) {
+      const sessionName = options?.sessionName;
+      if (sessionName) {
+        await handler.loadSession(sessionName);
+      } else {
+        await handler.loadDefaultSession();
+      }
+    }
+  }
+}

--- a/langchain/src/chains/analyze_documents_chain.ts
+++ b/langchain/src/chains/analyze_documents_chain.ts
@@ -1,4 +1,4 @@
-import { BaseChain, ChainValues, SerializedBaseChain } from "./index.js";
+import { BaseChain, SerializedBaseChain } from "./index.js";
 
 import {
   TextSplitter,
@@ -6,6 +6,7 @@ import {
 } from "../text_splitter.js";
 
 import { resolveConfigFromFile } from "../util/index.js";
+import { ChainValues } from "../schema/index.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type LoadValues = Record<string, any>;

--- a/langchain/src/chains/chat_vector_db_chain.ts
+++ b/langchain/src/chains/chat_vector_db_chain.ts
@@ -1,6 +1,5 @@
 import {
   BaseChain,
-  ChainValues,
   LLMChain,
   loadQAStuffChain,
   SerializedBaseChain,
@@ -13,6 +12,7 @@ import { BaseLLM } from "../llms/index.js";
 import { VectorStore } from "../vectorstores/base.js";
 
 import { resolveConfigFromFile } from "../util/index.js";
+import { ChainValues } from "../schema/index.js";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type LoadValues = Record<string, any>;
 

--- a/langchain/src/chains/combine_docs_chain.ts
+++ b/langchain/src/chains/combine_docs_chain.ts
@@ -1,6 +1,5 @@
 import {
   BaseChain,
-  ChainValues,
   LLMChain,
   SerializedLLMChain,
   SerializedBaseChain,
@@ -9,6 +8,7 @@ import {
 import { Document } from "../document.js";
 
 import { resolveConfigFromFile } from "../util/index.js";
+import { ChainValues } from "../schema/index.js";
 
 export interface StuffDocumentsChainInput {
   /** LLM Wrapper to use after formatting documents */

--- a/langchain/src/chains/conversation.ts
+++ b/langchain/src/chains/conversation.ts
@@ -1,8 +1,8 @@
 import { LLMChain } from "./llm_chain.js";
-import { BaseLanguageModel } from "../schema/index.js";
 import { BasePromptTemplate, PromptTemplate } from "../prompts/index.js";
 
 import { BaseMemory, BufferMemory } from "../memory/index.js";
+import { BaseLanguageModel } from "../base_language/index.js";
 
 const defaultTemplate = `The following is a friendly conversation between a human and an AI. The AI is talkative and provides lots of specific details from its context. If the AI does not know the answer to a question, it truthfully says it does not know.
 

--- a/langchain/src/chains/index.ts
+++ b/langchain/src/chains/index.ts
@@ -1,9 +1,4 @@
-export {
-  BaseChain,
-  ChainValues,
-  ChainInputs,
-  SerializedBaseChain,
-} from "./base.js";
+export { BaseChain, ChainInputs, SerializedBaseChain } from "./base.js";
 export {
   SerializedLLMChain,
   LLMChain,

--- a/langchain/src/chains/llm_chain.ts
+++ b/langchain/src/chains/llm_chain.ts
@@ -1,7 +1,6 @@
-import { BaseChain, ChainInputs, ChainValues } from "./index.js";
+import { BaseChain, ChainInputs } from "./index.js";
 
 import { BaseLLM, SerializedLLM } from "../llms/index.js";
-import { BaseLanguageModel } from "../schema/index.js";
 
 import { BaseMemory, BufferMemory } from "../memory/index.js";
 import {
@@ -11,6 +10,8 @@ import {
 } from "../prompts/index.js";
 
 import { resolveConfigFromFile } from "../util/index.js";
+import { BaseLanguageModel } from "../base_language/index.js";
+import { ChainValues } from "../schema/index.js";
 
 export interface LLMChainInput extends ChainInputs {
   /** Prompt object to use */

--- a/langchain/src/chains/prompt_selector.ts
+++ b/langchain/src/chains/prompt_selector.ts
@@ -1,7 +1,7 @@
 import { BaseChatModel } from "../chat_models/base.js";
 import { BaseLLM } from "../llms/base.js";
 import { BasePromptTemplate } from "../prompts/base.js";
-import { BaseLanguageModel } from "../schema/index.js";
+import { BaseLanguageModel } from "../base_language/index.js";
 
 export abstract class BasePromptSelector {
   abstract getPrompt(llm: BaseLanguageModel): BasePromptTemplate;

--- a/langchain/src/chains/sql_db/sql_db_chain.ts
+++ b/langchain/src/chains/sql_db/sql_db_chain.ts
@@ -1,11 +1,12 @@
 import { DEFAULT_SQL_DATABASE_PROMPT } from "./sql_db_prompt.js";
-import { BaseChain, ChainValues } from "../base.js";
+import { BaseChain } from "../base.js";
 import { BaseMemory } from "../../memory/index.js";
 import { BaseLLM, SerializedLLM } from "../../llms/index.js";
 import { LLMChain } from "../llm_chain.js";
 import { SqlDatabase } from "../../sql_db.js";
 import { resolveConfigFromFile } from "../../util/index.js";
 import { SerializedSqlDatabase } from "../../util/sql_utils.js";
+import { ChainValues } from "../../schema/index.js";
 
 export type SerializedSqlDatabaseChain = {
   sql_database: SerializedSqlDatabase;

--- a/langchain/src/chains/vector_db_qa.ts
+++ b/langchain/src/chains/vector_db_qa.ts
@@ -1,14 +1,10 @@
-import {
-  BaseChain,
-  ChainValues,
-  SerializedBaseChain,
-  loadQAStuffChain,
-} from "./index.js";
+import { BaseChain, SerializedBaseChain, loadQAStuffChain } from "./index.js";
 
 import { VectorStore } from "../vectorstores/base.js";
 import { BaseLLM } from "../llms/index.js";
 
 import { resolveConfigFromFile } from "../util/index.js";
+import { ChainValues } from "../schema/index.js";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type LoadValues = Record<string, any>;
 

--- a/langchain/src/chat_models/base.ts
+++ b/langchain/src/chat_models/base.ts
@@ -3,6 +3,7 @@ import {
   AIChatMessage,
   BaseChatMessage,
   BaseLanguageModel,
+  BaseLanguageModelParams,
   BasePromptValue,
   ChatGeneration,
   ChatResult,
@@ -22,26 +23,22 @@ const getCallbackManager = (): LLMCallbackManager => ({
   },
 });
 
-const getVerbosity = () => true;
-
 export type SerializedChatModel = {
   _model: string;
   _type: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } & Record<string, any>;
 
+export interface BaseChatModelParams extends BaseLanguageModelParams {
+  callbackManager?: LLMCallbackManager;
+}
+
 export abstract class BaseChatModel extends BaseLanguageModel {
   callbackManager: LLMCallbackManager;
 
-  verbose: boolean;
-
-  protected constructor(
-    callbackManager?: LLMCallbackManager,
-    verbose?: boolean
-  ) {
-    super();
+  protected constructor({ callbackManager, ...rest }: BaseChatModelParams) {
+    super(rest);
     this.callbackManager = callbackManager ?? getCallbackManager();
-    this.verbose = verbose ?? getVerbosity();
   }
 
   async generate(
@@ -131,13 +128,6 @@ export abstract class BaseChatModel extends BaseLanguageModel {
 }
 
 export abstract class SimpleChatModel extends BaseChatModel {
-  protected constructor(
-    callbackManager?: LLMCallbackManager,
-    verbose?: boolean
-  ) {
-    super(callbackManager, verbose);
-  }
-
   abstract _call(messages: BaseChatMessage[], stop?: string[]): Promise<string>;
 
   async _generate(

--- a/langchain/src/chat_models/base.ts
+++ b/langchain/src/chat_models/base.ts
@@ -2,26 +2,16 @@ import GPT3Tokenizer from "gpt3-tokenizer";
 import {
   AIChatMessage,
   BaseChatMessage,
-  BaseLanguageModel,
-  BaseLanguageModelParams,
   BasePromptValue,
   ChatGeneration,
   ChatResult,
-  LLMCallbackManager,
   LLMResult,
 } from "../schema/index.js";
-
-const getCallbackManager = (): LLMCallbackManager => ({
-  handleStart: (..._args) => {
-    // console.log(args);
-  },
-  handleEnd: (..._args) => {
-    // console.log(args);
-  },
-  handleError: (..._args) => {
-    // console.log(args);
-  },
-});
+import {
+  BaseLanguageModel,
+  BaseLanguageModelParams,
+} from "../base_language/index.js";
+import { getBufferString } from "../memory/base.js";
 
 export type SerializedChatModel = {
   _model: string;
@@ -29,16 +19,11 @@ export type SerializedChatModel = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } & Record<string, any>;
 
-export interface BaseChatModelParams extends BaseLanguageModelParams {
-  callbackManager?: LLMCallbackManager;
-}
+export type BaseChatModelParams = BaseLanguageModelParams;
 
 export abstract class BaseChatModel extends BaseLanguageModel {
-  callbackManager: LLMCallbackManager;
-
-  protected constructor({ callbackManager, ...rest }: BaseChatModelParams) {
+  protected constructor({ ...rest }: BaseChatModelParams) {
     super(rest);
-    this.callbackManager = callbackManager ?? getCallbackManager();
   }
 
   async generate(
@@ -46,13 +31,28 @@ export abstract class BaseChatModel extends BaseLanguageModel {
     stop?: string[]
   ): Promise<LLMResult> {
     const generations: ChatGeneration[][] = [];
-    for (const message of messages) {
-      const result = await this._generate(message, stop);
-      generations.push(result.generations);
+    const messageStrings: string[] = messages.map((messageList) =>
+      getBufferString(messageList)
+    );
+    await this.callbackManager.handleLLMStart(
+      { name: this._llmType() },
+      messageStrings,
+      this.verbose
+    );
+    try {
+      for (const message of messages) {
+        const result = await this._generate(message, stop);
+        generations.push(result.generations);
+      }
+    } catch (err) {
+      await this.callbackManager.handleLLMError(err, this.verbose);
+      throw err;
     }
-    return {
+    const output: LLMResult = {
       generations,
     };
+    await this.callbackManager.handleLLMEnd(output, this.verbose);
+    return output;
   }
 
   /**
@@ -114,8 +114,9 @@ export abstract class BaseChatModel extends BaseLanguageModel {
     messages: BaseChatMessage[],
     stop?: string[]
   ): Promise<BaseChatMessage> {
-    const { generations } = await this._generate(messages, stop);
-    return generations[0].message;
+    const result = await this.generate([messages], stop);
+    const generations = result.generations as ChatGeneration[][];
+    return generations[0][0].message;
   }
 
   async callPrompt(

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -288,7 +288,8 @@ export class ChatOpenAI extends BaseChatModel implements OpenAIInput {
               if (part != null) {
                 innerCompletion += part.delta?.content ?? "";
                 role = part.delta?.role ?? role;
-                this.callbackManager.handleNewToken?.(
+                // eslint-disable-next-line no-void
+                void this.callbackManager.handleLLMNewToken(
                   part.delta?.content ?? "",
                   this.verbose
                 );

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -9,7 +9,7 @@ import type { IncomingMessage } from "http";
 import { createParser } from "eventsource-parser";
 import { backOff } from "exponential-backoff";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
-import { BaseChatModel } from "./base.js";
+import { BaseChatModel, BaseChatModelParams } from "./base.js";
 import {
   AIChatMessage,
   BaseChatMessage,
@@ -17,7 +17,6 @@ import {
   ChatMessage,
   ChatResult,
   HumanChatMessage,
-  LLMCallbackManager,
   MessageType,
   SystemChatMessage,
 } from "../schema/index.js";
@@ -155,16 +154,15 @@ export class ChatOpenAI extends BaseChatModel implements OpenAIInput {
   private clientConfig: ConfigurationParameters;
 
   constructor(
-    fields?: Partial<OpenAIInput> & {
-      callbackManager?: LLMCallbackManager;
-      concurrency?: number;
-      cache?: boolean;
-      verbose?: boolean;
-      openAIApiKey?: string;
-    },
+    fields?: Partial<OpenAIInput> &
+      BaseChatModelParams & {
+        concurrency?: number;
+        cache?: boolean;
+        openAIApiKey?: string;
+      },
     configuration?: ConfigurationParameters
   ) {
-    super(fields?.callbackManager, fields?.verbose);
+    super(fields ?? {});
 
     const apiKey = fields?.openAIApiKey ?? process.env.OPENAI_API_KEY;
     if (!apiKey) {

--- a/langchain/src/chat_models/tests/chatopenai.int.test.ts
+++ b/langchain/src/chat_models/tests/chatopenai.int.test.ts
@@ -9,6 +9,7 @@ import {
   SystemMessagePromptTemplate,
 } from "../../prompts/index.js";
 import { LLMChain } from "../../chains/index.js";
+import { BaseCallbackHandler, CallbackManager } from "../../callbacks/index.js";
 
 test("Test ChatOpenAI", async () => {
   const chat = new ChatOpenAI({ modelName: "gpt-3.5-turbo", maxTokens: 10 });
@@ -44,25 +45,34 @@ test("Test ChatOpenAI Generate", async () => {
 });
 
 test("Test ChatOpenAI in streaming mode", async () => {
-  let nrNewTokens = 0;
-  let streamedCompletion = "";
+  class StreamCallbackHandler extends BaseCallbackHandler {
+    nrNewTokens = 0;
+
+    alwaysVerbose = true;
+
+    streamedCompletion = "";
+
+    async handleLLMNewToken(token: string) {
+      this.nrNewTokens += 1;
+      this.streamedCompletion += token;
+    }
+  }
+
+  const streamCallbackHandler = new StreamCallbackHandler();
+  const callbackManager = new CallbackManager();
+  callbackManager.addHandler(streamCallbackHandler);
 
   const model = new ChatOpenAI({
     modelName: "gpt-3.5-turbo",
     streaming: true,
-    callbackManager: {
-      handleNewToken(token) {
-        nrNewTokens += 1;
-        streamedCompletion += token;
-      },
-    },
+    callbackManager,
   });
   const message = new HumanChatMessage("Hello!");
   const res = await model.call([message]);
   console.log({ res });
 
-  expect(nrNewTokens > 0).toBe(true);
-  expect(res.text).toBe(streamedCompletion);
+  expect(streamCallbackHandler.nrNewTokens > 0).toBe(true);
+  expect(res.text).toBe(streamCallbackHandler.streamedCompletion);
 });
 
 test("Test ChatOpenAI prompt value", async () => {

--- a/langchain/src/llms/base.ts
+++ b/langchain/src/llms/base.ts
@@ -4,6 +4,7 @@ import PQueue from "p-queue";
 import { BaseCache, InMemoryCache } from "../cache.js";
 import {
   BaseLanguageModel,
+  BaseLanguageModelParams,
   BasePromptValue,
   LLMCallbackManager,
   LLMResult,
@@ -21,8 +22,6 @@ const getCallbackManager = (): LLMCallbackManager => ({
   },
 });
 
-const getVerbosity = () => true;
-
 const GLOBAL_CACHE: BaseCache = new InMemoryCache();
 
 export type SerializedLLM = {
@@ -30,6 +29,12 @@ export type SerializedLLM = {
   _type: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } & Record<string, any>;
+
+export interface BaseLLMParams extends BaseLanguageModelParams {
+  callbackManager?: LLMCallbackManager;
+  concurrency?: number;
+  cache?: BaseCache | boolean;
+}
 
 /**
  * LLM Wrapper. Provides an {@link call} (an {@link generate}) function that takes in a prompt (or prompts) and returns a string.
@@ -52,20 +57,10 @@ export abstract class BaseLLM extends BaseLanguageModel {
 
   protected queue: PQueue;
 
-  /**
-   * Whether to print out response text.
-   */
-  verbose?: boolean = false;
+  constructor({ callbackManager, concurrency, cache, ...rest }: BaseLLMParams) {
+    super(rest);
 
-  constructor(
-    callbackManager?: LLMCallbackManager,
-    verbose?: boolean,
-    concurrency?: number,
-    cache?: BaseCache | boolean
-  ) {
-    super();
     this.callbackManager = callbackManager ?? getCallbackManager();
-    this.verbose = verbose ?? getVerbosity();
     if (cache instanceof BaseCache) {
       this.cache = cache;
     } else if (cache) {

--- a/langchain/src/llms/cohere.ts
+++ b/langchain/src/llms/cohere.ts
@@ -1,6 +1,4 @@
-import { LLM } from "./base.js";
-import { LLMCallbackManager } from "../schema/index.js";
-import { BaseCache } from "../cache.js";
+import { LLM, BaseLLMParams } from "./base.js";
 
 interface CohereInput {
   /** Sampling temperature to use */
@@ -24,20 +22,8 @@ export class Cohere extends LLM implements CohereInput {
 
   apiKey: string;
 
-  constructor(
-    fields?: Partial<CohereInput> & {
-      callbackManager?: LLMCallbackManager;
-      verbose?: boolean;
-      concurrency?: number;
-      cache?: BaseCache | boolean;
-    }
-  ) {
-    super(
-      fields?.callbackManager,
-      fields?.verbose,
-      fields?.concurrency,
-      fields?.cache
-    );
+  constructor(fields?: Partial<CohereInput> & BaseLLMParams) {
+    super(fields ?? {});
 
     const apiKey = process.env.COHERE_API_KEY;
 

--- a/langchain/src/llms/hf.ts
+++ b/langchain/src/llms/hf.ts
@@ -1,6 +1,4 @@
-import { LLM } from "./base.js";
-import { LLMCallbackManager } from "../schema/index.js";
-import { BaseCache } from "../cache.js";
+import { LLM, BaseLLMParams } from "./base.js";
 
 interface HFInput {
   /** Model to use */
@@ -37,20 +35,9 @@ export class HuggingFaceInference extends LLM implements HFInput {
 
   frequencyPenalty: number | undefined = undefined;
 
-  constructor(
-    fields?: Partial<HFInput> & {
-      callbackManager?: LLMCallbackManager;
-      verbose?: boolean;
-      concurrency?: number;
-      cache?: BaseCache | boolean;
-    }
-  ) {
-    super(
-      fields?.callbackManager,
-      fields?.verbose,
-      fields?.concurrency,
-      fields?.cache
-    );
+  constructor(fields?: Partial<HFInput> & BaseLLMParams) {
+    super(fields ?? {});
+
     this.model = fields?.model ?? this.model;
     this.temperature = fields?.temperature ?? this.temperature;
     this.maxTokens = fields?.maxTokens ?? this.maxTokens;

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -9,9 +9,7 @@ import type { IncomingMessage } from "http";
 import { createParser } from "eventsource-parser";
 import { backOff } from "exponential-backoff";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
-import { LLM } from "./base.js";
-import { LLMCallbackManager } from "../schema/index.js";
-import { BaseCache } from "../cache.js";
+import { BaseLLMParams, LLM } from "./base.js";
 
 interface ModelParams {
   /** Sampling temperature to use, between 0 and 2, defaults to 1 */
@@ -112,21 +110,13 @@ export class OpenAIChat extends LLM implements OpenAIInput {
   private clientConfig: ConfigurationParameters;
 
   constructor(
-    fields?: Partial<OpenAIInput> & {
-      callbackManager?: LLMCallbackManager;
-      concurrency?: number;
-      cache?: BaseCache | boolean;
-      verbose?: boolean;
-      openAIApiKey?: string;
-    },
+    fields?: Partial<OpenAIInput> &
+      BaseLLMParams & {
+        openAIApiKey?: string;
+      },
     configuration?: ConfigurationParameters
   ) {
-    super(
-      fields?.callbackManager,
-      fields?.verbose,
-      fields?.concurrency,
-      fields?.cache
-    );
+    super(fields ?? {});
 
     const apiKey = fields?.openAIApiKey ?? process.env.OPENAI_API_KEY;
     if (!apiKey) {

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -246,8 +246,8 @@ export class OpenAIChat extends LLM implements OpenAIInput {
               const part = response.choices[0];
               if (part != null) {
                 innerCompletion += part.delta?.content ?? "";
-
-                this.callbackManager.handleNewToken?.(
+                // eslint-disable-next-line no-void
+                void this.callbackManager.handleLLMNewToken(
                   part.delta?.content ?? "",
                   this.verbose
                 );

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -12,11 +12,10 @@ import {
 } from "openai";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
 import { chunkArray } from "../util/index.js";
-import { BaseLLM } from "./base.js";
+import { BaseLLM, BaseLLMParams } from "./base.js";
 import { calculateMaxTokens } from "./calculateMaxTokens.js";
 import { OpenAIChat } from "./openai-chat.js";
-import { LLMCallbackManager, LLMResult } from "../schema/index.js";
-import { BaseCache } from "../cache.js";
+import { LLMResult } from "../schema/index.js";
 
 interface ModelParams {
   /** Sampling temperature to use */
@@ -136,25 +135,17 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
   private clientConfig: ConfigurationParameters;
 
   constructor(
-    fields?: Partial<OpenAIInput> & {
-      callbackManager?: LLMCallbackManager;
-      concurrency?: number;
-      cache?: BaseCache | boolean;
-      verbose?: boolean;
-      openAIApiKey?: string;
-    },
+    fields?: Partial<OpenAIInput> &
+      BaseLLMParams & {
+        openAIApiKey?: string;
+      },
     configuration?: ConfigurationParameters
   ) {
     if (fields?.modelName?.startsWith("gpt-3.5-turbo")) {
       // eslint-disable-next-line no-constructor-return, @typescript-eslint/no-explicit-any
       return new OpenAIChat(fields, configuration) as any as OpenAI;
     }
-    super(
-      fields?.callbackManager,
-      fields?.verbose,
-      fields?.concurrency,
-      fields?.cache
-    );
+    super(fields ?? {});
 
     const apiKey = fields?.openAIApiKey ?? process.env.OPENAI_API_KEY;
     if (!apiKey) {

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -283,8 +283,8 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
                     choice.text = (choice.text ?? "") + (part.text ?? "");
                     choice.finish_reason = part.finish_reason;
                     choice.logprobs = part.logprobs;
-
-                    this.callbackManager.handleNewToken?.(
+                    // eslint-disable-next-line no-void
+                    void this.callbackManager.handleLLMNewToken(
                       part.text ?? "",
                       this.verbose
                     );

--- a/langchain/src/llms/tests/openai.int.test.ts
+++ b/langchain/src/llms/tests/openai.int.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@jest/globals";
 import { OpenAIChat } from "../openai-chat.js";
 import { OpenAI } from "../openai.js";
 import { StringPromptValue } from "../../prompts/index.js";
+import { BaseCallbackHandler, CallbackManager } from "../../callbacks/index.js";
 
 test("Test OpenAI", async () => {
   const model = new OpenAI({ maxTokens: 5, modelName: "text-ada-001" });
@@ -24,25 +25,33 @@ test("Test OpenAI with chat model returns OpenAIChat", async () => {
 });
 
 test("Test OpenAI in streaming mode", async () => {
-  let nrNewTokens = 0;
-  let streamedCompletion = "";
+  class StreamCallbackHandler extends BaseCallbackHandler {
+    nrNewTokens = 0;
 
+    alwaysVerbose = true;
+
+    streamedCompletion = "";
+
+    async handleLLMNewToken(token: string) {
+      this.nrNewTokens += 1;
+      this.streamedCompletion += token;
+    }
+  }
+
+  const streamCallbackHandler = new StreamCallbackHandler();
+  const callbackManager = new CallbackManager();
+  callbackManager.addHandler(streamCallbackHandler);
   const model = new OpenAI({
     maxTokens: 5,
     modelName: "text-ada-001",
     streaming: true,
-    callbackManager: {
-      handleNewToken(token) {
-        nrNewTokens += 1;
-        streamedCompletion += token;
-      },
-    },
+    callbackManager,
   });
   const res = await model.call("Print hello world");
   console.log({ res });
 
-  expect(nrNewTokens > 0).toBe(true);
-  expect(res).toBe(streamedCompletion);
+  expect(streamCallbackHandler.nrNewTokens > 0).toBe(true);
+  expect(res).toBe(streamCallbackHandler.streamedCompletion);
 });
 
 test("Test OpenAI prompt value", async () => {

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -104,10 +104,30 @@ export abstract class BasePromptValue {
   abstract toChatMessages(): BaseChatMessage[];
 }
 
+const getVerbosity = () => true;
+
+/**
+ * Base interface for language model parameters.
+ * A subclass of {@link BaseLanguageModel} should have a constructor that
+ * takes in a parameter that extends this interface.
+ */
+export interface BaseLanguageModelParams {
+  verbose?: boolean;
+}
+
 /**
  * Base class for language models.
  */
-export abstract class BaseLanguageModel {
+export abstract class BaseLanguageModel implements BaseLanguageModelParams {
+  /**
+   * Whether to print out response text.
+   */
+  verbose: boolean;
+
+  constructor(params: BaseLanguageModelParams) {
+    this.verbose = params.verbose ?? getVerbosity();
+  }
+
   abstract generatePrompt(
     promptValues: BasePromptValue[],
     stop?: string[]

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -1,14 +1,3 @@
-export type LLMCallbackManager = {
-  handleStart?: (
-    llm: { name: string },
-    prompts: string[],
-    verbose?: boolean
-  ) => void;
-  handleNewToken?: (token: string, verbose?: boolean) => void;
-  handleError?: (err: string, verbose?: boolean) => void;
-  handleEnd?: (output: LLMResult, verbose?: boolean) => void;
-};
-
 /**
  * Output of a single generation.
  */
@@ -104,36 +93,20 @@ export abstract class BasePromptValue {
   abstract toChatMessages(): BaseChatMessage[];
 }
 
-const getVerbosity = () => true;
+export type AgentAction = {
+  tool: string;
+  toolInput: string;
+  log: string;
+};
+export type AgentFinish = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  returnValues: Record<string, any>;
+  log: string;
+};
+export type AgentStep = {
+  action: AgentAction;
+  observation: string;
+};
 
-/**
- * Base interface for language model parameters.
- * A subclass of {@link BaseLanguageModel} should have a constructor that
- * takes in a parameter that extends this interface.
- */
-export interface BaseLanguageModelParams {
-  verbose?: boolean;
-}
-
-/**
- * Base class for language models.
- */
-export abstract class BaseLanguageModel implements BaseLanguageModelParams {
-  /**
-   * Whether to print out response text.
-   */
-  verbose: boolean;
-
-  constructor(params: BaseLanguageModelParams) {
-    this.verbose = params.verbose ?? getVerbosity();
-  }
-
-  abstract generatePrompt(
-    promptValues: BasePromptValue[],
-    stop?: string[]
-  ): Promise<LLMResult>;
-
-  abstract _modelType(): string;
-
-  abstract getNumTokens(text: string): number;
-}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ChainValues = Record<string, any>;

--- a/langchain/src/tests/cache.test.ts
+++ b/langchain/src/tests/cache.test.ts
@@ -22,6 +22,7 @@ test("RedisCache", async () => {
       return null;
     }),
   };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const cache = new RedisCache(redis as any);
   expect(await cache.lookup("foo", "bar")).toEqual([{ text: "baz" }]);
 });

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -51,6 +51,7 @@
       "src/chat_models/index.ts",
       "src/schema/index.ts",
       "src/sql_db.ts",
+      "src/callbacks/index.ts",
       "src/index.ts"
     ],
     "excludePrivate": true,


### PR DESCRIPTION
cc @agola11 this is laying the groundwork for moving common functionality into BaseLanguageModel (such as callback manager) I moved verbose flag in this PR as an example 