### PR TITLE
Create reusable AsyncCaller class for calling "expensive" resources like APIs or LLMs

### DIFF
--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -6,7 +6,7 @@
       "ESNext",
       "DOM"
     ],
-    "target": "ES2020",
+    "target": "ES2021",
     "module": "nodenext",
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "lib": [
       "ES2021",
+      "ES2022.Object",
       "DOM"
     ],
     "target": "ES2021",

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "lib": [
-      "ESNext",
+      "ES2021",
       "DOM"
     ],
     "target": "ES2021",

--- a/langchain/src/embeddings/base.ts
+++ b/langchain/src/embeddings/base.ts
@@ -1,4 +1,18 @@
+import { AsyncCaller, AsyncCallerParams } from "../util/async_caller.js";
+
+export type EmbeddingsParams = AsyncCallerParams;
+
 export abstract class Embeddings {
+  /**
+   * The async caller should be used by subclasses to make any async calls,
+   * which will thus benefit from the concurrency and retry logic.
+   */
+  protected caller: AsyncCaller;
+
+  constructor(params: EmbeddingsParams) {
+    this.caller = new AsyncCaller(params ?? {});
+  }
+
   abstract embedDocuments(documents: string[]): Promise<number[][]>;
 
   abstract embedQuery(document: string): Promise<number[]>;

--- a/langchain/src/embeddings/fake.ts
+++ b/langchain/src/embeddings/fake.ts
@@ -1,6 +1,10 @@
-import { Embeddings } from "./base.js";
+import { Embeddings, EmbeddingsParams } from "./base.js";
 
 export class FakeEmbeddings extends Embeddings {
+  constructor(params?: EmbeddingsParams) {
+    super(params ?? {});
+  }
+
   embedDocuments(documents: string[]): Promise<number[][]> {
     return Promise.resolve(documents.map(() => [0.1, 0.2, 0.3, 0.4]));
   }

--- a/langchain/src/util/async_caller.ts
+++ b/langchain/src/util/async_caller.ts
@@ -1,0 +1,51 @@
+import { backOff } from "exponential-backoff";
+import PQueue from "p-queue";
+
+export interface AsyncCallerParams {
+  maxConcurrency?: number;
+  maxRetries?: number;
+}
+
+/**
+ * A class that can be used to make async calls with concurrency and retry logic.
+ *
+ * This is useful for making calls to any kind of "expensive" external resource,
+ * be it because it's rate-limited, subject to network issues, etc.
+ *
+ * Concurrent calls are limited by the `maxConcurrency` parameter, which defaults
+ * to `Infinity`. This means that by default, all calls will be made in parallel.
+ *
+ * Retries are limited by the `maxRetries` parameter, which defaults to 6. This
+ * means that by default, each call will be retried up to 6 times, with an
+ * exponential backoff between each attempt.
+ */
+export class AsyncCaller {
+  protected maxConcurrency: AsyncCallerParams["maxConcurrency"];
+
+  protected maxRetries: AsyncCallerParams["maxRetries"];
+
+  protected queue: PQueue;
+
+  constructor(params: AsyncCallerParams) {
+    this.maxConcurrency = params.maxConcurrency ?? Infinity;
+    this.maxRetries = params.maxRetries ?? 6;
+
+    this.queue = new PQueue({ concurrency: this.maxConcurrency });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  call<A extends any[], T extends (...args: A) => Promise<any>>(
+    callable: T,
+    ...args: Parameters<T>
+  ): Promise<ReturnType<T>> {
+    return this.queue.add(
+      () =>
+        backOff(() => callable(...args), {
+          numOfAttempts: this.maxRetries,
+          // If needed we can change some of the defaults here,
+          // but they're quite sensible.
+        }),
+      { throwOnTimeout: true }
+    );
+  }
+}

--- a/langchain/src/util/tests/async_caller.test.ts
+++ b/langchain/src/util/tests/async_caller.test.ts
@@ -1,0 +1,36 @@
+import { test, expect, jest } from "@jest/globals";
+import { AsyncCaller } from "../async_caller.js";
+
+test("AsyncCaller passes on arguments and returns return value", async () => {
+  const caller = new AsyncCaller({});
+  const callable = jest.fn((arg1, arg2) => Promise.resolve([arg2, arg1]));
+
+  const resultDirect = await callable(1, 2);
+  const resultWrapped = await caller.call(callable, 1, 2);
+
+  expect(resultDirect).toEqual([2, 1]);
+  expect(resultWrapped).toEqual([2, 1]);
+});
+
+test("AsyncCaller retries on failure", async () => {
+  const caller = new AsyncCaller({});
+
+  // A direct call throws an error.
+  let callable = jest
+    .fn<() => Promise<number[]>>()
+    .mockRejectedValueOnce("error")
+    .mockResolvedValueOnce([2, 1]);
+
+  await expect(() => callable()).rejects.toEqual("error");
+
+  // A wrapped call retries and succeeds.
+  callable = jest
+    .fn<() => Promise<number[]>>()
+    .mockRejectedValueOnce("error")
+    .mockResolvedValueOnce([2, 1]);
+
+  const resultWrapped = await caller.call(callable);
+
+  expect(resultWrapped).toEqual([2, 1]);
+  expect(callable.mock.calls).toHaveLength(2);
+});

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ES2021",
     "lib": [
       "ES2021",
+      "ES2022.Object",
       "DOM"
     ],
     "module": "ES2020",

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../dist",
     "rootDir": "./src",
-    "target": "ES2020",
+    "target": "ES2021",
     "lib": [
       "ESNext",
       "DOM"

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "target": "ES2021",
     "lib": [
-      "ESNext",
+      "ES2021",
       "DOM"
     ],
     "module": "ES2020",

--- a/test-exports/tsconfig.json
+++ b/test-exports/tsconfig.json
@@ -6,6 +6,7 @@
       "ESNext",
       "DOM"
     ],
+    "target": "ES2021",
     "module": "nodenext",
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,

--- a/test-exports/tsconfig.json
+++ b/test-exports/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "lib": [
       "ES2021",
+      "ES2022.Object",
       "DOM"
     ],
     "target": "ES2021",

--- a/test-exports/tsconfig.json
+++ b/test-exports/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "lib": [
-      "ESNext",
+      "ES2021",
       "DOM"
     ],
     "target": "ES2021",


### PR DESCRIPTION
This class contains generic logic useful for calling any "expensive" resource, eg. an API or LLM. This logic up to now has lived in various forms in subclassess of BaseLLM. As a follow on this will be applied across all those places.

As a follow on to this and to #277 will open a future PR using this in BaseLanguageModel