### PR TITLE
Allow options to be passed to fromLLM constructor in ChatVectorDBQAChain

### DIFF
--- a/langchain/src/chains/chat_vector_db_chain.ts
+++ b/langchain/src/chains/chat_vector_db_chain.ts
@@ -179,7 +179,16 @@ export class ChatVectorDBQAChain
     };
   }
 
-  static fromLLM(llm: BaseLLM, vectorstore: VectorStore): ChatVectorDBQAChain {
+  static fromLLM(
+    llm: BaseLLM,
+    vectorstore: VectorStore,
+    options?: {
+      inputKey?: string;
+      outputKey?: string;
+      k?: number;
+      returnSourceDocuments?: boolean;
+    }
+  ): ChatVectorDBQAChain {
     const qaChain = loadQAStuffChain(llm, { prompt: qa_prompt });
     const questionGeneratorChain = new LLMChain({
       prompt: question_generator_prompt,
@@ -189,6 +198,7 @@ export class ChatVectorDBQAChain
       vectorstore,
       combineDocumentsChain: qaChain,
       questionGeneratorChain,
+      ...options,
     });
     return instance;
   }


### PR DESCRIPTION
Allow options to be passed to fromLLM constructor. 
Allow the options: inputKey, outputKey, k, returnSourceDocuments to be passed when creating a chain fromLLM.