### PR TITLE
prevent the agent to throw an error

### DIFF
--- a/langchain/src/agents/mrkl/index.ts
+++ b/langchain/src/agents/mrkl/index.ts
@@ -121,6 +121,7 @@ export class ZeroShotAgent extends Agent {
 
     const match = /Action: (.*)\nAction Input: (.*)/s.exec(text);
     if (!match) {
+      return { tool: "Final Answer", input: text };
       //throw new Error(`Could not parse LLM output: ${text}`);
     }
 

--- a/langchain/src/agents/mrkl/index.ts
+++ b/langchain/src/agents/mrkl/index.ts
@@ -121,7 +121,7 @@ export class ZeroShotAgent extends Agent {
 
     const match = /Action: (.*)\nAction Input: (.*)/s.exec(text);
     if (!match) {
-      throw new Error(`Could not parse LLM output: ${text}`);
+      //throw new Error(`Could not parse LLM output: ${text}`);
     }
 
     return {

--- a/langchain/src/agents/mrkl/index.ts
+++ b/langchain/src/agents/mrkl/index.ts
@@ -121,6 +121,7 @@ export class ZeroShotAgent extends Agent {
 
     const match = /Action: (.*)\nAction Input: (.*)/s.exec(text);
     if (!match) {
+      // assume no tool is needed
       return { tool: "Final Answer", input: text };
       //throw new Error(`Could not parse LLM output: ${text}`);
     }


### PR DESCRIPTION
This is equivalent to [improve agent ux with chatgpt](https://github.com/hwchase17/langchain/pull/1474) #1474 in the py project.
If the tool does not have any proper output, assume this is the last one and return the response of the llm.