### PR TITLE
add options to VectorDBQAChain.fromLLM

### DIFF
--- a/docs/docs/modules/indexes/vector_stores/pinecone.md
+++ b/docs/docs/modules/indexes/vector_stores/pinecone.md
@@ -43,7 +43,9 @@ const vectorStore = await PineconeStore.fromExistingIndex(
 );
 
 const model = new OpenAI();
-const chain = VectorDBQAChain.fromLLM(model, vectorStore);
+const chain = VectorDBQAChain.fromLLM(model, vectorStore, {
+  returnSourceDocuments: true,
+});
 const response = await chain.call({
   query: "what does the doc say about pinecone",
 });

--- a/langchain/src/chains/vector_db_qa.ts
+++ b/langchain/src/chains/vector_db_qa.ts
@@ -18,6 +18,7 @@ export interface VectorDBQAChainInput {
   combineDocumentsChain: BaseChain;
   outputKey: string;
   inputKey: string;
+  returnSourceDocuments?: boolean;
 }
 
 export type SerializedVectorDBQAChain = {
@@ -115,8 +116,16 @@ export class VectorDBQAChain extends BaseChain implements VectorDBQAChainInput {
     };
   }
 
-  static fromLLM(llm: BaseLLM, vectorstore: VectorStore): VectorDBQAChain {
+  static fromLLM(
+    llm: BaseLLM,
+    vectorstore: VectorStore,
+    options?: Partial<VectorDBQAChainInput>
+  ): VectorDBQAChain {
     const qaChain = loadQAStuffChain(llm);
-    return new this({ vectorstore, combineDocumentsChain: qaChain });
+    return new this({
+      vectorstore,
+      combineDocumentsChain: qaChain,
+      ...(options || {}),
+    });
   }
 }

--- a/langchain/src/chains/vector_db_qa.ts
+++ b/langchain/src/chains/vector_db_qa.ts
@@ -119,7 +119,7 @@ export class VectorDBQAChain extends BaseChain implements VectorDBQAChainInput {
   static fromLLM(
     llm: BaseLLM,
     vectorstore: VectorStore,
-    options?: Partial<VectorDBQAChainInput>
+    options?: Partial<Omit<VectorDBQAChainInput, 'combineDocumentsChain' | 'vectorstore'>>
   ): VectorDBQAChain {
     const qaChain = loadQAStuffChain(llm);
     return new this({

--- a/langchain/src/chains/vector_db_qa.ts
+++ b/langchain/src/chains/vector_db_qa.ts
@@ -119,13 +119,15 @@ export class VectorDBQAChain extends BaseChain implements VectorDBQAChainInput {
   static fromLLM(
     llm: BaseLLM,
     vectorstore: VectorStore,
-    options?: Partial<Omit<VectorDBQAChainInput, 'combineDocumentsChain' | 'vectorstore'>>
+    options?: Partial<
+      Omit<VectorDBQAChainInput, "combineDocumentsChain" | "vectorstore">
+    >
   ): VectorDBQAChain {
     const qaChain = loadQAStuffChain(llm);
     return new this({
       vectorstore,
       combineDocumentsChain: qaChain,
-      ...(options || {}),
+      ...options,
     });
   }
 }


### PR DESCRIPTION
allows for passing `VectorDBQAChain` options into `VectorDBQAChain.fromLLM`.

updated the doc for discoverability

sorry about https://github.com/hwchase17/langchainjs/pull/287 I was struggling with my fork 🤓 