### PR TITLE
update error message to new hf package

### DIFF
--- a/langchain/src/llms/hf.ts
+++ b/langchain/src/llms/hf.ts
@@ -95,7 +95,7 @@ export class HuggingFaceInference extends LLM implements HFInput {
       return { HfInference };
     } catch (e) {
       throw new Error(
-        "Please install huggingface as a dependency with, e.g. `yarn add huggingface`"
+        "Please install huggingface as a dependency with, e.g. `yarn add @huggingface/inference`"
       );
     }
   }


### PR DESCRIPTION
yarn add huggingface not working anymore deprecated. use yarn add @huggingface/inference` instead.