### PR TITLE
Support concurrent runs in tracer

### DIFF
--- a/langchain/src/agents/tools/base.ts
+++ b/langchain/src/agents/tools/base.ts
@@ -21,19 +21,20 @@ export abstract class Tool {
 
   async call(arg: string, verbose?: boolean): Promise<string> {
     const _verbose = verbose ?? this.verbose;
-    await this.callbackManager.handleToolStart(
+    const runId = await this.callbackManager.handleToolStart(
       { name: this.name },
       arg,
+      undefined,
       _verbose
     );
     let result;
     try {
       result = await this._call(arg);
     } catch (e) {
-      await this.callbackManager.handleToolError(e, _verbose);
+      await this.callbackManager.handleToolError(e, runId, _verbose);
       throw e;
     }
-    await this.callbackManager.handleToolEnd(result, _verbose);
+    await this.callbackManager.handleToolEnd(result, runId, _verbose);
     return result;
   }
 

--- a/langchain/src/callbacks/base.ts
+++ b/langchain/src/callbacks/base.ts
@@ -19,34 +19,57 @@ abstract class BaseCallbackHandlerMethods {
   handleLLMStart?(
     llm: { name: string },
     prompts: string[],
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void | unknown>;
+
+  handleLLMNewToken?(
+    token: string,
+    runId: symbol,
     verbose?: boolean
   ): Promise<void>;
 
-  handleLLMNewToken?(token: string, verbose?: boolean): Promise<void>;
+  handleLLMError?(err: Error, runId: symbol, verbose?: boolean): Promise<void>;
 
-  handleLLMError?(err: Error, verbose?: boolean): Promise<void>;
-
-  handleLLMEnd?(output: LLMResult, verbose?: boolean): Promise<void>;
+  handleLLMEnd?(
+    output: LLMResult,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void>;
 
   handleChainStart?(
     chain: { name: string },
     inputs: ChainValues,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void | unknown>;
+
+  handleChainError?(
+    err: Error,
+    runId: symbol,
     verbose?: boolean
   ): Promise<void>;
 
-  handleChainError?(err: Error, verbose?: boolean): Promise<void>;
-
-  handleChainEnd?(outputs: ChainValues, verbose?: boolean): Promise<void>;
+  handleChainEnd?(
+    outputs: ChainValues,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void>;
 
   handleToolStart?(
     tool: { name: string },
     input: string,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void | unknown>;
+
+  handleToolError?(err: Error, runId: symbol, verbose?: boolean): Promise<void>;
+
+  handleToolEnd?(
+    output: string,
+    runId: symbol,
     verbose?: boolean
   ): Promise<void>;
-
-  handleToolError?(err: Error, verbose?: boolean): Promise<void>;
-
-  handleToolEnd?(output: string, verbose?: boolean): Promise<void>;
 
   handleText?(text: string, verbose?: boolean): Promise<void>;
 
@@ -101,13 +124,14 @@ export class CallbackManager extends BaseCallbackManager {
   async handleLLMStart(
     llm: { name: string },
     prompts: string[],
-    verbose?: boolean
-  ): Promise<void> {
+    runId = Symbol("LLM"),
+    verbose = false
+  ): Promise<symbol> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMStart?.(llm, prompts);
+            await handler.handleLLMStart?.(llm, prompts, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMStart: ${err}`
@@ -116,14 +140,19 @@ export class CallbackManager extends BaseCallbackManager {
         }
       })
     );
+    return runId;
   }
 
-  async handleLLMNewToken(token: string, verbose?: boolean): Promise<void> {
+  async handleLLMNewToken(
+    token: string,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMNewToken?.(token);
+            await handler.handleLLMNewToken?.(token, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMNewToken: ${err}`
@@ -134,12 +163,16 @@ export class CallbackManager extends BaseCallbackManager {
     );
   }
 
-  async handleLLMError(err: Error, verbose?: boolean): Promise<void> {
+  async handleLLMError(
+    err: Error,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMError?.(err);
+            await handler.handleLLMError?.(err, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMError: ${err}`
@@ -150,12 +183,16 @@ export class CallbackManager extends BaseCallbackManager {
     );
   }
 
-  async handleLLMEnd(output: LLMResult, verbose?: boolean): Promise<void> {
+  async handleLLMEnd(
+    output: LLMResult,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMEnd?.(output);
+            await handler.handleLLMEnd?.(output, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMEnd: ${err}`
@@ -169,13 +206,14 @@ export class CallbackManager extends BaseCallbackManager {
   async handleChainStart(
     chain: { name: string },
     inputs: ChainValues,
-    verbose?: boolean
-  ): Promise<void> {
+    runId = Symbol("Chain"),
+    verbose = false
+  ): Promise<symbol> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleChainStart?.(chain, inputs);
+            await handler.handleChainStart?.(chain, inputs, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleChainStart: ${err}`
@@ -184,14 +222,19 @@ export class CallbackManager extends BaseCallbackManager {
         }
       })
     );
+    return runId;
   }
 
-  async handleChainError(err: Error, verbose?: boolean): Promise<void> {
+  async handleChainError(
+    err: Error,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleChainError?.(err);
+            await handler.handleChainError?.(err, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleChainError: ${err}`
@@ -202,12 +245,16 @@ export class CallbackManager extends BaseCallbackManager {
     );
   }
 
-  async handleChainEnd(output: ChainValues, verbose?: boolean): Promise<void> {
+  async handleChainEnd(
+    output: ChainValues,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleChainEnd?.(output);
+            await handler.handleChainEnd?.(output, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleChainEnd: ${err}`
@@ -221,13 +268,14 @@ export class CallbackManager extends BaseCallbackManager {
   async handleToolStart(
     tool: { name: string },
     input: string,
-    verbose?: boolean
-  ): Promise<void> {
+    runId = Symbol("Tool"),
+    verbose = false
+  ): Promise<symbol> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleToolStart?.(tool, input);
+            await handler.handleToolStart?.(tool, input, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleToolStart: ${err}`
@@ -236,14 +284,19 @@ export class CallbackManager extends BaseCallbackManager {
         }
       })
     );
+    return runId;
   }
 
-  async handleToolError(err: Error, verbose?: boolean): Promise<void> {
+  async handleToolError(
+    err: Error,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleToolError?.(err);
+            await handler.handleToolError?.(err, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleToolError: ${err}`
@@ -254,12 +307,16 @@ export class CallbackManager extends BaseCallbackManager {
     );
   }
 
-  async handleToolEnd(output: string, verbose?: boolean): Promise<void> {
+  async handleToolEnd(
+    output: string,
+    runId: symbol,
+    verbose?: boolean
+  ): Promise<void> {
     await Promise.all(
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleToolEnd?.(output);
+            await handler.handleToolEnd?.(output, runId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleToolEnd: ${err}`

--- a/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
+++ b/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
@@ -9,17 +9,21 @@ test("Test LangChain tracer", async () => {
   const tracer = new LangChainTracer();
   expect(tracer.alwaysVerbose).toBe(true);
 
-  await tracer.handleChainStart({ name: "test" }, { foo: "bar" });
-  await tracer.handleToolStart({ name: "test" }, "test");
-  await tracer.handleLLMStart({ name: "test" }, ["test"]);
-  await tracer.handleLLMEnd({ generations: [[]] });
-  await tracer.handleToolEnd("output");
-  await tracer.handleLLMStart({ name: "test2" }, ["test"]);
-  await tracer.handleLLMEnd({ generations: [[]] });
-  await tracer.handleChainEnd({ foo: "bar" });
+  const chainRunId = Symbol("");
+  const toolRunId = Symbol("");
+  const llmRunId = Symbol("");
+  await tracer.handleChainStart({ name: "test" }, { foo: "bar" }, chainRunId);
+  await tracer.handleToolStart({ name: "test" }, "test", toolRunId);
+  await tracer.handleLLMStart({ name: "test" }, ["test"], llmRunId);
+  await tracer.handleLLMEnd({ generations: [[]] }, llmRunId);
+  await tracer.handleToolEnd("output", toolRunId);
+  await tracer.handleLLMStart({ name: "test2" }, ["test"], llmRunId);
+  await tracer.handleLLMEnd({ generations: [[]] }, llmRunId);
+  await tracer.handleChainEnd({ foo: "bar" }, chainRunId);
 
-  await tracer.handleLLMStart({ name: "test" }, ["test"]);
-  await tracer.handleLLMEnd({ generations: [[]] });
+  const llmRunId2 = Symbol("");
+  await tracer.handleLLMStart({ name: "test" }, ["test"], llmRunId2);
+  await tracer.handleLLMEnd({ generations: [[]] }, llmRunId2);
 });
 
 test.skip("Test Traced Agent with concurrency (skipped until we fix concurrency)", async () => {

--- a/langchain/src/chains/base.ts
+++ b/langchain/src/chains/base.ts
@@ -84,19 +84,24 @@ export abstract class BaseChain implements ChainInputs {
         fullValues[key] = value;
       }
     }
-    await this.callbackManager.handleChainStart(
+    const runId = await this.callbackManager.handleChainStart(
       { name: this._chainType() },
       fullValues,
+      undefined,
       this.verbose
     );
     let outputValues;
     try {
       outputValues = await this._call(fullValues);
     } catch (e) {
-      await this.callbackManager.handleChainError(e, this.verbose);
+      await this.callbackManager.handleChainError(e, runId, this.verbose);
       throw e;
     }
-    await this.callbackManager.handleChainEnd(outputValues, this.verbose);
+    await this.callbackManager.handleChainEnd(
+      outputValues,
+      runId,
+      this.verbose
+    );
     if (!(this.memory == null)) {
       await this.memory.saveContext(values, outputValues);
     }

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -243,7 +243,8 @@ export class ChatOpenAI extends BaseChatModel implements OpenAIInput {
    */
   async _generate(
     messages: BaseChatMessage[],
-    stop?: string[]
+    stop: string[],
+    runId: symbol
   ): Promise<ChatResult> {
     if (this.stop && stop) {
       throw new Error("Stop found in input and default params");
@@ -291,6 +292,7 @@ export class ChatOpenAI extends BaseChatModel implements OpenAIInput {
                 // eslint-disable-next-line no-void
                 void this.callbackManager.handleLLMNewToken(
                   part.delta?.content ?? "",
+                  runId,
                   true
                 );
               }

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -208,7 +208,11 @@ export class OpenAIChat extends LLM implements OpenAIInput {
    * const response = await openai.generate(["Tell me a joke."]);
    * ```
    */
-  async _call(prompt: string, stop?: string[]): Promise<string> {
+  async _call(
+    prompt: string,
+    stop: string[] | undefined,
+    runId: symbol
+  ): Promise<string> {
     if (this.stop && stop) {
       throw new Error("Stop found in input and default params");
     }
@@ -249,6 +253,7 @@ export class OpenAIChat extends LLM implements OpenAIInput {
                 // eslint-disable-next-line no-void
                 void this.callbackManager.handleLLMNewToken(
                   part.delta?.content ?? "",
+                  runId,
                   true
                 );
               }

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -233,7 +233,11 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
    * const response = await openai.generate(["Tell me a joke."]);
    * ```
    */
-  async _generate(prompts: string[], stop?: string[]): Promise<LLMResult> {
+  async _generate(
+    prompts: string[],
+    stop: string[] | undefined,
+    runId: symbol
+  ): Promise<LLMResult> {
     const subPrompts = chunkArray(prompts, this.batchSize);
     const choices: CreateCompletionResponseChoicesInner[] = [];
     const tokenUsage: TokenUsage = {};
@@ -286,6 +290,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
                     // eslint-disable-next-line no-void
                     void this.callbackManager.handleLLMNewToken(
                       part.text ?? "",
+                      runId,
                       true
                     );
                   }


### PR DESCRIPTION
Note this currently does not try to guess which concurrent run a child run should get associated to, that would be an improvement to make on top of this