### PR TITLE
BaseLLM -> Base language

### DIFF
--- a/docs/docs/modules/chains/chat_vector_db_qa.md
+++ b/docs/docs/modules/chains/chat_vector_db_qa.md
@@ -42,7 +42,7 @@ In this code snippet, the fromLLM method of the ChatVectorDBQAChain class has th
 
 ```typescript
 static fromLLM(
-  llm: BaseLLM,
+  llm: BaseLanguageModel,
   vectorstore: VectorStore,
   options?: {
     questionGeneratorTemplate?: string;

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -1,5 +1,7 @@
 agents.js
 agents.d.ts
+base_language.js
+base_language.d.ts
 tools.js
 tools.d.ts
 chains.js

--- a/langchain/create-entrypoints.js
+++ b/langchain/create-entrypoints.js
@@ -4,6 +4,7 @@ import fs from "fs";
 
 const entrypoints = {
   agents: "agents/index",
+  base_language: "base_language/index",
   tools: "agents/tools/index",
   chains: "chains/index",
   embeddings: "embeddings/index",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -9,6 +9,8 @@
     "dist/",
     "agents.js",
     "agents.d.ts",
+    "base_language.js",
+    "base_language.d.ts",
     "tools.js",
     "tools.d.ts",
     "chains.js",
@@ -219,6 +221,10 @@
     "./agents": {
       "types": "./agents.d.ts",
       "import": "./agents.js"
+    },
+    "./base_language": {
+      "types": "./base_language.d.ts",
+      "import": "./base_language.js"
     },
     "./tools": {
       "types": "./tools.d.ts",

--- a/langchain/src/agents/agent.ts
+++ b/langchain/src/agents/agent.ts
@@ -1,4 +1,4 @@
-import { BaseLLM } from "../llms/index.js";
+import { BaseLanguageModel } from "../base_language/index.js";
 import { LLMChain } from "../chains/llm_chain.js";
 import { BasePromptTemplate } from "../prompts/index.js";
 import {
@@ -98,7 +98,7 @@ export abstract class Agent {
 
   /** Construct an agent from an LLM and a list of tools */
   static fromLLMAndTools(
-    _llm: BaseLLM,
+    _llm: BaseLanguageModel,
     _tools: Tool[],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     _args?: Record<string, any>
@@ -226,7 +226,7 @@ export abstract class Agent {
    * Load an agent from a json-like object describing it.
    */
   static async deserialize(
-    data: SerializedAgent & { llm?: BaseLLM; tools?: Tool[] }
+    data: SerializedAgent & { llm?: BaseLanguageModel; tools?: Tool[] }
   ): Promise<Agent> {
     switch (data._type) {
       case "zero-shot-react-description": {

--- a/langchain/src/agents/agent_toolkits/json/json.ts
+++ b/langchain/src/agents/agent_toolkits/json/json.ts
@@ -1,4 +1,4 @@
-import { BaseLLM } from "../../../llms/index.js";
+import { BaseLanguageModel } from "../../../base_language/index.js";
 import {
   JsonGetValueTool,
   JsonListKeysTool,
@@ -24,7 +24,7 @@ export class JsonToolkit extends Toolkit {
 }
 
 export function createJsonAgent(
-  llm: BaseLLM,
+  llm: BaseLanguageModel,
   toolkit: JsonToolkit,
   args?: CreatePromptArgs
 ) {

--- a/langchain/src/agents/agent_toolkits/openapi/openapi.ts
+++ b/langchain/src/agents/agent_toolkits/openapi/openapi.ts
@@ -1,4 +1,4 @@
-import { BaseLLM } from "../../../llms/index.js";
+import { BaseLanguageModel } from "../../../base_language/index.js";
 import {
   DynamicTool,
   JsonSpec,
@@ -28,7 +28,7 @@ export class RequestsToolkit extends Toolkit {
 }
 
 export class OpenApiToolkit extends RequestsToolkit {
-  constructor(jsonSpec: JsonSpec, llm: BaseLLM, headers?: Headers) {
+  constructor(jsonSpec: JsonSpec, llm: BaseLanguageModel, headers?: Headers) {
     super(headers);
     const jsonAgent = createJsonAgent(llm, new JsonToolkit(jsonSpec));
     this.tools = [
@@ -46,7 +46,7 @@ export class OpenApiToolkit extends RequestsToolkit {
 }
 
 export function createOpenApiAgent(
-  llm: BaseLLM,
+  llm: BaseLanguageModel,
   openApiToolkit: OpenApiToolkit,
   args?: CreatePromptArgs
 ) {

--- a/langchain/src/agents/agent_toolkits/sql/sql.ts
+++ b/langchain/src/agents/agent_toolkits/sql/sql.ts
@@ -6,7 +6,7 @@ import {
   QuerySqlTool,
 } from "../../tools/index.js";
 import { Toolkit } from "../base.js";
-import { BaseLLM } from "../../../llms/index.js";
+import { BaseLanguageModel } from "../../../base_language/index.js";
 import { SQL_PREFIX, SQL_SUFFIX } from "./prompt.js";
 import { renderTemplate } from "../../../prompts/template.js";
 import { LLMChain } from "../../../chains/index.js";
@@ -39,7 +39,7 @@ export class SqlToolkit extends Toolkit {
 }
 
 export function createSqlAgent(
-  llm: BaseLLM,
+  llm: BaseLanguageModel,
   toolkit: SqlToolkit,
   args?: SqlCreatePromptArgs
 ) {

--- a/langchain/src/agents/agent_toolkits/vectorstore/vectorstore.ts
+++ b/langchain/src/agents/agent_toolkits/vectorstore/vectorstore.ts
@@ -1,7 +1,7 @@
 import { Tool, VectorStoreQATool } from "../../tools/index.js";
 import { VectorStore } from "../../../vectorstores/index.js";
 import { Toolkit } from "../base.js";
-import { BaseLLM } from "../../../llms/index.js";
+import { BaseLanguageModel } from "../../../base_language/index.js";
 import { CreatePromptArgs, ZeroShotAgent } from "../../mrkl/index.js";
 import { VECTOR_PREFIX, VECTOR_ROUTER_PREFIX } from "./prompt.js";
 import { SUFFIX } from "../../mrkl/prompt.js";
@@ -17,9 +17,9 @@ export interface VectorStoreInfo {
 export class VectorStoreToolkit extends Toolkit {
   tools: Tool[];
 
-  llm: BaseLLM;
+  llm: BaseLanguageModel;
 
-  constructor(vectorStoreInfo: VectorStoreInfo, llm: BaseLLM) {
+  constructor(vectorStoreInfo: VectorStoreInfo, llm: BaseLanguageModel) {
     super();
     const description = VectorStoreQATool.getDescription(
       vectorStoreInfo.name,
@@ -40,9 +40,9 @@ export class VectorStoreRouterToolkit extends Toolkit {
 
   vectorStoreInfos: VectorStoreInfo[];
 
-  llm: BaseLLM;
+  llm: BaseLanguageModel;
 
-  constructor(vectorStoreInfos: VectorStoreInfo[], llm: BaseLLM) {
+  constructor(vectorStoreInfos: VectorStoreInfo[], llm: BaseLanguageModel) {
     super();
     this.llm = llm;
     this.vectorStoreInfos = vectorStoreInfos;
@@ -60,7 +60,7 @@ export class VectorStoreRouterToolkit extends Toolkit {
 }
 
 export function createVectorStoreAgent(
-  llm: BaseLLM,
+  llm: BaseLanguageModel,
   toolkit: VectorStoreToolkit,
   args?: CreatePromptArgs
 ) {
@@ -88,7 +88,7 @@ export function createVectorStoreAgent(
 }
 
 export function createVectorStoreRouterAgent(
-  llm: BaseLLM,
+  llm: BaseLanguageModel,
   toolkit: VectorStoreRouterToolkit,
   args?: CreatePromptArgs
 ) {

--- a/langchain/src/agents/load.ts
+++ b/langchain/src/agents/load.ts
@@ -1,13 +1,13 @@
 import { Agent } from "./agent.js";
 import { Tool } from "./tools/base.js";
-import { BaseLLM } from "../llms/index.js";
+import { BaseLanguageModel } from "../base_language/index.js";
 import { loadFromHub } from "../util/hub.js";
 import { FileLoader, loadFromFile, parseFileConfig } from "../util/index.js";
 
 const loadAgentFromFile: FileLoader<Agent> = async (
   file: string,
   path: string,
-  llmAndTools?: { llm?: BaseLLM; tools?: Tool[] }
+  llmAndTools?: { llm?: BaseLanguageModel; tools?: Tool[] }
 ) => {
   const serialized = parseFileConfig(file, path);
   return Agent.deserialize({ ...serialized, ...llmAndTools });
@@ -15,7 +15,7 @@ const loadAgentFromFile: FileLoader<Agent> = async (
 
 export const loadAgent = async (
   uri: string,
-  llmAndTools?: { llm?: BaseLLM; tools?: Tool[] }
+  llmAndTools?: { llm?: BaseLanguageModel; tools?: Tool[] }
 ): Promise<Agent> => {
   const hubResult = await loadFromHub(
     uri,

--- a/langchain/src/agents/tools/vectorstore.ts
+++ b/langchain/src/agents/tools/vectorstore.ts
@@ -1,17 +1,17 @@
 import { VectorStore } from "../../vectorstores/index.js";
-import { BaseLLM } from "../../llms/index.js";
+import { BaseLanguageModel } from "../../base_language/index.js";
 import { VectorDBQAChain } from "../../chains/index.js";
 import { Tool } from "./base.js";
 
 interface VectorStoreTool {
   vectorStore: VectorStore;
-  llm: BaseLLM;
+  llm: BaseLanguageModel;
 }
 
 export class VectorStoreQATool extends Tool implements VectorStoreTool {
   vectorStore: VectorStore;
 
-  llm: BaseLLM;
+  llm: BaseLanguageModel;
 
   name: string;
 

--- a/langchain/src/base_language/index.ts
+++ b/langchain/src/base_language/index.ts
@@ -3,6 +3,12 @@ import { CallbackManager, getCallbackManager } from "../callbacks/index.js";
 
 const getVerbosity = () => false;
 
+export type SerializedLLM = {
+  _model: string;
+  _type: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} & Record<string, any>;
+
 /**
  * Base interface for language model parameters.
  * A subclass of {@link BaseLanguageModel} should have a constructor that
@@ -37,4 +43,18 @@ export abstract class BaseLanguageModel implements BaseLanguageModelParams {
   abstract _modelType(): string;
 
   abstract getNumTokens(text: string): number;
+
+  /**
+   * Return a json-like object representing this LLM.
+   */
+  serialize(): SerializedLLM {
+    throw new Error("Not implemented");
+  }
+
+  /**
+   * Load an LLM from a json-like object describing it.
+   */
+  static async deserialize(_data: SerializedLLM): Promise<BaseLanguageModel> {
+    throw new Error("Not implemented");
+  }
 }

--- a/langchain/src/base_language/index.ts
+++ b/langchain/src/base_language/index.ts
@@ -42,19 +42,43 @@ export abstract class BaseLanguageModel implements BaseLanguageModelParams {
 
   abstract _modelType(): string;
 
+  abstract _llmType(): string;
+
   abstract getNumTokens(text: string): number;
+
+  /**
+   * Get the identifying parameters of the LLM.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _identifyingParams(): Record<string, any> {
+    return {};
+  }
 
   /**
    * Return a json-like object representing this LLM.
    */
   serialize(): SerializedLLM {
-    throw new Error("Not implemented");
+    return {
+      ...this._identifyingParams(),
+      _type: this._llmType(),
+      _model: this._modelType(),
+    };
   }
 
   /**
    * Load an LLM from a json-like object describing it.
    */
-  static async deserialize(_data: SerializedLLM): Promise<BaseLanguageModel> {
-    throw new Error("Not implemented");
+  static async deserialize(data: SerializedLLM): Promise<BaseLanguageModel> {
+    const { _type, _model, ...rest } = data;
+    if (_model && _model !== "base_llm") {
+      throw new Error(`Cannot load LLM with model ${_model}`);
+    }
+    const Cls = {
+      openai: (await import("../chat_models/openai.js")).ChatOpenAI,
+    }[_type];
+    if (Cls === undefined) {
+      throw new Error(`Cannot load  LLM with type ${_type}`);
+    }
+    return new Cls(rest);
   }
 }

--- a/langchain/src/base_language/index.ts
+++ b/langchain/src/base_language/index.ts
@@ -70,7 +70,7 @@ export abstract class BaseLanguageModel implements BaseLanguageModelParams {
    */
   static async deserialize(data: SerializedLLM): Promise<BaseLanguageModel> {
     const { _type, _model, ...rest } = data;
-    if (_model && _model !== "base_llm") {
+    if (_model && _model !== "base_chat_model") {
       throw new Error(`Cannot load LLM with model ${_model}`);
     }
     const Cls = {

--- a/langchain/src/chains/chat_vector_db_chain.ts
+++ b/langchain/src/chains/chat_vector_db_chain.ts
@@ -1,5 +1,5 @@
 import { PromptTemplate } from "../prompts/index.js";
-import { BaseLLM } from "../llms/index.js";
+import { BaseLanguageModel } from "../base_language/index.js";
 import { VectorStore } from "../vectorstores/base.js";
 import {
   SerializedBaseChain,
@@ -167,7 +167,7 @@ export class ChatVectorDBQAChain
   }
 
   static fromLLM(
-    llm: BaseLLM,
+    llm: BaseLanguageModel,
     vectorstore: VectorStore,
     options: {
       inputKey?: string;

--- a/langchain/src/chains/llm_chain.ts
+++ b/langchain/src/chains/llm_chain.ts
@@ -1,5 +1,6 @@
 import { BaseChain, ChainInputs } from "./base.js";
-import { BaseLLM, SerializedLLM } from "../llms/index.js";
+import { SerializedLLM } from "../llms/index.js";
+
 import { BaseMemory, BufferMemory } from "../memory/index.js";
 import {
   BasePromptTemplate,
@@ -97,7 +98,7 @@ export class LLMChain extends BaseChain implements LLMChainInput {
     >("prompt", data);
 
     return new LLMChain({
-      llm: await BaseLLM.deserialize(serializedLLM),
+      llm: await BaseLanguageModel.deserialize(serializedLLM),
       prompt: await BasePromptTemplate.deserialize(serializedPrompt),
     });
   }
@@ -105,7 +106,7 @@ export class LLMChain extends BaseChain implements LLMChainInput {
   serialize(): SerializedLLMChain {
     return {
       _type: this._chainType(),
-      // llm: this.llm.serialize(), TODO fix this now that llm is BaseLanguageModel
+      llm: this.llm.serialize(),
       prompt: this.prompt.serialize(),
     };
   }

--- a/langchain/src/chains/prompt_selector.ts
+++ b/langchain/src/chains/prompt_selector.ts
@@ -1,5 +1,4 @@
 import { BaseChatModel } from "../chat_models/base.js";
-import { BaseLLM } from "../llms/base.js";
 import { BasePromptTemplate } from "../prompts/base.js";
 import { BaseLanguageModel } from "../base_language/index.js";
 
@@ -38,8 +37,8 @@ export class ConditionalPromptSelector extends BasePromptSelector {
   }
 }
 
-export function isLLM(llm: BaseLanguageModel): llm is BaseLLM {
-  return llm instanceof BaseLLM;
+export function isLLM(llm: BaseLanguageModel): llm is BaseLanguageModel {
+  return llm instanceof BaseLanguageModel;
 }
 
 export function isChatModel(llm: BaseLanguageModel): llm is BaseChatModel {

--- a/langchain/src/chains/question_answering/load.ts
+++ b/langchain/src/chains/question_answering/load.ts
@@ -1,4 +1,3 @@
-import { BaseLLM } from "../../llms/index.js";
 import { LLMChain } from "../llm_chain.js";
 import { PromptTemplate } from "../../prompts/index.js";
 import {
@@ -12,6 +11,7 @@ import {
   COMBINE_PROMPT_SELECTOR,
   COMBINE_QA_PROMPT_SELECTOR,
 } from "./map_reduce_prompts.js";
+import { BaseLanguageModel } from "../../base_language/index.js";
 
 interface qaChainParams {
   prompt?: PromptTemplate;
@@ -19,7 +19,10 @@ interface qaChainParams {
   combinePrompt?: PromptTemplate;
   type?: string;
 }
-export const loadQAChain = (llm: BaseLLM, params: qaChainParams = {}) => {
+export const loadQAChain = (
+  llm: BaseLanguageModel,
+  params: qaChainParams = {}
+) => {
   const {
     prompt = DEFAULT_QA_PROMPT,
     combineMapPrompt = DEFAULT_COMBINE_QA_PROMPT,
@@ -52,7 +55,7 @@ interface StuffQAChainParams {
 }
 
 export const loadQAStuffChain = (
-  llm: BaseLLM,
+  llm: BaseLanguageModel,
   params: StuffQAChainParams = {}
 ) => {
   const { prompt = QA_PROMPT_SELECTOR.getPrompt(llm) } = params;
@@ -67,7 +70,7 @@ interface MapReduceQAChainParams {
 }
 
 export const loadQAMapReduceChain = (
-  llm: BaseLLM,
+  llm: BaseLanguageModel,
   params: MapReduceQAChainParams = {}
 ) => {
   const {

--- a/langchain/src/chains/sql_db/sql_db_chain.ts
+++ b/langchain/src/chains/sql_db/sql_db_chain.ts
@@ -1,17 +1,18 @@
 import { DEFAULT_SQL_DATABASE_PROMPT } from "./sql_db_prompt.js";
 import { BaseChain } from "../base.js";
 import { BaseMemory } from "../../memory/index.js";
-import { BaseLLM, SerializedLLM } from "../../llms/index.js";
+import { SerializedLLM } from "../../llms/index.js";
 import { LLMChain } from "../llm_chain.js";
 import { SqlDatabase } from "../../sql_db.js";
 import { resolveConfigFromFile } from "../../util/index.js";
 import { SerializedSqlDatabase } from "../../util/sql_utils.js";
 import { ChainValues } from "../../schema/index.js";
 import { SerializedSqlDatabaseChain } from "../serde.js";
+import { BaseLanguageModel } from "../../base_language/index.js";
 
 export class SqlDatabaseChain extends BaseChain {
   // LLM wrapper to use
-  llm: BaseLLM;
+  llm: BaseLanguageModel;
 
   // SQL Database to connect to.
   database: SqlDatabase;
@@ -30,7 +31,7 @@ export class SqlDatabaseChain extends BaseChain {
   returnDirect = false;
 
   constructor(fields: {
-    llm: BaseLLM;
+    llm: BaseLanguageModel;
     database: SqlDatabase;
     inputKey?: string;
     outputKey?: string;
@@ -105,7 +106,7 @@ export class SqlDatabaseChain extends BaseChain {
       "llm",
       data
     );
-    const llm = await BaseLLM.deserialize(serializedLLM);
+    const llm = await BaseLanguageModel.deserialize(serializedLLM);
     const serializedDatabase = await resolveConfigFromFile<
       "sql_database",
       SerializedSqlDatabase

--- a/langchain/src/chains/summarization/load.ts
+++ b/langchain/src/chains/summarization/load.ts
@@ -1,4 +1,4 @@
-import { BaseLLM } from "../../llms/index.js";
+import { BaseLanguageModel } from "../../base_language/index.js";
 import { LLMChain } from "../llm_chain.js";
 import { PromptTemplate } from "../../prompts/index.js";
 import {
@@ -14,7 +14,7 @@ interface summarizationChainParams {
   type?: "map_reduce" | "stuff";
 }
 export const loadSummarizationChain = (
-  llm: BaseLLM,
+  llm: BaseLanguageModel,
   params: summarizationChainParams = {}
 ) => {
   const {

--- a/langchain/src/chains/tests/llm_chain.int.test.ts
+++ b/langchain/src/chains/tests/llm_chain.int.test.ts
@@ -69,7 +69,7 @@ test("Test LLMChain with ChatOpenAI", async () => {
 });
 
 test("Test deserialize", async () => {
-  const model = new OpenAI({ modelName: "text-ada-001" });
+  const model = new ChatOpenAI();
   const prompt = new PromptTemplate({
     template: "Print {foo}",
     inputVariables: ["foo"],

--- a/langchain/src/chains/tests/llm_chain.int.test.ts
+++ b/langchain/src/chains/tests/llm_chain.int.test.ts
@@ -67,3 +67,59 @@ test("Test LLMChain with ChatOpenAI", async () => {
   const res = await chatChain.call({ product: "colorful socks" });
   console.log({ res });
 });
+
+test("Test deserialize", async () => {
+  const model = new OpenAI({ modelName: "text-ada-001" });
+  const prompt = new PromptTemplate({
+    template: "Print {foo}",
+    inputVariables: ["foo"],
+  });
+  const chain = new LLMChain({ prompt, llm: model });
+
+  const serialized = chain.serialize();
+  console.log(serialized);
+  const chain2 = await LLMChain.deserialize({ ...serialized });
+
+  const res = await chain2.run("my favorite color");
+  console.log({ res });
+});
+
+// {
+//   _type: 'llm_chain',
+//   prompt: {
+//     _type: 'prompt',
+//     input_variables: [ 'foo' ],
+//     output_parser: undefined,
+//     template: 'Print {foo}',
+//     template_format: 'f-string'
+//   }
+// }
+
+// {
+//   "memory": null,
+//   "verbose": false,
+//   "prompt": {
+//       "input_variables": [
+//           "topic"
+//       ],
+//       "output_parser": null,
+//       "template": "Tell me a joke about {topic}:",
+//       "template_format": "f-string",
+//       "_type": "prompt"
+//   },
+//   "llm": {
+//       "model_name": "text-davinci-003",
+//       "temperature": 0.9,
+//       "max_tokens": 256,
+//       "top_p": 1,
+//       "frequency_penalty": 0,
+//       "presence_penalty": 0,
+//       "n": 1,
+//       "best_of": 1,
+//       "request_timeout": null,
+//       "logit_bias": {},
+//       "_type": "openai"
+//   },
+//   "output_key": "text",
+//   "_type": "llm_chain"
+// }

--- a/langchain/src/chains/tests/llm_chain.int.test.ts
+++ b/langchain/src/chains/tests/llm_chain.int.test.ts
@@ -77,49 +77,11 @@ test("Test deserialize", async () => {
   const chain = new LLMChain({ prompt, llm: model });
 
   const serialized = chain.serialize();
-  console.log(serialized);
+  // console.log(serialized)
   const chain2 = await LLMChain.deserialize({ ...serialized });
 
   const res = await chain2.run("my favorite color");
   console.log({ res });
+
+  // chain === chain2?
 });
-
-// {
-//   _type: 'llm_chain',
-//   prompt: {
-//     _type: 'prompt',
-//     input_variables: [ 'foo' ],
-//     output_parser: undefined,
-//     template: 'Print {foo}',
-//     template_format: 'f-string'
-//   }
-// }
-
-// {
-//   "memory": null,
-//   "verbose": false,
-//   "prompt": {
-//       "input_variables": [
-//           "topic"
-//       ],
-//       "output_parser": null,
-//       "template": "Tell me a joke about {topic}:",
-//       "template_format": "f-string",
-//       "_type": "prompt"
-//   },
-//   "llm": {
-//       "model_name": "text-davinci-003",
-//       "temperature": 0.9,
-//       "max_tokens": 256,
-//       "top_p": 1,
-//       "frequency_penalty": 0,
-//       "presence_penalty": 0,
-//       "n": 1,
-//       "best_of": 1,
-//       "request_timeout": null,
-//       "logit_bias": {},
-//       "_type": "openai"
-//   },
-//   "output_key": "text",
-//   "_type": "llm_chain"
-// }

--- a/langchain/src/chains/vector_db_qa.ts
+++ b/langchain/src/chains/vector_db_qa.ts
@@ -1,7 +1,8 @@
 import { BaseChain } from "./base.js";
 import { VectorStore } from "../vectorstores/base.js";
-import { BaseLLM } from "../llms/index.js";
 import { SerializedBaseChain, SerializedVectorDBQAChain } from "./serde.js";
+import { BaseLanguageModel } from "../base_language/index.js";
+
 import { resolveConfigFromFile } from "../util/index.js";
 import { ChainValues } from "../schema/index.js";
 import { loadQAStuffChain } from "./question_answering/load.js";
@@ -107,7 +108,7 @@ export class VectorDBQAChain extends BaseChain implements VectorDBQAChainInput {
   }
 
   static fromLLM(
-    llm: BaseLLM,
+    llm: BaseLanguageModel,
     vectorstore: VectorStore,
     options?: Partial<
       Omit<VectorDBQAChainInput, "combineDocumentsChain" | "vectorstore">

--- a/langchain/src/chat_models/base.ts
+++ b/langchain/src/chat_models/base.ts
@@ -66,37 +66,11 @@ export abstract class BaseChatModel extends BaseLanguageModel {
     return output;
   }
 
-  /**
-   * Get the identifying parameters of the LLM.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _identifyingParams(): Record<string, any> {
-    return {};
-  }
-
   _modelType(): string {
     return "base_chat_model" as const;
   }
 
   abstract _llmType(): string;
-
-  /**
-   * Return a json-like object representing this Chat model.
-   */
-  serialize(): SerializedChatModel {
-    return {
-      ...this._identifyingParams(),
-      _type: this._llmType(),
-      _model: this._modelType(),
-    };
-  }
-
-  /**
-   * Load an LLM from a json-like object describing it.
-   */
-  static async deserialize(_data: SerializedLLM): Promise<BaseLanguageModel> {
-    throw new Error("Not implemented");
-  }
 
   private _tokenizer?: GPT3Tokenizer.default;
 

--- a/langchain/src/chat_models/base.ts
+++ b/langchain/src/chat_models/base.ts
@@ -19,6 +19,13 @@ export type SerializedChatModel = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } & Record<string, any>;
 
+// todo?
+export type SerializedLLM = {
+  _model: string;
+  _type: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} & Record<string, any>;
+
 export type BaseChatModelParams = BaseLanguageModelParams;
 
 export abstract class BaseChatModel extends BaseLanguageModel {
@@ -84,7 +91,12 @@ export abstract class BaseChatModel extends BaseLanguageModel {
     };
   }
 
-  // TODO deserialize
+  /**
+   * Load an LLM from a json-like object describing it.
+   */
+  static async deserialize(_data: SerializedLLM): Promise<BaseLanguageModel> {
+    throw new Error("Not implemented");
+  }
 
   private _tokenizer?: GPT3Tokenizer.default;
 

--- a/langchain/src/llms/load.ts
+++ b/langchain/src/llms/load.ts
@@ -11,7 +11,7 @@ import { BaseLanguageModel } from "../base_language/index.js";
  * ```
  */
 const loader: FileLoader<BaseLanguageModel> = (file: string, path: string) =>
-BaseLanguageModel.deserialize(parseFileConfig(file, path));
+  BaseLanguageModel.deserialize(parseFileConfig(file, path));
 
 export const loadLLM = (uri: string): Promise<BaseLanguageModel> =>
   loadFromFile(uri, loader);

--- a/langchain/src/llms/load.ts
+++ b/langchain/src/llms/load.ts
@@ -1,5 +1,5 @@
-import { BaseLLM } from "./base.js";
 import { FileLoader, loadFromFile, parseFileConfig } from "../util/index.js";
+import { BaseLanguageModel } from "../base_language/index.js";
 
 /**
  * Load an LLM from a local file.
@@ -10,8 +10,8 @@ import { FileLoader, loadFromFile, parseFileConfig } from "../util/index.js";
  * const model = await loadLLM("/path/to/llm.json");
  * ```
  */
-const loader: FileLoader<BaseLLM> = (file: string, path: string) =>
-  BaseLLM.deserialize(parseFileConfig(file, path));
+const loader: FileLoader<BaseLanguageModel> = (file: string, path: string) =>
+BaseLanguageModel.deserialize(parseFileConfig(file, path));
 
-export const loadLLM = (uri: string): Promise<BaseLLM> =>
+export const loadLLM = (uri: string): Promise<BaseLanguageModel> =>
   loadFromFile(uri, loader);

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -39,6 +39,7 @@
     ],
     "entryPoints": [
       "src/agents/index.ts",
+      "src/base_language/index.ts",
       "src/agents/tools/index.ts",
       "src/chains/index.ts",
       "src/embeddings/index.ts",


### PR DESCRIPTION
This mostly does the chains.  I havent looked into agents yet. I know recent Prs are making a whole new class for agent for the new model anyway..

I looked around the python I dont think ser/de is done there either so not sure of the format or if it needs to be supported in order to merge this.

But tests pass and the touched examples run with either model. I dont know if its time to default examples into the ChatOpenAI class yet?

I have not tested the langchain/base_language export as my typescript tooling is poor these days, still working that out but this would seem to do it. 

