### PR TITLE
feat: add MarkdownTextSplitter

### DIFF
--- a/langchain/src/tests/text_splitter.test.ts
+++ b/langchain/src/tests/text_splitter.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@jest/globals";
 import { Document } from "../document.js";
 import {
   CharacterTextSplitter,
+  MarkdownTextSplitter,
   RecursiveCharacterTextSplitter,
   TokenTextSplitter,
 } from "../text_splitter.js";
@@ -149,5 +150,32 @@ test("Token text splitter", async () => {
   const output = await splitter.splitText(text);
   const expectedOutput = ["foo bar b", "az a a"];
 
+  expect(output).toEqual(expectedOutput);
+});
+
+test("Test markdown text splitter.", async () => {
+  const text =
+    "# 🦜️🔗 LangChain\n" +
+    "\n" +
+    "⚡ Building applications with LLMs through composability ⚡\n" +
+    "\n" +
+    "## Quick Install\n" +
+    "\n" +
+    "```bash\n" +
+    "# Hopefully this code block isn't split\n" +
+    "pip install langchain\n" +
+    "```\n" +
+    "\n" +
+    "As an open source project in a rapidly developing field, we are extremely open to contributions.";
+  const splitter = new MarkdownTextSplitter({
+    chunkSize: 100,
+    chunkOverlap: 0,
+  });
+  const output = await splitter.splitText(text);
+  const expectedOutput = [
+    "# 🦜️🔗 LangChain\n\n⚡ Building applications with LLMs through composability ⚡",
+    "Quick Install\n\n```bash\n# Hopefully this code block isn't split\npip install langchain",
+    "As an open source project in a rapidly developing field, we are extremely open to contributions.",
+  ];
   expect(output).toEqual(expectedOutput);
 });

--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -254,3 +254,38 @@ export class TokenTextSplitter
     }
   }
 }
+
+export type MarkdownTextSplitterParams = TextSplitterParams;
+
+export class MarkdownTextSplitter
+  extends RecursiveCharacterTextSplitter
+  implements MarkdownTextSplitterParams
+{
+  separators: string[] = [
+    // First, try to split along Markdown headings (starting with level 2)
+    "\n## ",
+    "\n### ",
+    "\n#### ",
+    "\n##### ",
+    "\n###### ",
+    // Note the alternative syntax for headings (below) is not handled here
+    // Heading level 2
+    // ---------------
+    // End of code block
+    "```\n\n",
+    // Horizontal lines
+    "\n\n***\n\n",
+    "\n\n---\n\n",
+    "\n\n___\n\n",
+    // Note that this splitter doesn't handle horizontal lines defined
+    // by *three or more* of ***, ---, or ___, but this is not handled
+    "\n\n",
+    "\n",
+    " ",
+    "",
+  ];
+
+  constructor(fields?: Partial<MarkdownTextSplitterParams>) {
+    super(fields);
+  }
+}


### PR DESCRIPTION
## Summary


This PR adds a feature called `MarkdownTextSplitter` which is equal to the [Markdown Text Splitter in Python](https://langchain.readthedocs.io/en/latest/modules/indexes/examples/textsplitter.html#markdown-text-splitter).
## Relevant PR

https://github.com/hwchase17/langchain/pull/1169.