### PR TITLE
agent: allow not to set stop

### DIFF
--- a/langchain/src/agents/agent.ts
+++ b/langchain/src/agents/agent.ts
@@ -148,8 +148,12 @@ export abstract class Agent {
     const newInputs: ChainValues = {
       ...inputs,
       agent_scratchpad: suffix ? `${thoughts}${suffix}` : thoughts,
-      stop: this._stop(),
     };
+
+    if (this._stop().length !== 0) {
+      newInputs.stop = this._stop();
+    }
+
     const output = await this.llmChain.predict(newInputs);
     const parsed = this.extractToolAndInput(output);
     if (!parsed) {


### PR DESCRIPTION
Im working with only returning json blob, and parsing it entirely as json in the agent. 
```
export const PREFIX = `You have access to the following actions:`
export const FORMAT_INSTRUCTIONS = `You MUST only respond only via a JSON array of Action or Response type objects defined below. You may use mulitple Action objects, but only ever one Response object. If you do not need to use an Action, the last element in the array MUST be a Response type object.
\`\`\`
type Action = {{
// you should always think about which action to take
  thought: string
  // the action from the list above to take
  action: string
  // the valid input to the action 
  action_input: string
  // the resulting observation
  observation: string
}}
type Response = {{
// think about how to answer the original Question with the information available
  thought: string
  // your final response to the question field
  output: string
}}
\`\`\``
```

For this its far easier if I dont use the stop, but I cant get it done from outside the agent class currently