### PR TITLE
json based convo agent - for discussion

### DIFF
--- a/examples/src/agents/chat_convo.ts
+++ b/examples/src/agents/chat_convo.ts
@@ -1,0 +1,49 @@
+import {
+  Tool,
+  ChatConversationalAgent2,
+  AgentExecutor,
+} from "langchain/agents";
+import { CallbackManager } from "langchain/callbacks";
+import { ChatOpenAI } from "langchain/chat_models";
+import { LLMResult } from "langchain/schema";
+import { SerpAPI, Calculator } from "langchain/tools";
+
+export const run = async () => {
+  const callbackManager = CallbackManager.fromHandlers({
+    async handleLLMStart(_llm: { name: string }, prompts: string[]) {
+      console.log(JSON.stringify(prompts, null, 2));
+    },
+    async handleLLMEnd(output: LLMResult) {
+      for (const generation of output.generations) {
+        for (const gen of generation) {
+          console.log(gen.text);
+        }
+      }
+    },
+  });
+
+  const model = new ChatOpenAI({
+    temperature: 0,
+    callbackManager,
+  });
+
+  const tools: Tool[] = [new SerpAPI(), new Calculator()];
+
+  const executor = AgentExecutor.fromAgentAndTools({
+    agent: ChatConversationalAgent2.fromLLMAndTools(model, tools),
+    tools,
+    returnIntermediateSteps: true,
+  });
+
+  const input = `Who is Olivia Wilde's boyfriend and what is his current age raised to the 0.23 power?`;
+  const res = await executor.call({
+    input,
+    chat_history: [],
+  });
+
+  console.log(`Got output ${res.output}`);
+
+  console.log(
+    `Got intermediate steps ${JSON.stringify(res.intermediateSteps, null, 2)}`
+  );
+};

--- a/langchain/src/agents/chat_convo2/index.ts
+++ b/langchain/src/agents/chat_convo2/index.ts
@@ -1,0 +1,176 @@
+import { LLMChain } from "../../chains/index.js";
+import { Agent, Tool, AgentInput } from "../index.js";
+import {
+  SystemMessagePromptTemplate,
+  HumanMessagePromptTemplate,
+  ChatPromptTemplate,
+  MessagesPlaceholder,
+} from "../../prompts/index.js";
+import { interpolateFString } from "../../prompts/template.js";
+import { PREFIX, SUFFIX, FORMAT_INSTRUCTIONS } from "./prompt.js";
+import { BaseLanguageModel } from "../../base_language/index.js";
+import {
+  AgentStep,
+  BaseChatMessage,
+  AIChatMessage,
+} from "../../schema/index.js";
+import { BaseOutputParser } from "../../output_parsers/base.js";
+import { SerializedOutputParser } from "../../output_parsers/serde.js";
+
+// presumably pointless to be a seperate parser class
+export class AgentOputputParser extends BaseOutputParser {
+  parse(text: string): unknown {
+    return JSON.parse(text.trim());
+  }
+
+  getFormatInstructions(): string {
+    return FORMAT_INSTRUCTIONS;
+  }
+
+  serialize(): SerializedOutputParser {
+    throw new Error("Method not implemented.");
+  }
+}
+
+export type CreatePromptArgs = {
+  /** String to put after the list of tools. */
+  systemMessage?: string;
+  /** String to put before the list of tools. */
+  humanMessage?: string;
+  /** List of input variables the final prompt will expect. */
+  inputVariables?: string[];
+  /** Output parser to use for formatting. */
+  outputParser?: BaseOutputParser;
+};
+
+type ZeroShotAgentInput = AgentInput;
+
+/**
+ * Agent for the MRKL chain.
+ * @augments Agent
+ */
+export class ChatConversationalAgent2 extends Agent {
+  outputParser: BaseOutputParser;
+
+  constructor(input: ZeroShotAgentInput, outputParser: BaseOutputParser) {
+    super(input);
+    this.outputParser = outputParser;
+  }
+
+  _agentType(): string {
+    /** Not turning on serialization until more sure of abstractions. */
+    throw new Error("Method not implemented.");
+  }
+
+  llmPrefix() {
+    return `{  "thought": "`;
+  }
+
+  jsonPrefix() {
+    return `[\n${this.llmPrefix()}`;
+  }
+
+  finishToolName(): string {
+    return "Finished";
+  }
+
+  // empty because were not stopping
+  observationPrefix() {
+    return "";
+  }
+
+  // empty we dont want to stop so we can parse the entire response as an object
+  // needs a hack in agent.ts to bypass when empty
+  _stop(): string[] {
+    return [];
+  }
+
+  static validateTools(tools: Tool[]) {
+    const invalidTool = tools.find((tool) => !tool.description);
+    if (invalidTool) {
+      const msg =
+        `Got a tool ${invalidTool.name} without a description.` +
+        ` This agent requires descriptions for all tools.`;
+      throw new Error(msg);
+    }
+  }
+
+  constructScratchPad(steps: AgentStep[]): string | BaseChatMessage[] {
+    if (steps.length === 0) {
+      return [new AIChatMessage(this.jsonPrefix())];
+    }
+
+    const toolsText = steps.reduce((thoughts, { action, observation }) => {
+      const tools = JSON.parse(this.jsonPrefix() + action.log);
+      const tool = tools[0];
+      tool.observation = observation;
+      const val = [JSON.stringify(tool), this.llmPrefix()].join(",\n");
+      return thoughts + val;
+    }, "[");
+
+    return [new AIChatMessage(toolsText)];
+  }
+
+  /**
+   * Create prompt in the style of the zero shot agent.
+   *
+   * @param tools - List of tools the agent will have access to, used to format the prompt.
+   * @param args - Arguments to create the prompt with.
+   * @param args.suffix - String to put after the list of tools.
+   * @param args.prefix - String to put before the list of tools.
+   */
+  static createPrompt(tools: Tool[], args?: CreatePromptArgs) {
+    const {
+      systemMessage = PREFIX,
+      humanMessage = SUFFIX,
+      outputParser = new AgentOputputParser(),
+    } = args ?? {};
+    const toolStrings = tools
+      .map((tool) => `${tool.name}: ${tool.description}`)
+      .join("\n");
+    const formatInstructions = interpolateFString(humanMessage, {
+      format_instructions: outputParser.getFormatInstructions(),
+    });
+
+    const toolNames = tools.map((tool) => tool.name).join("\n");
+    const finalPrompt = interpolateFString(formatInstructions, {
+      tools: toolStrings,
+      tool_names: toolNames,
+    });
+    const messages = [
+      SystemMessagePromptTemplate.fromTemplate(systemMessage),
+      new MessagesPlaceholder("chat_history"),
+      HumanMessagePromptTemplate.fromTemplate(finalPrompt),
+      new MessagesPlaceholder("agent_scratchpad"),
+    ];
+    return ChatPromptTemplate.fromPromptMessages(messages);
+  }
+
+  static fromLLMAndTools(
+    llm: BaseLanguageModel,
+    tools: Tool[],
+    args?: CreatePromptArgs
+  ) {
+    ChatConversationalAgent2.validateTools(tools);
+    const prompt = ChatConversationalAgent2.createPrompt(tools, args);
+    const chain = new LLMChain({ prompt, llm });
+    const { outputParser = new AgentOputputParser() } = args ?? {};
+    return new ChatConversationalAgent2(
+      {
+        llmChain: chain,
+        allowedTools: tools.map((t) => t.name),
+      },
+      outputParser
+    );
+  }
+
+  extractToolAndInput(text: string): { tool: string; input: string } | null {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const actions = this.outputParser.parse(this.jsonPrefix() + text) as any[];
+    if ("output" in actions[0]) {
+      return { tool: this.finishToolName(), input: actions[0].output };
+    }
+
+    return { tool: actions[0].action, input: actions[0].action_input };
+  }
+}

--- a/langchain/src/agents/chat_convo2/index.ts
+++ b/langchain/src/agents/chat_convo2/index.ts
@@ -1,5 +1,5 @@
 import { LLMChain } from "../../chains/index.js";
-import { Agent, Tool, AgentInput } from "../index.js";
+import { Agent } from "../agent.js";
 import {
   SystemMessagePromptTemplate,
   HumanMessagePromptTemplate,
@@ -16,6 +16,8 @@ import {
 } from "../../schema/index.js";
 import { BaseOutputParser } from "../../output_parsers/base.js";
 import { SerializedOutputParser } from "../../output_parsers/serde.js";
+import { AgentInput } from "../types.js";
+import { Tool } from "../tools/base.js";
 
 // presumably pointless to be a seperate parser class
 export class AgentOputputParser extends BaseOutputParser {

--- a/langchain/src/agents/chat_convo2/prompt.ts
+++ b/langchain/src/agents/chat_convo2/prompt.ts
@@ -1,0 +1,33 @@
+export const PREFIX = `Assistant is a large language model trained by OpenAI.
+
+Assistant is designed to be able to assist with a wide range of tasks, from answering simple questions to providing in-depth explanations and discussions on a wide range of topics. As a language model, Assistant is able to generate human-like text based on the input it receives, allowing it to engage in natural-sounding conversations and provide responses that are coherent and relevant to the topic at hand.
+
+Assistant is constantly learning and improving, and its capabilities are constantly evolving. It is able to process and understand large amounts of text, and can use this knowledge to provide accurate and informative responses to a wide range of questions. Additionally, Assistant is able to generate its own text based on the input it receives, allowing it to engage in discussions and provide explanations and descriptions on a wide range of topics.
+
+Overall, Assistant is a powerful system that can help with a wide range of tasks and provide valuable insights and information on a wide range of topics. Whether you need help with a specific question or just want to have a conversation about a particular topic, Assistant is here to assist.`;
+
+export const FORMAT_INSTRUCTIONS = `You MUST only respond only via a JSON array of Action or Response type objects defined below. You may use mulitple Action objects, but only ever one Response object. If you do not need to use an Action, the last element in the array MUST be a Response type object.
+\`\`\`
+type Action = {{{{
+// you MUST provide a thought about which action to take
+  thought: string
+  // the action from the list above to take
+  action: string
+  // the valid input to the action 
+  action_input: string
+  // the resulting observation
+  observation: string
+}}}}
+type Response = {{{{
+// think about how to answer the original Question with the information available
+  thought: string
+  // your final response to the question field
+  output: string
+}}}}
+\`\`\``;
+export const SUFFIX = `You have access to the following actions:
+{{tools}}
+
+{format_instructions}
+
+Question: {{{{input}}}}`;

--- a/langchain/src/agents/index.ts
+++ b/langchain/src/agents/index.ts
@@ -8,6 +8,7 @@ export {
 export { Agent } from "./agent.js";
 export { AgentExecutor } from "./executor.js";
 export { ZeroShotAgent } from "./mrkl/index.js";
+export { ChatConversationalAgent2 } from "./chat_convo2/index.js";
 export { ChatAgent } from "./chat/index.js";
 export { ChatConversationalAgent } from "./chat_convo/index.js";
 export { Tool } from "./tools/index.js";


### PR DESCRIPTION
This is a json based convo fork ive been playing with. It takes json only from chatgpt, defining its api via typescript examples. This is less token verbose and ive found it to be more reliable than the upstream one as constraining to a json array for actions really seems to give it less ways to screw up

I think the COT prompting with thought: is really necessary, and with the current agent interface its pretty ackwardly written. Not particularly extendable. 

Its a bit slower, because I dont use the stop, so it has to receive all the tokens. Maybe theres a way to reliably detect like the comma between two objects

For discussion, maybe someone has a way to clean it up or just abandon the idea that its extendable

~All the other commits are just Prs I needed to build this on top of out of tree, just the last commit is the agent when everything else clears.~
related to my request in https://github.com/hwchase17/langchainjs/pull/349
