### PR TITLE
Use OpenAIChat class to initialize gpt-4 models

### DIFF
--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -141,7 +141,10 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
       },
     configuration?: ConfigurationParameters
   ) {
-    if (fields?.modelName?.startsWith("gpt-3.5-turbo") || fields?.modelName?.startsWith("gpt-4")) {
+    if (
+      fields?.modelName?.startsWith("gpt-3.5-turbo") ||
+      fields?.modelName?.startsWith("gpt-4")
+    ) {
       // eslint-disable-next-line no-constructor-return, @typescript-eslint/no-explicit-any
       return new OpenAIChat(fields, configuration) as any as OpenAI;
     }

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -141,7 +141,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
       },
     configuration?: ConfigurationParameters
   ) {
-    if (fields?.modelName?.startsWith("gpt-3.5-turbo")) {
+    if (fields?.modelName?.startsWith("gpt-3.5-turbo") || fields?.modelName?.startsWith("gpt-4")) {
       // eslint-disable-next-line no-constructor-return, @typescript-eslint/no-explicit-any
       return new OpenAIChat(fields, configuration) as any as OpenAI;
     }


### PR DESCRIPTION
GPT-4 is classified the same way as GPT-3.5, and uses the `v1/chat/completions` endpoint rather than the `v1/completions` endpoint.