### PR TITLE
Update `memory.ts` example to explicitly set `memoryKey`

### DIFF
--- a/examples/src/chat/memory.ts
+++ b/examples/src/chat/memory.ts
@@ -20,7 +20,7 @@ export const run = async () => {
   ]);
 
   const chain = new ConversationChain({
-    memory: new BufferMemory({ returnMessages: true }),
+    memory: new BufferMemory({ returnMessages: true, memoryKey: "history" }),
     prompt: chatPrompt,
     llm: chat,
   });


### PR DESCRIPTION
I know that `BufferMemory` uses a default `memoryKey = "history"`, but for the [example Chat Memory docs](https://hwchase17.github.io/langchainjs/docs/modules/chat_models/examples/memory) I think it'd be useful to explicitly show the `memoryKey` being set, like is done in the [Chat Overview](https://hwchase17.github.io/langchainjs/docs/modules/chat_models/overview#stateful-chains) section.