### PR TITLE
Add ability to create child callback managers

### DIFF
--- a/examples/src/agents/mrkl_with_tracing.ts
+++ b/examples/src/agents/mrkl_with_tracing.ts
@@ -1,10 +1,9 @@
 import { OpenAI } from "langchain";
 import { initializeAgentExecutor } from "langchain/agents";
 import { SerpAPI, Calculator } from "langchain/tools";
-import process from "process";
+import {getTracingCallbackManager} from "langchain/callbacks";
 
 export const run = async () => {
-  process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new OpenAI({ temperature: 0 });
   const tools = [new SerpAPI(), new Calculator()];
 
@@ -20,7 +19,7 @@ export const run = async () => {
 
   console.log(`Executing with input "${input}"...`);
 
-  const result = await executor.call({ input });
+  const result = await executor.call({ input }, getTracingCallbackManager());
 
   console.log(`Got output ${result.output}`);
 };

--- a/langchain/src/agents/executor.ts
+++ b/langchain/src/agents/executor.ts
@@ -92,7 +92,7 @@ export class AgentExecutor extends BaseChain {
     };
 
     while (this.shouldContinue(iterations)) {
-      const action = await this.agent.plan(steps, inputs, callbackManager);
+      const action = await this.agent.plan(steps, inputs, callbackManager?.getChild());
       if ("returnValues" in action) {
         return getOutput(action);
       }
@@ -104,7 +104,7 @@ export class AgentExecutor extends BaseChain {
 
       const tool = toolsByName[action.tool.toLowerCase()];
       const observation = tool
-        ? await tool.call(action.toolInput, this.verbose, callbackManager)
+        ? await tool.call(action.toolInput, this.verbose, callbackManager?.getChild())
         : `${action.tool} is not a valid tool, try another one.`;
       steps.push({ action, observation });
       if (tool?.returnDirect) {

--- a/langchain/src/callbacks/base.ts
+++ b/langchain/src/callbacks/base.ts
@@ -170,7 +170,13 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMStart?.(llm, prompts, runId, undefined, this._parentRunId);
+            await handler.handleLLMStart?.(
+              llm,
+              prompts,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMStart: ${err}`
@@ -192,7 +198,12 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMNewToken?.(token, runId, undefined, this._parentRunId);
+            await handler.handleLLMNewToken?.(
+              token,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMNewToken: ${err}`
@@ -212,7 +223,12 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMError?.(err, runId, undefined, this._parentRunId);
+            await handler.handleLLMError?.(
+              err,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMError: ${err}`
@@ -232,7 +248,12 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMEnd?.(output, runId, undefined, this._parentRunId);
+            await handler.handleLLMEnd?.(
+              output,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMEnd: ${err}`
@@ -253,7 +274,13 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleChainStart?.(chain, inputs, runId, undefined, this._parentRunId);
+            await handler.handleChainStart?.(
+              chain,
+              inputs,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleChainStart: ${err}`
@@ -275,7 +302,12 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleChainError?.(err, runId, undefined, this._parentRunId);
+            await handler.handleChainError?.(
+              err,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleChainError: ${err}`
@@ -295,7 +327,12 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleChainEnd?.(output, runId, undefined, this._parentRunId);
+            await handler.handleChainEnd?.(
+              output,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleChainEnd: ${err}`
@@ -316,7 +353,13 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleToolStart?.(tool, input, runId, undefined, this._parentRunId);
+            await handler.handleToolStart?.(
+              tool,
+              input,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleToolStart: ${err}`
@@ -338,7 +381,12 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleToolError?.(err, runId, undefined, this._parentRunId);
+            await handler.handleToolError?.(
+              err,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleToolError: ${err}`
@@ -378,7 +426,12 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (verbose || handler.alwaysVerbose) {
           try {
-            await handler.handleText?.(text, runId, undefined, this._parentRunId);
+            await handler.handleText?.(
+              text,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleText: ${err}`
@@ -398,7 +451,12 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleAgentAction?.(action, runId, undefined, this._parentRunId);
+            await handler.handleAgentAction?.(
+              action,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleAgentAction: ${err}`
@@ -418,7 +476,12 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleAgentEnd?.(action, runId, undefined, this._parentRunId);
+            await handler.handleAgentEnd?.(
+              action,
+              runId,
+              undefined,
+              this._parentRunId
+            );
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleAgentEnd: ${err}`

--- a/langchain/src/callbacks/base.ts
+++ b/langchain/src/callbacks/base.ts
@@ -21,69 +21,94 @@ abstract class BaseCallbackHandlerMethods {
     llm: { name: string },
     prompts: string[],
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void | string>;
 
   handleLLMNewToken?(
     token: string,
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void>;
 
-  handleLLMError?(err: Error, runId: string, verbose?: boolean): Promise<void>;
+  handleLLMError?(
+    err: Error,
+    runId: string,
+    verbose?: boolean,
+    parentRunId?: string
+  ): Promise<void>;
 
   handleLLMEnd?(
     output: LLMResult,
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void>;
 
   handleChainStart?(
     chain: { name: string },
     inputs: ChainValues,
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void | string>;
 
   handleChainError?(
     err: Error,
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void>;
 
   handleChainEnd?(
     outputs: ChainValues,
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void>;
 
   handleToolStart?(
     tool: { name: string },
     input: string,
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void | string>;
 
-  handleToolError?(err: Error, runId: string, verbose?: boolean): Promise<void>;
+  handleToolError?(
+    err: Error,
+    runId: string,
+    verbose?: boolean,
+    parentRunId?: string
+  ): Promise<void>;
 
   handleToolEnd?(
     output: string,
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void>;
 
-  handleText?(text: string, runId: string, verbose?: boolean): Promise<void>;
+  handleText?(
+    text: string,
+    runId: string,
+    verbose?: boolean,
+    parentRunId?: string
+  ): Promise<void>;
 
   handleAgentAction?(
     action: AgentAction,
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void>;
 
   handleAgentEnd?(
     action: AgentFinish,
     runId: string,
-    verbose?: boolean
+    verbose?: boolean,
+    parentRunId?: string
   ): Promise<void>;
 }
 
@@ -125,9 +150,14 @@ export abstract class BaseCallbackManager extends BaseCallbackHandler {
 export class CallbackManager extends BaseCallbackManager {
   handlers: BaseCallbackHandler[];
 
-  constructor() {
+  private _currentRunId?: string;
+
+  private readonly _parentRunId?: string;
+
+  constructor(parentRunId?: string) {
     super();
     this.handlers = [];
+    this._parentRunId = parentRunId;
   }
 
   async handleLLMStart(
@@ -140,7 +170,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMStart?.(llm, prompts, runId);
+            await handler.handleLLMStart?.(llm, prompts, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMStart: ${err}`
@@ -149,6 +179,7 @@ export class CallbackManager extends BaseCallbackManager {
         }
       })
     );
+    this._currentRunId = runId;
     return runId;
   }
 
@@ -161,7 +192,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMNewToken?.(token, runId);
+            await handler.handleLLMNewToken?.(token, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMNewToken: ${err}`
@@ -181,7 +212,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMError?.(err, runId);
+            await handler.handleLLMError?.(err, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMError: ${err}`
@@ -201,7 +232,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleLLMEnd?.(output, runId);
+            await handler.handleLLMEnd?.(output, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMEnd: ${err}`
@@ -222,7 +253,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleChainStart?.(chain, inputs, runId);
+            await handler.handleChainStart?.(chain, inputs, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleChainStart: ${err}`
@@ -231,6 +262,7 @@ export class CallbackManager extends BaseCallbackManager {
         }
       })
     );
+    this._currentRunId = runId;
     return runId;
   }
 
@@ -243,7 +275,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleChainError?.(err, runId);
+            await handler.handleChainError?.(err, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleChainError: ${err}`
@@ -263,7 +295,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreChain && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleChainEnd?.(output, runId);
+            await handler.handleChainEnd?.(output, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleChainEnd: ${err}`
@@ -284,7 +316,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleToolStart?.(tool, input, runId);
+            await handler.handleToolStart?.(tool, input, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleToolStart: ${err}`
@@ -293,6 +325,7 @@ export class CallbackManager extends BaseCallbackManager {
         }
       })
     );
+    this._currentRunId = runId;
     return runId;
   }
 
@@ -305,7 +338,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleToolError?.(err, runId);
+            await handler.handleToolError?.(err, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleToolError: ${err}`
@@ -345,7 +378,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (verbose || handler.alwaysVerbose) {
           try {
-            await handler.handleText?.(text, runId);
+            await handler.handleText?.(text, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleText: ${err}`
@@ -365,7 +398,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleAgentAction?.(action, runId);
+            await handler.handleAgentAction?.(action, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleAgentAction: ${err}`
@@ -385,7 +418,7 @@ export class CallbackManager extends BaseCallbackManager {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreAgent && (verbose || handler.alwaysVerbose)) {
           try {
-            await handler.handleAgentEnd?.(action, runId);
+            await handler.handleAgentEnd?.(action, runId, undefined, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleAgentEnd: ${err}`
@@ -406,6 +439,12 @@ export class CallbackManager extends BaseCallbackManager {
 
   setHandlers(handlers: BaseCallbackHandler[]): void {
     this.handlers = handlers;
+  }
+
+  getChild(): CallbackManager {
+    const manager = new CallbackManager(this._currentRunId);
+    manager.setHandlers(this.handlers);
+    return manager;
   }
 
   static fromHandlers(handlers: BaseCallbackHandlerMethods) {

--- a/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
+++ b/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
@@ -12,14 +12,31 @@ test("Test LangChain tracer", async () => {
   const chainRunId = uuidv4();
   const toolRunId = uuidv4();
   const llmRunId = uuidv4();
-
   await tracer.handleChainStart({ name: "test" }, { foo: "bar" }, chainRunId);
-  await tracer.handleToolStart({ name: "test" }, "test", toolRunId);
-  await tracer.handleLLMStart({ name: "test" }, ["test"], llmRunId);
+  await tracer.handleToolStart(
+    { name: "test" },
+    "test",
+    toolRunId,
+    undefined,
+    chainRunId
+  );
+  await tracer.handleLLMStart(
+    { name: "test" },
+    ["test"],
+    llmRunId,
+    undefined,
+    toolRunId
+  );
   await tracer.handleLLMEnd({ generations: [[]] }, llmRunId);
   await tracer.handleToolEnd("output", toolRunId);
   const llmRunId2 = uuidv4();
-  await tracer.handleLLMStart({ name: "test2" }, ["test"], llmRunId2);
+  await tracer.handleLLMStart(
+    { name: "test2" },
+    ["test"],
+    llmRunId2,
+    undefined,
+    chainRunId
+  );
   await tracer.handleLLMEnd({ generations: [[]] }, llmRunId2);
   await tracer.handleChainEnd({ foo: "bar" }, chainRunId);
 

--- a/langchain/src/chains/llm_chain.ts
+++ b/langchain/src/chains/llm_chain.ts
@@ -69,7 +69,7 @@ export class LLMChain extends BaseChain implements LLMChainInput {
     const { generations } = await this.llm.generatePrompt(
       [promptValue],
       stop,
-      callbackManager
+      callbackManager?.getChild()
     );
     return { [this.outputKey]: generations[0][0].text };
   }


### PR DESCRIPTION
We need to get rid of the tracer's stack and, instead, explicitly assign the parent uuid for a specific run. This is because, in the middle of a run, we could spawn multiple concurrent child runs (this would be the case with multi-output agents, in each step, we could spawn multiple tool runs concurrently).

To avoid having to pass the parent run id to each call of the callback manager, we can wrap this with a child callback manager. The child callback manager would get a parentRunId from the parent callback manager and pass it through to the callbacks.

