### PR TITLE
fix: agent json parser fails with text in suffix

### DIFF
--- a/langchain/src/agents/chat_convo/index.ts
+++ b/langchain/src/agents/chat_convo/index.ts
@@ -27,16 +27,18 @@ import { Tool } from "../tools/base.js";
 
 export class ChatConversationalAgentOutputParser extends BaseOutputParser {
   parse(text: string): unknown {
-    const cleanedOutput = text.trim();
-    let jsonOutput = cleanedOutput;
+    let jsonOutput = text.trim();
     if (jsonOutput.includes("```json")) {
-      jsonOutput = jsonOutput.split("```json")[1].trimLeft();
+      jsonOutput = jsonOutput.split("```json")[1].trimStart();
+    }
+    if (jsonOutput.includes("```")) {
+      jsonOutput = jsonOutput.split("```")[0].trimEnd();
     }
     if (jsonOutput.startsWith("```")) {
-      jsonOutput = jsonOutput.slice(3).trimLeft();
+      jsonOutput = jsonOutput.slice(3).trimStart();
     }
     if (jsonOutput.endsWith("```")) {
-      jsonOutput = jsonOutput.slice(0, -3).trimRight();
+      jsonOutput = jsonOutput.slice(0, -3).trimEnd();
     }
     const response = JSON.parse(jsonOutput);
     return { action: response.action, action_input: response.action_input };


### PR DESCRIPTION
This issue is the same as https://github.com/hwchase17/langchain/pull/1734

<code>/Git/chatbot-llm-ecommerce/node_modules/langchain/dist/agents/chat_convo/index.js:122
            throw new Error(`Unable to parse JSON response from chat agent.\n\n${text}`);
                  ^
[Error: Unable to parse JSON response from chat agent.
My apologies for the confusion. Here are some pots that are available in the store:
```json
{
    "action": "Product Info",
    "action_input": "pots"
}
``` 
The items with the IDs clay-plant-pot, white-ceramic-pot, and biodegradable-cardboard-pots are all pots.]
</code>

i.e. The response had a text before & after the expected JSON, leading to JSONDecodeError. It's fixed now, by removing text after '```' to remove unwanted text.

Code to reproduce [here](https://github.com/anselm94/chatbot-llm-ecommerce)