### PR TITLE
Update zapier.ts to handle errors in return JSON object

### DIFF
--- a/langchain/src/agents/tools/zapier.ts
+++ b/langchain/src/agents/tools/zapier.ts
@@ -63,7 +63,16 @@ export class ZapierNLAWrapper {
         `Failed to execute action ${actionId} with instructions ${instructions}`
       );
     }
-    return resp.json();
+
+    // Get the JSON response as usual
+    const jsonResponse = await resp.json();
+
+    // Check if there's an error property in the JSON response
+    if (jsonResponse.error) {
+      throw new Error(`Error from Zapier: ${jsonResponse.error}`);
+    }
+
+    return jsonResponse;
   }
 
   /**


### PR DESCRIPTION
Hey @GautierT this should fix the error you described in #386 

Zapier errors are not always defined by a non 2XX status code, but instead Zapier can return an object with an error key.

Co-authored by [bloop](https://bloop.ai/).