### PR TITLE
Fix: Pinecone upsert errors due to large size

### DIFF
--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -47,20 +47,26 @@ export class PineconeStore extends VectorStore {
     ids?: string[]
   ): Promise<void> {
     const documentIds = ids == null ? documents.map(() => uuidv4()) : ids;
-
-    await this.pineconeIndex.upsert({
-      upsertRequest: {
-        vectors: vectors.map((values, idx) => ({
-          id: documentIds[idx],
-          metadata: {
-            ...documents[idx].metadata,
-            [this.textKey]: documents[idx].pageContent,
-          },
-          values,
-        })),
-        namespace: this.namespace,
+    const pineconeVectors = vectors.map((values, idx) => ({
+      id: documentIds[idx],
+      metadata: {
+        ...documents[idx].metadata,
+        [this.textKey]: documents[idx].pageContent,
       },
-    });
+      values,
+    }));
+
+    // Pinecone recommends a limit of 100 vectors per upsert request
+    const chunkSize = 50;
+    for (let i = 0; i < pineconeVectors.length; i += chunkSize) {
+      const chunk = pineconeVectors.slice(i, i + chunkSize);
+      await this.pineconeIndex.upsert({
+        upsertRequest: {
+          vectors: chunk,
+          namespace: this.namespace,
+        },
+      });
+    }
   }
 
   async similaritySearchVectorWithScore(


### PR DESCRIPTION
@nfcampos as discussed, users are frequently complaining about upsert errors whilst using LangChain alongside Pinecone. The main culprit is that Pinecone has a max size for an upsert request at 2MB and a recommended upsert limit of 100 vectors per request as per the [docs](https://docs.pinecone.io/docs/limits#:~:text=Max%20size%20for%20an%20upsert,to%20queries%20immediately%20after%20upserting.)

The solution is simply to add logic that splits the vectors into chunks of approx. 50, before calling the upsert function for each chunk.

I've tested this locally and it works fine.