### PR TITLE
Fix: Missing 'await' keyword is most examples using the format function

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -84,7 +84,7 @@ const prompt = new PromptTemplate({
 Let's now see how this works! We can call the `.format` method to format it.
 
 ```typescript
-const res = prompt.format({ product: "colorful socks" });
+const res = await prompt.format({ product: "colorful socks" });
 console.log(res);
 ```
 

--- a/docs/docs/modules/prompts/few_shot_examples.md
+++ b/docs/docs/modules/prompts/few_shot_examples.md
@@ -39,6 +39,6 @@ const fewShotPrompt = new FewShotPromptTemplate({
   templateFormat: "f-string",
 });
 /*We can now generate a prompt using the `format` method.*/
-const res = fewShotPrompt.format({ input: "big" });
+const res = await fewShotPrompt.format({ input: "big" });
 console.log({ res });
 ```

--- a/docs/docs/modules/prompts/load_from_hub.md
+++ b/docs/docs/modules/prompts/load_from_hub.md
@@ -9,6 +9,6 @@ sidebar_position: 3
 ```typescript
 import { loadPrompt } from "langchain/prompts";
 const prompt = await loadPrompt("lc://prompts/hello-world/prompt.yaml");
-const res = prompt.format({});
+const res = await prompt.format({});
 console.log({ res });
 ```

--- a/docs/docs/modules/prompts/prompt_template.md
+++ b/docs/docs/modules/prompts/prompt_template.md
@@ -18,7 +18,7 @@ const prompt = new PromptTemplate({
 Let's now see how this works! We can call the `.format` method to format it.
 
 ```typescript
-const res = prompt.format({ product: "colorful socks" });
+const res = await prompt.format({ product: "colorful socks" });
 console.log({ res });
 ```
 

--- a/examples/src/prompts/load_from_hub.ts
+++ b/examples/src/prompts/load_from_hub.ts
@@ -2,6 +2,6 @@ import { loadPrompt } from "langchain/prompts";
 
 export const run = async () => {
   const prompt = await loadPrompt("lc://prompts/hello-world/prompt.yaml");
-  const res = prompt.format({});
+  const res = await prompt.format({});
   console.log({ res });
 };

--- a/examples/src/prompts/prompts.ts
+++ b/examples/src/prompts/prompts.ts
@@ -3,6 +3,6 @@ import { PromptTemplate } from "langchain/prompts";
 export const run = async () => {
   const template = "What is a good name for a company that makes {product}?";
   const prompt = new PromptTemplate({ template, inputVariables: ["product"] });
-  const res = prompt.format({ product: "colorful socks" });
+  const res = await prompt.format({ product: "colorful socks" });
   console.log({ res });
 };


### PR DESCRIPTION
Most examples and documentation using the format function i.e. `prompt.format` fail to return the promise because the `await` keyword is missing.

These changes fix these bugs across the repo. Example: `await prompt.format`