### PR TITLE
Fix process exit on `new OpenAI({concurrency: 1}).call('')`, Add AsyncCaller to BaseLanguageModel, Make all existing LLMs and Chat models use async caller to control concurrency and retries

### DIFF
--- a/examples/src/emb_openai_concurrency.ts
+++ b/examples/src/emb_openai_concurrency.ts
@@ -1,0 +1,12 @@
+import { OpenAIEmbeddings } from "langchain/embeddings";
+
+export const run = async () => {
+  const model = new OpenAIEmbeddings({
+    maxConcurrency: 1,
+  });
+  console.log("yooooo");
+  const res = await model.embedQuery(
+    "What would be a good company name a company that makes colorful socks?"
+  );
+  console.log("hello", { res });
+};

--- a/examples/src/llm_cohere_concurrency.ts
+++ b/examples/src/llm_cohere_concurrency.ts
@@ -1,0 +1,15 @@
+import { Cohere } from "langchain/llms";
+
+export const run = async () => {
+  const model = new Cohere({
+    temperature: 0.7,
+    verbose: true,
+    maxConcurrency: 1,
+    maxTokens: 20,
+    maxRetries: 5,
+  });
+  const res = await model.call(
+    "What would be a good company name a company that makes colorful socks?"
+  );
+  console.log("hello", { res });
+};

--- a/examples/src/llm_openai_concurrency.ts
+++ b/examples/src/llm_openai_concurrency.ts
@@ -1,0 +1,16 @@
+import { OpenAI } from "langchain/llms";
+
+export const run = async () => {
+  const model = new OpenAI({
+    modelName: "gpt-4",
+    temperature: 0.7,
+    verbose: true,
+    maxConcurrency: 1,
+    maxTokens: 1000,
+    maxRetries: 5,
+  });
+  const res = await model.call(
+    "What would be a good company name a company that makes colorful socks?"
+  );
+  console.log("hello", { res });
+};

--- a/langchain/src/base_language/index.ts
+++ b/langchain/src/base_language/index.ts
@@ -1,5 +1,6 @@
 import { BasePromptValue, LLMResult } from "../schema/index.js";
 import { CallbackManager, getCallbackManager } from "../callbacks/index.js";
+import { AsyncCaller, AsyncCallerParams } from "../util/async_caller.js";
 
 const getVerbosity = () => false;
 
@@ -14,7 +15,7 @@ export type SerializedLLM = {
  * A subclass of {@link BaseLanguageModel} should have a constructor that
  * takes in a parameter that extends this interface.
  */
-export interface BaseLanguageModelParams {
+export interface BaseLanguageModelParams extends AsyncCallerParams {
   verbose?: boolean;
   callbackManager?: CallbackManager;
 }
@@ -30,9 +31,16 @@ export abstract class BaseLanguageModel implements BaseLanguageModelParams {
 
   callbackManager: CallbackManager;
 
+  /**
+   * The async caller should be used by subclasses to make any async calls,
+   * which will thus benefit from the concurrency and retry logic.
+   */
+  protected caller: AsyncCaller;
+
   protected constructor(params: BaseLanguageModelParams) {
     this.verbose = params.verbose ?? getVerbosity();
     this.callbackManager = params.callbackManager ?? getCallbackManager();
+    this.caller = new AsyncCaller(params ?? {});
   }
 
   abstract generatePrompt(

--- a/langchain/src/llms/cohere.ts
+++ b/langchain/src/llms/cohere.ts
@@ -47,12 +47,15 @@ export class Cohere extends LLM implements CohereInput {
     cohere.init(this.apiKey);
 
     // Hit the `generate` endpoint on the `large` model
-    const generateResponse = await cohere.generate({
-      prompt,
-      model: this.model,
-      max_tokens: this.maxTokens,
-      temperature: this.temperature,
-    });
+    const generateResponse = await this.caller.call(
+      cohere.generate.bind(cohere),
+      {
+        prompt,
+        model: this.model,
+        max_tokens: this.maxTokens,
+        temperature: this.temperature,
+      }
+    );
     try {
       return generateResponse.body.generations[0].text;
     } catch {

--- a/langchain/src/llms/hf.ts
+++ b/langchain/src/llms/hf.ts
@@ -58,7 +58,7 @@ export class HuggingFaceInference extends LLM implements HFInput {
     }
     const { HfInference } = await HuggingFaceInference.imports();
     const hf = new HfInference(process.env.HUGGINGFACEHUB_API_KEY ?? "");
-    const res = await hf.textGeneration({
+    const res = await this.caller.call(hf.textGeneration.bind(hf), {
       model: this.model,
       parameters: {
         // make it behave similar to openai, returning only the generated text

--- a/langchain/src/llms/tests/openai.int.test.ts
+++ b/langchain/src/llms/tests/openai.int.test.ts
@@ -11,6 +11,19 @@ test("Test OpenAI", async () => {
   console.log({ res });
 });
 
+test("Test OpenAI with concurrency == 1", async () => {
+  const model = new OpenAI({
+    maxTokens: 5,
+    modelName: "text-ada-001",
+    maxConcurrency: 1,
+  });
+  const res = await Promise.all([
+    model.call("Print hello world"),
+    model.call("Print hello world"),
+  ]);
+  console.log({ res });
+});
+
 test("Test OpenAI with maxTokens -1", async () => {
   const model = new OpenAI({ maxTokens: -1, modelName: "text-ada-001" });
   const res = await model.call("Print hello world", ["world"]);


### PR DESCRIPTION
Closes #418 
