### PR TITLE
Add quickstart example to langchain.js docs

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -1,5 +1,13 @@
 # Setup and Installation
 
+## Quickstart
+
+To get started with Langchain, you'll need to initialize a new Node.js project and configure some scripts to build, format, and compile your code.
+
+If you just want to get started quickly, [clone this repository](https://github.com/domeccleston/langchain-ts-starter) and follow the README instructions for a boilerplate project with those dependencies set up.
+
+If you'd prefer to set things up yourself, read on for instructions.
+
 ## Installation
 
 To get started, install LangChain with the following command:


### PR DESCRIPTION
Currently it's necessary to spend a bit of time wrangling build scripts to get started with a Langchain project using TS. This adds a 'quickstart' section to the langchain.js docs, with a link to a starter repository with scripts set up. 

The linked [starter repo](https://github.com/domeccleston/langchain-ts-starter) is under my name but I'd be happy to move it into this repo. Currently it's just a repository to clone, but in future we could make it a node script with some configuration options.

Thanks for the amazing work on this project!