### PR TITLE
feat(vectorstores): allow single metadata object to span across all text

### DIFF
--- a/langchain/src/vectorstores/base.ts
+++ b/langchain/src/vectorstores/base.ts
@@ -50,7 +50,7 @@ export abstract class VectorStore {
 
   static fromTexts(
     _texts: string[],
-    _metadatas: object[],
+    _metadatas: object[] | object,
     _embeddings: Embeddings,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     _dbConfig: Record<string, any>

--- a/langchain/src/vectorstores/chroma.ts
+++ b/langchain/src/vectorstores/chroma.ts
@@ -121,7 +121,7 @@ export class Chroma extends VectorStore {
 
   static async fromTexts(
     texts: string[],
-    metadatas: object[],
+    metadatas: object[] | object,
     embeddings: Embeddings,
     dbConfig: {
       collectionName?: string;
@@ -130,9 +130,10 @@ export class Chroma extends VectorStore {
   ): Promise<Chroma> {
     const docs: Document[] = [];
     for (let i = 0; i < texts.length; i += 1) {
+      const metadata = Array.isArray(metadatas) ? metadatas[i] : metadatas;
       const newDoc = new Document({
         pageContent: texts[i],
-        metadata: metadatas[i],
+        metadata,
       });
       docs.push(newDoc);
     }

--- a/langchain/src/vectorstores/hnswlib.ts
+++ b/langchain/src/vectorstores/hnswlib.ts
@@ -167,7 +167,7 @@ export class HNSWLib extends SaveableVectorStore {
 
   static async fromTexts(
     texts: string[],
-    metadatas: object[],
+    metadatas: object[] | object,
     embeddings: Embeddings,
     dbConfig?: {
       docstore?: InMemoryDocstore;
@@ -175,9 +175,10 @@ export class HNSWLib extends SaveableVectorStore {
   ): Promise<HNSWLib> {
     const docs: Document[] = [];
     for (let i = 0; i < texts.length; i += 1) {
+      const metadata = Array.isArray(metadatas) ? metadatas[i] : metadatas;
       const newDoc = new Document({
         pageContent: texts[i],
-        metadata: metadatas[i],
+        metadata,
       });
       docs.push(newDoc);
     }

--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -107,7 +107,7 @@ export class PineconeStore extends VectorStore {
 
   static async fromTexts(
     texts: string[],
-    metadatas: object[],
+    metadatas: object[] | object,
     embeddings: Embeddings,
     dbConfig:
       | {
@@ -122,9 +122,10 @@ export class PineconeStore extends VectorStore {
   ): Promise<PineconeStore> {
     const docs: Document[] = [];
     for (let i = 0; i < texts.length; i += 1) {
+      const metadata = Array.isArray(metadatas) ? metadatas[i] : metadatas;
       const newDoc = new Document({
         pageContent: texts[i],
-        metadata: metadatas[i],
+        metadata,
       });
       docs.push(newDoc);
     }

--- a/langchain/src/vectorstores/supabase.ts
+++ b/langchain/src/vectorstores/supabase.ts
@@ -99,15 +99,16 @@ export class SupabaseVectorStore extends VectorStore {
 
   static async fromTexts(
     texts: string[],
-    metadatas: object[],
+    metadatas: object[] | object,
     embeddings: Embeddings,
     dbConfig: SupabaseLibArgs
   ): Promise<SupabaseVectorStore> {
     const docs = [];
     for (let i = 0; i < texts.length; i += 1) {
+      const metadata = Array.isArray(metadatas) ? metadatas[i] : metadatas;
       const newDoc = new Document({
         pageContent: texts[i],
-        metadata: metadatas[i],
+        metadata,
       });
       docs.push(newDoc);
     }


### PR DESCRIPTION
This allows a single metadata object to be applied to an entire collection of text, for when we want to insert text from a single corpus into a vectorstore, or similar.