### PR TITLE
Fixed PromptLayer's API Key envrionment variable name. 

### DIFF
--- a/docs/docs/modules/llms/openai.md
+++ b/docs/docs/modules/llms/openai.md
@@ -17,7 +17,7 @@ console.log({ res });
 This library supports PromptLayer for logging and debugging prompts and responses. To add support for PromptLayer:
 
 1. Create a PromptLayer account here: [https://promptlayer.com](https://promptlayer.com).
-2. Create an API token and pass it either as `promptLayerApiKey` argument in the `PromptLayerOpenAI` constructor or in the `PROMPT_LAYER_API_KEY` environment variable.
+2. Create an API token and pass it either as `promptLayerApiKey` argument in the `PromptLayerOpenAI` constructor or in the `PROMPTLAYER_API_KEY` environment variable.
 
 ```typescript
 const model = new PromptLayerOpenAI({ temperature: 0.9 });


### PR DESCRIPTION
It threw me an error, and then checked the source code to verify. 
From `PROMPT_LAYER_API_KEY` to `PROMPTLAYER_API_KEY`.

Check here: https://github.com/hwchase17/langchainjs/blob/edd6ed610a6fde4daae1df9e9963e05438eb9102/langchain/src/llms/openai.ts#L389