### PR TITLE
Fix ChatConversationalAgent Memory Bug

### DIFF
--- a/langchain/src/agents/chat_convo/index.ts
+++ b/langchain/src/agents/chat_convo/index.ts
@@ -22,6 +22,7 @@ import {
   BaseOutputParser,
 } from "../../schema/index.js";
 import { AgentInput } from "../types.js";
+import { AgentFinish } from "../../schema/index.js";
 import { Tool } from "../tools/base.js";
 
 export class ChatConversationalAgentOutputParser extends BaseOutputParser {
@@ -117,6 +118,20 @@ export class ChatConversationalAgent extends Agent {
       );
     }
     return thoughts;
+  }
+
+  /**
+   * Add the return value to the llmChain memory if it exists
+   */
+  async prepareForOutput(
+    returnValues: AgentFinish["returnValues"],
+    _steps: AgentStep[]
+  ): Promise<AgentFinish["returnValues"]> {
+    const { memory } = this.llmChain;
+    if (memory) {
+      memory.saveContext({}, returnValues);
+    }
+    return returnValues;
   }
 
   /**

--- a/langchain/src/memory/chat_memory.ts
+++ b/langchain/src/memory/chat_memory.ts
@@ -18,11 +18,15 @@ export class ChatMessageHistory {
   }
 
   addUserMessage(message: string): void {
-    this.messages.push(new HumanChatMessage(message));
+    if (message) {
+      this.messages.push(new HumanChatMessage(message));
+    }
   }
 
   addAIChatMessage(message: string): void {
-    this.messages.push(new AIChatMessage(message));
+    if (message) {
+      this.messages.push(new AIChatMessage(message));
+    }
   }
 }
 


### PR DESCRIPTION
The ChatConversationalAgent was not properly saving AI output into the message history since it was being passed the raw output rather than the parsed output from the executor. This PR fixes that issue but adding parsed output value in the `prepareForOutput` call. It also adds a fix that prevents undefined messages from being added into the history on ChatHistory.