### PR TITLE
Fixed: use the name_for_model and description_for_model for AIPluginTool

### DIFF
--- a/langchain/src/agents/tools/aiplugin.ts
+++ b/langchain/src/agents/tools/aiplugin.ts
@@ -51,7 +51,7 @@ export class AIPluginTool extends Tool implements AIPluginToolParams {
 
     return new AIPluginTool({
       name: aiPluginJson.name_for_model,
-      description: `Call this tool to get the OpenAPI spec (and usage guide) for interacting with the ${aiPluginJson.name_for_human} API. You should only call this ONCE! What is the ${aiPluginJson.name_for_human} API useful for? ${aiPluginJson.description_for_human}`,
+      description: `Call this tool to get the OpenAPI spec (and usage guide) for interacting with the ${aiPluginJson.name_for_model} API. You should only call this ONCE! What is the ${aiPluginJson.name_for_model} API useful for? ${aiPluginJson.description_for_model}`,
       apiSpec: `Usage Guide: ${aiPluginJson.description_for_model}
 
 OpenAPI Spec: ${apiUrlJson}`,


### PR DESCRIPTION
Using name_for_model, description_for_model in AIPluginTool  makes more sense.