### PR TITLE
test: test for agent using chatopenai -- broken

### DIFF
--- a/examples/src/agents/llm_mrkl_with_chat_model.ts
+++ b/examples/src/agents/llm_mrkl_with_chat_model.ts
@@ -1,0 +1,22 @@
+import { ChatOpenAI } from "langchain/chat_models";
+import { initializeAgentExecutor } from "langchain/agents";
+import { SerpAPI, Calculator } from "langchain/tools";
+
+export const run = async () => {
+  const model = new ChatOpenAI({ temperature: 0 });
+  const tools = [new SerpAPI(), new Calculator()];
+
+  const executor = await initializeAgentExecutor(
+    tools,
+    model,
+    "zero-shot-react-description"
+  );
+  console.log("Loaded agent.");
+
+  const input = `Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?`;
+  console.log(`Executing with input "${input}"...`);
+
+  const result = await executor.call({ input, chat_history: [] });
+
+  console.log(`Got output ${result.output}`);
+};

--- a/langchain/src/agents/tests/agent.int.test.ts
+++ b/langchain/src/agents/tests/agent.int.test.ts
@@ -5,6 +5,7 @@ import { AgentExecutor, Tool } from "../index.js";
 import { SerpAPI } from "../tools/serpapi.js";
 import { Calculator } from "../tools/calculator.js";
 import { initializeAgentExecutor } from "../initialize.js";
+import { ChatOpenAI } from "../../chat_models/index.js";
 
 test("Run agent from hub", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-babbage-001" });
@@ -25,7 +26,7 @@ test("Run agent from hub", async () => {
   console.log(res);
 }, 30000);
 
-test("Run agent locally", async () => {
+test("Run agent locally with OpenAI", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-babbage-001" });
   const tools = [new SerpAPI(), new Calculator()];
 
@@ -40,6 +41,25 @@ test("Run agent locally", async () => {
   console.log(`Executing with input "${input}"...`);
 
   const result = await executor.call({ input });
+
+  console.log(`Got output ${result.output}`);
+}, 30000);
+
+test.only("Run agent locally with ChatOpenAI", async () => {
+  const model = new ChatOpenAI({ temperature: 0 });
+  const tools = [new SerpAPI(), new Calculator()];
+
+  const executor = await initializeAgentExecutor(
+    tools,
+    model,
+    "zero-shot-react-description"
+  );
+  console.log("Loaded agent.");
+
+  const input = `Who is Olivia Wilde's boyfriend? What is his current age raised to the 0.23 power?`;
+  console.log(`Executing with input "${input}"...`);
+
+  const result = await executor.call({ input, chat_history: [] });
 
   console.log(`Got output ${result.output}`);
 }, 30000);


### PR DESCRIPTION
Trying to write a more complicated test, but couldnt get this simpler one to work and I dont think theres other agent tests with chatopen. Some tooling error hopefully someone else can understand

```
(node:1337224) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
 FAIL  src/agents/tests/agent.int.test.ts (7.04 s)
  ✕ Run agent locally with ChatOpenAI (1905 ms)
  ○ skipped Run agent from hub
  ○ skipped Run agent locally with OpenAI

  ● Run agent locally with ChatOpenAI

    Must use import to load ES Module: /home/jacob/z/langchainjs/node_modules/undici/lib/llhttp/llhttp.wasm

      at Runtime.requireModule (../node_modules/jest-runtime/build/index.js:841:21)
      at lazyllhttp (../node_modules/undici/lib/client.js:352:55)
      at Object.<anonymous> (../node_modules/undici/lib/client.js:414:21)
      at Object.<anonymous> (../node_modules/undici/index.js:3:16)

  ● Run agent locally with ChatOpenAI

    TypeError: fetch failed

      36 |   async _call(input: string) {
      37 |     const { getJson } = await SerpAPI.imports();
    > 38 |     const res = await getJson("google", {
         |                 ^
      39 |       ...this.params,
      40 |       api_key: this.key,
      41 |       q: input,

      at Object.fetch (../node_modules/undici/index.js:109:13)
      at Object.execute (../node_modules/serpapi/esm/src/utils.js:86:12)
      at getJson (../node_modules/serpapi/esm/src/serpapi.js:58:22)
      at SerpAPI._call (src/agents/tools/serpapi.ts:38:17)
      at SerpAPI.call (src/agents/tools/base.ts:31:16)
      at AgentExecutor._call (src/agents/executor.ts:95:11)
      at AgentExecutor.call (src/chains/base.ts:94:22)
      at Object.<anonymous> (src/agents/tests/agent.int.test.ts:62:18)

    Cause:
    Must use import to load ES Module: /home/jacob/z/langchainjs/node_modules/undici/lib/llhttp/llhttp.wasm

      at Runtime.requireModule (../node_modules/jest-runtime/build/index.js:841:21)
      at lazyllhttp (../node_modules/undici/lib/client.js:352:55)
      at Object.<anonymous> (../node_modules/undici/lib/client.js:414:21)
      at Object.<anonymous> (../node_modules/undici/index.js:3:16)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 2 skipped, 3 total
Snapshots:   0 total
Time:        7.138 s
Ran all test suites matching /agents\/tests\/agent/i.
Jest did not exit one second after the test run has completed.

'This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```