### PR TITLE
feat: print top level object describe

### DIFF
--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -11,7 +11,7 @@ function printSchema(schema: z.ZodTypeAny, depth = 0): string {
   } else if (schema instanceof z.ZodObject) {
     const indent = "\t".repeat(depth);
     const indentIn = "\t".repeat(depth + 1);
-    return `{
+    return `{${schema._def.description ? ` // ${schema._def.description}` : ""}
 ${Object.entries(schema.shape)
   .map(
     ([key, value]) =>

--- a/langchain/src/output_parsers/tests/structured.test.ts
+++ b/langchain/src/output_parsers/tests/structured.test.ts
@@ -47,16 +47,18 @@ test("StructuredOutputParser.fromZodSchema", async () => {
 
 test("StructuredOutputParser.fromZodSchema", async () => {
   const parser = StructuredOutputParser.fromZodSchema(
-    z.object({
-      url: z.string().describe("A link to the resource"),
-      title: z.string().describe("A title for the resource"),
-      authors: z.array(
-        z.object({
-          name: z.string().describe("The name of the author"),
-          email: z.string().describe("The email of the author"),
-        })
-      ),
-    })
+    z
+      .object({
+        url: z.string().describe("A link to the resource"),
+        title: z.string().describe("A title for the resource"),
+        authors: z.array(
+          z.object({
+            name: z.string().describe("The name of the author"),
+            email: z.string().describe("The email of the author"),
+          })
+        ),
+      })
+      .describe("Only One object")
   );
 
   expect(
@@ -73,7 +75,7 @@ test("StructuredOutputParser.fromZodSchema", async () => {
     "The output should be a markdown code snippet formatted in the following schema:
 
     \`\`\`json
-    {
+    { // Only One object
     	"url": string // A link to the resource
     	"title": string // A title for the resource
     	"authors": {


### PR DESCRIPTION
Zod allowed me to make the .describe on a top level object, but we didnt print it. 

Seems like we should? But I honestly dont incredibly need this right now, did what I wanted by templating around the schema anyway