### PR TITLE
Zod parser now support more types and optional field

### DIFF
--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-else-return */
 import { z } from "zod";
 
 import { BaseOutputParser, OutputParserException } from "../schema/index.js";
@@ -6,26 +5,39 @@ import { BaseOutputParser, OutputParserException } from "../schema/index.js";
 function printSchema(schema: z.ZodTypeAny, depth = 0): string {
   if (schema instanceof z.ZodString) {
     return "string";
-  } else if (schema instanceof z.ZodArray) {
+  }
+  if (schema instanceof z.ZodNumber) {
+    return "number";
+  }
+  if (schema instanceof z.ZodBoolean) {
+    return "boolean";
+  }
+  if (schema instanceof z.ZodDate) {
+    return "date";
+  }
+  if (schema instanceof z.ZodOptional) {
+    return `${printSchema(schema._def.innerType, depth)} // Optional`;
+  }
+  if (schema instanceof z.ZodArray) {
     return `${printSchema(schema._def.type, depth)}[]`;
-  } else if (schema instanceof z.ZodObject) {
+  }
+  if (schema instanceof z.ZodObject) {
     const indent = "\t".repeat(depth);
     const indentIn = "\t".repeat(depth + 1);
     return `{${schema._def.description ? ` // ${schema._def.description}` : ""}
 ${Object.entries(schema.shape)
   .map(
     ([key, value]) =>
-      // eslint-disable-next-line prefer-template
-      `${indentIn}"${key}": ${printSchema(value as z.ZodTypeAny, depth + 1)}` +
-      ((value as z.ZodTypeAny)._def.description
-        ? ` // ${(value as z.ZodTypeAny)._def.description}`
-        : "")
+      `${indentIn}"${key}": ${printSchema(value as z.ZodTypeAny, depth + 1)}${
+        (value as z.ZodTypeAny)._def.description
+          ? ` // ${(value as z.ZodTypeAny)._def.description}`
+          : ""
+      }`
   )
   .join("\n")}
 ${indent}}`;
-  } else {
-    throw new Error(`Unsupported type: ${schema}`);
   }
+  throw new Error(`Unsupported type: ${schema._def.innerType}`);
 }
 
 export class StructuredOutputParser<

--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 import { BaseOutputParser, OutputParserException } from "../schema/index.js";
 
 function printSchema(schema: z.ZodTypeAny, depth = 0): string {
+  if (
+    schema instanceof z.ZodString &&
+    schema._def.checks.some((check) => check.kind === "datetime")
+  ) {
+    return "datetime";
+  }
   if (schema instanceof z.ZodString) {
     return "string";
   }

--- a/langchain/src/output_parsers/tests/structured.test.ts
+++ b/langchain/src/output_parsers/tests/structured.test.ts
@@ -77,8 +77,6 @@ test("StructuredOutputParser.fromZodSchema", async () => {
     authors: [{ name: "value", email: "value" }],
   });
 
-  console.log("parser.getFormatInstructions()", parser.getFormatInstructions());
-
   expect(parser.getFormatInstructions()).toMatchInlineSnapshot(
     `
 "The output should be a markdown code snippet formatted in the following schema:

--- a/langchain/src/output_parsers/tests/structured.test.ts
+++ b/langchain/src/output_parsers/tests/structured.test.ts
@@ -52,6 +52,10 @@ test("StructuredOutputParser.fromZodSchema", async () => {
         url: z.string().describe("A link to the resource"),
         title: z.string().describe("A title for the resource"),
         year: z.number().describe("The year the resource was created"),
+        createdAt: z
+          .string()
+          .datetime()
+          .describe("The date the resource was created"),
         authors: z.array(
           z.object({
             name: z.string().describe("The name of the author"),
@@ -68,12 +72,13 @@ test("StructuredOutputParser.fromZodSchema", async () => {
 
   expect(
     await parser.parse(
-      '```json\n{"url": "value", "title": "value", "year": 2011, "authors": [{"name": "value", "email": "value"}]}```'
+      '```json\n{"url": "value", "title": "value", "year": 2011, "createdAt": "2023-03-29T16:07:09.600Z", "authors": [{"name": "value", "email": "value"}]}```'
     )
   ).toEqual({
     url: "value",
     title: "value",
     year: 2011,
+    createdAt: "2023-03-29T16:07:09.600Z",
     authors: [{ name: "value", email: "value" }],
   });
 
@@ -86,6 +91,7 @@ test("StructuredOutputParser.fromZodSchema", async () => {
 	"url": string // A link to the resource
 	"title": string // A title for the resource
 	"year": number // The year the resource was created
+	"createdAt": datetime // The date the resource was created
 	"authors": {
 		"name": string // The name of the author
 		"email": string // The email of the author

--- a/langchain/src/output_parsers/tests/structured.test.ts
+++ b/langchain/src/output_parsers/tests/structured.test.ts
@@ -51,10 +51,15 @@ test("StructuredOutputParser.fromZodSchema", async () => {
       .object({
         url: z.string().describe("A link to the resource"),
         title: z.string().describe("A title for the resource"),
+        year: z.number().describe("The year the resource was created"),
         authors: z.array(
           z.object({
             name: z.string().describe("The name of the author"),
             email: z.string().describe("The email of the author"),
+            address: z
+              .string()
+              .optional()
+              .describe("The address of the author"),
           })
         ),
       })
@@ -63,27 +68,34 @@ test("StructuredOutputParser.fromZodSchema", async () => {
 
   expect(
     await parser.parse(
-      '```json\n{"url": "value", "title": "value", "authors": [{"name": "value", "email": "value"}]}```'
+      '```json\n{"url": "value", "title": "value", "year": 2011, "authors": [{"name": "value", "email": "value"}]}```'
     )
   ).toEqual({
     url: "value",
     title: "value",
+    year: 2011,
     authors: [{ name: "value", email: "value" }],
   });
 
-  expect(parser.getFormatInstructions()).toMatchInlineSnapshot(`
-    "The output should be a markdown code snippet formatted in the following schema:
+  console.log("parser.getFormatInstructions()", parser.getFormatInstructions());
 
-    \`\`\`json
-    { // Only One object
-    	"url": string // A link to the resource
-    	"title": string // A title for the resource
-    	"authors": {
-    		"name": string // The name of the author
-    		"email": string // The email of the author
-    	}[]
-    }
-    \`\`\` 
-    "
-  `);
+  expect(parser.getFormatInstructions()).toMatchInlineSnapshot(
+    `
+"The output should be a markdown code snippet formatted in the following schema:
+
+\`\`\`json
+{ // Only One object
+	"url": string // A link to the resource
+	"title": string // A title for the resource
+	"year": number // The year the resource was created
+	"authors": {
+		"name": string // The name of the author
+		"email": string // The email of the author
+		"address": string // Optional // The address of the author
+	}[]
+}
+\`\`\` 
+"
+`
+  );
 });


### PR DESCRIPTION
The StructuredOutputParser now only supports "string" fields. and throw error for other types and optional
This PR to support:
+ String
+ Number
+ Boolean
+ Date
+ Optional

```typescript
StructuredOutputParser.fromZodSchema(
    z
      .object({
        url: z.string().describe("A link to the resource"),
        title: z.string().describe("A title for the resource"),
        year: z.number().describe("The year the resource was created"),
        createdAt: z
          .string()
          .datetime()
          .describe("The date the resource was created"),
        authors: z.array(
          z.object({
            name: z.string().describe("The name of the author"),
            email: z.string().describe("The email of the author"),
            address: z
              .string()
              .optional()
              .describe("The address of the author"),
          })
        ),
      })
      .describe("Only One object")
  )
```
result
```
"The output should be a markdown code snippet formatted in the following schema:

\`\`\`json
{ // Only One object
	"url": string // A link to the resource
	"title": string // A title for the resource
	"year": number // The year the resource was created
	"createdAt": datetime // The date the resource was created
	"authors": {
		"name": string // The name of the author
		"email": string // The email of the author
		"address": string // Optional // The address of the author
	}[]
}
\`\`\` 
"
```