### PR TITLE
Update the docs for TextSplitter

### DIFF
--- a/docs/docs/modules/indexes/text_splitters/examples/character.mdx
+++ b/docs/docs/modules/indexes/text_splitters/examples/character.mdx
@@ -16,5 +16,5 @@ const splitter = new CharacterTextSplitter({
   chunkSize: 7,
   chunkOverlap: 3,
 });
-const output = splitter.createDocuments([text]);
+const output = await splitter.createDocuments([text]);
 ```

--- a/docs/docs/modules/indexes/text_splitters/examples/markdown.mdx
+++ b/docs/docs/modules/indexes/text_splitters/examples/markdown.mdx
@@ -39,7 +39,7 @@ This is even more content.`;
 
 const splitter = new MarkdownTextSplitter();
 
-const output = splitter.createDocuments([text], { metadata: "something" });
+const output = await splitter.createDocuments([text], { metadata: "something" });
 /*
 [
   {

--- a/docs/docs/modules/indexes/text_splitters/examples/recursive_character.mdx
+++ b/docs/docs/modules/indexes/text_splitters/examples/recursive_character.mdx
@@ -18,7 +18,8 @@ const splitter = new RecursiveCharacterTextSplitter({
   chunkSize: 10,
   chunkOverlap: 1,
 });
-const output = splitter.createDocuments([text]);
+
+const output = await splitter.createDocuments([text]);
 ```
 
 You'll note that in the above example we are splitting a raw text string and getting back a list of documents. We can also split documents directly.
@@ -34,7 +35,8 @@ const splitter = new RecursiveCharacterTextSplitter({
   chunkSize: 10,
   chunkOverlap: 1,
 });
-const docOutput = splitter.splitDocuments([
+
+const docOutput = await splitter.splitDocuments([
   new Document({ pageContent: text }),
 ]);
 ```

--- a/docs/docs/modules/indexes/text_splitters/examples/token.mdx
+++ b/docs/docs/modules/indexes/text_splitters/examples/token.mdx
@@ -26,5 +26,5 @@ const splitter = new TokenTextSplitter({
   chunkOverlap: 0,
 });
 
-const output = splitter.createDocuments([text]);
+const output = await splitter.createDocuments([text]);
 ```


### PR DESCRIPTION
The `TextSplitter` class `createDocuments` and `splitDocuments` methods return [promises](http://localhost:3000/docs/modules/indexes/text_splitters/). That wasn't made obvious by looking at the examples in the docs, so I updated them to make it more clear. 