### PR TITLE
change the order of fetchAdaptor and axios baseOptions

### DIFF
--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -320,8 +320,8 @@ export class OpenAIChat extends LLM implements OpenAIInput {
         ...this.clientConfig,
         baseOptions: {
           timeout: this.timeout,
-          ...this.clientConfig.baseOptions,
           adapter: fetchAdapter,
+          ...this.clientConfig.baseOptions,
         },
       });
       this.client = new OpenAIApi(clientConfig);

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -366,8 +366,8 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
         ...this.clientConfig,
         baseOptions: {
           timeout: this.timeout,
-          ...this.clientConfig.baseOptions,
           adapter: fetchAdapter,
+          ...this.clientConfig.baseOptions,
         },
       });
       this.client = new OpenAIApi(clientConfig);


### PR DESCRIPTION
Then we have a different way to solve #388.
```
const model = new OpenAI({
    openAIApiKey: '',
    temperature: 0.9
}, {
    baseOptions: {
        httpsAgent: new SocksProxyAgent({
            hostname: 'xxx',
            port: xxx
        }),
        adapter: null
    }
});
```