### PR TITLE
`Fix passing chat history into buffer memory, add tests, update docs

### DIFF
--- a/docs/docs/modules/memory/examples/buffer_memory.md
+++ b/docs/docs/modules/memory/examples/buffer_memory.md
@@ -26,3 +26,20 @@ console.log({ res2 });
 ```shell
 {response: ' You said your name is Jim. Is there anything else you would like to talk about?'}
 ```
+
+You can also load messages into a `BufferMemory` instance by creating and passing in a `ChatHistory` object.
+This lets you easily pick up state from past conversations:
+
+```typescript
+import { ChatMessageHistory } from "langchain/memory";
+import { HumanChatMessage, AIChatMessage } from "langchain/schema";
+
+const pastMessages = [
+  new HumanChatMessage("My name's Jonas"),
+  new AIChatMessage("Nice to meet you, Jonas!"),
+];
+
+const memory = new BufferMemory({
+  chatHistory: new ChatMessageHistory(pastMessages),
+});
+```

--- a/docs/docs/modules/memory/examples/buffer_memory_chat.mdx
+++ b/docs/docs/modules/memory/examples/buffer_memory_chat.mdx
@@ -5,9 +5,9 @@ hide_table_of_contents: true
 import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/chat/memory.ts";
 
-# Memory
+# Using Buffer Memory with Chat Models
 
-This example covers how to use chat specific memory classes with chat models.
+This example covers how to use chat-specific memory classes with chat models.
 The key thing to notice is that setting `returnMessages: true` makes the memory return a list of chat messages instead of a string.
 
 <CodeBlock language="typescript">{Example}</CodeBlock>

--- a/langchain/src/memory/buffer_memory.ts
+++ b/langchain/src/memory/buffer_memory.ts
@@ -16,6 +16,7 @@ export class BufferMemory extends BaseChatMemory implements BufferMemoryInput {
 
   constructor(fields?: Partial<BufferMemoryInput>) {
     super({
+      chatHistory: fields?.chatHistory,
       returnMessages: fields?.returnMessages ?? false,
       inputKey: fields?.inputKey,
       outputKey: fields?.outputKey,

--- a/langchain/src/memory/buffer_window_memory.ts
+++ b/langchain/src/memory/buffer_window_memory.ts
@@ -22,7 +22,10 @@ export class BufferWindowMemory
   k = 5;
 
   constructor(fields?: Partial<BufferWindowMemoryInput>) {
-    super({ returnMessages: fields?.returnMessages ?? false });
+    super({
+      returnMessages: fields?.returnMessages ?? false,
+      chatHistory: fields?.chatHistory,
+    });
     this.humanPrefix = fields?.humanPrefix ?? this.humanPrefix;
     this.aiPrefix = fields?.aiPrefix ?? this.aiPrefix;
     this.memoryKey = fields?.memoryKey ?? this.memoryKey;

--- a/langchain/src/memory/tests/buffer_memory.test.ts
+++ b/langchain/src/memory/tests/buffer_memory.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@jest/globals";
 import { BufferMemory } from "../buffer_memory.js";
+import { ChatMessageHistory } from "../chat_memory.js";
 import { HumanChatMessage, AIChatMessage } from "../../schema/index.js";
 
 test("Test buffer memory", async () => {
@@ -25,4 +26,17 @@ test("Test buffer memory return messages", async () => {
   ];
   const result2 = await memory.loadMemoryVariables({});
   expect(result2).toStrictEqual({ history: expectedResult });
+});
+
+test("Test buffer memory with pre-loaded history", async () => {
+  const pastMessages = [
+    new HumanChatMessage("My name's Jonas"),
+    new AIChatMessage("Nice to meet you, Jonas!"),
+  ];
+  const memory = new BufferMemory({
+    returnMessages: true,
+    chatHistory: new ChatMessageHistory(pastMessages),
+  });
+  const result = await memory.loadMemoryVariables({});
+  expect(result).toStrictEqual({ history: pastMessages });
 });

--- a/langchain/src/memory/tests/buffer_window_memory.test.ts
+++ b/langchain/src/memory/tests/buffer_window_memory.test.ts
@@ -1,8 +1,9 @@
 import { test, expect } from "@jest/globals";
 import { BufferWindowMemory } from "../buffer_window_memory.js";
+import { ChatMessageHistory } from "../chat_memory.js";
 import { HumanChatMessage, AIChatMessage } from "../../schema/index.js";
 
-test("Test buffer memory", async () => {
+test("Test buffer window memory", async () => {
   const memory = new BufferWindowMemory({ k: 1 });
   const result1 = await memory.loadMemoryVariables({});
   expect(result1).toStrictEqual({ history: "" });
@@ -18,7 +19,7 @@ test("Test buffer memory", async () => {
   expect(result3).toStrictEqual({ history: expectedString3 });
 });
 
-test("Test buffer memory return messages", async () => {
+test("Test buffer window memory return messages", async () => {
   const memory = new BufferWindowMemory({ k: 1, returnMessages: true });
   const result1 = await memory.loadMemoryVariables({});
   expect(result1).toStrictEqual({ history: [] });
@@ -38,4 +39,17 @@ test("Test buffer memory return messages", async () => {
   ];
   const result3 = await memory.loadMemoryVariables({});
   expect(result3).toStrictEqual({ history: expectedResult2 });
+});
+
+test("Test buffer window memory with pre-loaded history", async () => {
+  const pastMessages = [
+    new HumanChatMessage("My name's Jonas"),
+    new AIChatMessage("Nice to meet you, Jonas!"),
+  ];
+  const memory = new BufferWindowMemory({
+    returnMessages: true,
+    chatHistory: new ChatMessageHistory(pastMessages),
+  });
+  const result = await memory.loadMemoryVariables({});
+  expect(result).toStrictEqual({ history: pastMessages });
 });


### PR DESCRIPTION
Followup to #538 

The `chatHistory` field was not getting passed through to the `BaseChatMemory` constructor. This fixes that issue, adds tests, and updates the docs with an example.