### PR TITLE
Update the implements of MapReduceDocumentsChain and fix typo

### DIFF
--- a/langchain/src/chains/combine_docs_chain.ts
+++ b/langchain/src/chains/combine_docs_chain.ts
@@ -96,7 +96,7 @@ export class StuffDocumentsChain
 export interface MapReduceDocumentsChainInput extends StuffDocumentsChainInput {
   maxTokens: number;
   maxIterations: number;
-  combineDocumentsChain: BaseChain;
+  combineDocumentChain: BaseChain;
 }
 
 /**
@@ -106,7 +106,7 @@ export interface MapReduceDocumentsChainInput extends StuffDocumentsChainInput {
  */
 export class MapReduceDocumentsChain
   extends BaseChain
-  implements StuffDocumentsChainInput
+  implements MapReduceDocumentsChainInput
 {
   llmChain: LLMChain;
 


### PR DESCRIPTION
I found that `MapReduceDocumentsChain` implements `StuffDocumentsChainInput`, but `MapReduceDocumentsChainInput` was not being used. So I updated it and fixed a typo.