### PR TITLE
Fix the edit link of the document

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -77,7 +77,7 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/hwchase17/langchainjs/",
+          editUrl: "https://github.com/hwchase17/langchainjs/edit/main/docs/",
           async sidebarItemsGenerator({
             defaultSidebarItemsGenerator,
             ...args


### PR DESCRIPTION
It came up when I was trying to fix a bug in the docs and found that the address of the "Edit this page" link was wrong, so I made a PR to fix it first.

For example the document, https://js.langchain.com/docs/getting-started/guide-chat#memory-add-state-to-chains-and-agents

before correction: https://github.com/hwchase17/langchainjs/docs/getting-started/guide-chat.mdx
after fixing: https://github.com/hwchase17/langchainjs/edit/main/docs/docs/getting-started/guide-chat.mdx