### PR TITLE
Make zapier int test less flaky

### DIFF
--- a/langchain/src/agents/tests/zapier_toolkit.int.test.ts
+++ b/langchain/src/agents/tests/zapier_toolkit.int.test.ts
@@ -32,7 +32,6 @@ describe("ZapierNLAWrapper", () => {
         keyword: "cats",
         size: expect.any(String),
         url: expect.stringContaining("https://"),
-        width: expect.any(String),
       });
     });
   });


### PR DESCRIPTION
Sometimes zapier doesnt return `width` in reply