### PR TITLE
Fix: LLMSingleActionAgent constructor

### DIFF
--- a/langchain/src/agents/agent.ts
+++ b/langchain/src/agents/agent.ts
@@ -102,6 +102,7 @@ export class LLMSingleActionAgent extends BaseSingleActionAgent {
     super();
     this.llmChain = input.llmChain;
     this.outputParser = input.outputParser;
+    this.stop = input.stop;
   }
 
   get inputKeys(): string[] {


### PR DESCRIPTION
Currently, the `stop` input doesn't seem to function correctly.
Added `this.stop = input.stop` to LLMSingleActionAgent constructor.
