### PR TITLE
Adding Supabase Hybrid Search default assumptions to the docs

### DIFF
--- a/examples/src/retrievers/supabase_hybrid.ts
+++ b/examples/src/retrievers/supabase_hybrid.ts
@@ -12,8 +12,12 @@ export const run = async () => {
 
   const retriever = new SupabaseHybridSearch(embeddings, {
     client,
+    //  Below are the defaults, expecting that you set up your supabase table and functions according to the guide above. Please change if necessary.
     similarityK: 2,
     keywordK: 2,
+    tableName: "documents",
+    similarityQueryName: "match_documents",
+    keywordQueryName: "kw_match_documents",
   });
 
   const results = await retriever.getRelevantDocuments("hello bye");

--- a/langchain/src/retrievers/supabase-hybrid-search.ts
+++ b/langchain/src/retrievers/supabase-hybrid-search.ts
@@ -24,15 +24,24 @@ type SearchResult = [Document, number, number];
 
 export interface SupabaseLibArgs {
   client: SupabaseClient;
+  /**
+   * The table name on Supabase. Defaults to "documents".
+   */
   tableName?: string;
+  /**
+   * The name of the Similarity search function on Supabase. Defaults to "match_documents".
+   */
   similarityQueryName?: string;
+  /**
+   * The name of the Keyword search function on Supabase. Defaults to "kw_match_documents".
+   */
   keywordQueryName?: string;
   /**
-   * The number of documents to return from the similarity search
+   * The number of documents to return from the similarity search. Defaults to 2.
    */
   similarityK?: number;
   /**
-   * The number of documents to return from the keyword search
+   * The number of documents to return from the keyword search. Defaults to 2.
    */
   keywordK?: number;
 }


### PR DESCRIPTION
Adding Supabase default assumptions to the docs and some comments.

Few important variable defaults were missing from the Supabase Hybrid Search example. Namely:

- tableName: "documents"
- similarityQueryName: "match_documents"
- keywordQueryName: "kw_match_documents"