### PR TITLE
Configure lint-staged precommit on all workspaces

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "lint": "eslint --cache \"**/*.js\"",
     "lint:fix": "yarn lint --fix",
+    "precommit": "lint-staged",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,md,mdx}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,md,mdx}\""
   },

--- a/examples/package.json
+++ b/examples/package.json
@@ -14,6 +14,7 @@
     "start:dist": "yarn build && node -r dotenv/config dist/index.js",
     "lint": "eslint src",
     "lint:fix": "yarn lint --fix",
+    "precommit": "tsc --noEmit && lint-staged",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""
   },

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -130,7 +130,6 @@
     "hnswlib-node": "^1.4.2",
     "html-to-text": "^9.0.5",
     "jest": "^29.5.0",
-    "lint-staged": "^13.1.1",
     "mammoth": "^1.5.1",
     "pdfjs-dist": "^3.4.120",
     "prettier": "^2.8.3",
@@ -241,12 +240,6 @@
     "uuid": "^9.0.0",
     "yaml": "^2.2.1",
     "zod": "^3.21.4"
-  },
-  "lint-staged": {
-    "**/*.{ts,tsx}": [
-      "prettier --write --ignore-unknown",
-      "eslint --cache --fix"
-    ]
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -48,5 +48,12 @@
   },
   "resolutions": {
     "dpdm@^3.12.0": "patch:dpdm@npm%3A3.12.0#./.yarn/patches/dpdm-npm-3.12.0-0dfdd8e3b8.patch"
+  },
+  "lint-staged": {
+    "**/*.{ts,tsx}": [
+      "prettier --write --ignore-unknown",
+      "eslint --cache --fix"
+    ],
+    "*.md": "prettier --write"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11478,7 +11478,6 @@ __metadata:
     is-binary-path: ^2.1.0
     jest: ^29.5.0
     jsonpointer: ^5.0.1
-    lint-staged: ^13.1.1
     mammoth: ^1.5.1
     object-hash: ^3.0.0
     openai: ^3.2.0


### PR DESCRIPTION
Closes #44 

Only include lint-staged in top-level package.json as outlined in docs: https://github.com/okonet/lint-staged#how-to-use-lint-staged-in-a-multi-package-monorepo

Moves lint-staged config to top-level package.json since the same configuration works for all workspaces. lint-staged discovers the closest configuration to each staged file, so workspace specific configs can be added in the future if there are conflicts with the global config.