### PR TITLE
changed TextSplitter class to align with langchain

### DIFF
--- a/langchain/src/tests/text_splitter.test.ts
+++ b/langchain/src/tests/text_splitter.test.ts
@@ -137,8 +137,8 @@ Bye!\n\n-H.`;
     "write, but",
     "gotta test",
     "the",
-    "splitting",
-    "gggg",
+    "splittingg",
+    "ggg",
     "some how.",
     "Bye!\n\n-H.",
   ];

--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -93,7 +93,7 @@ export abstract class TextSplitter implements TextSplitterParams {
     let total = 0;
     for (const d of splits) {
       const _len = d.length;
-      if (total + _len >= this.chunkSize) {
+      if (total + _len + (currentDoc.length > 0 ? separator.length : 0) > this.chunkSize) {
         if (total > this.chunkSize) {
           console.warn(
             `Created a chunk of size ${total}, +

--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -93,7 +93,10 @@ export abstract class TextSplitter implements TextSplitterParams {
     let total = 0;
     for (const d of splits) {
       const _len = d.length;
-      if (total + _len + (currentDoc.length > 0 ? separator.length : 0) > this.chunkSize) {
+      if (
+        total + _len + (currentDoc.length > 0 ? separator.length : 0) >
+        this.chunkSize
+      ) {
         if (total > this.chunkSize) {
           console.warn(
             `Created a chunk of size ${total}, +


### PR DESCRIPTION
I have been playing around with langchain and langchainjs and noticed that the textsplitters were producing different results. My goal is to align the textsplitters in langchainjs to be more similar to the langchain textsplitters.

I changed one line of conditional logic that was different between the two libraries. In the mergeSplits function:
langchain: if (total + _len + (separator_len if len(current_doc) > 0 else 0) > self._chunk_size):
langchainjs: if (total + _len >= this.chunkSize)
new langchainjs: if (total + _len + (currentDoc.length > 0 ? separator.length : 0) > this.chunkSize)