### PR TITLE
Update queue type to avoid build error

### DIFF
--- a/langchain/src/util/async_caller.ts
+++ b/langchain/src/util/async_caller.ts
@@ -32,7 +32,7 @@ export class AsyncCaller {
 
   protected maxRetries: AsyncCallerParams["maxRetries"];
 
-  protected queue: PQueueMod.default;
+  protected queue: PQueueMod;
 
   constructor(params: AsyncCallerParams) {
     this.maxConcurrency = params.maxConcurrency ?? Infinity;

--- a/langchain/src/util/async_caller.ts
+++ b/langchain/src/util/async_caller.ts
@@ -32,7 +32,7 @@ export class AsyncCaller {
 
   protected maxRetries: AsyncCallerParams["maxRetries"];
 
-  protected queue: PQueueMod;
+  private queue: typeof import("p-queue")["default"]["prototype"];
 
   constructor(params: AsyncCallerParams) {
     this.maxConcurrency = params.maxConcurrency ?? Infinity;


### PR DESCRIPTION
Existing code gives this error

node_modules/langchain/dist/util/async_caller.d.ts:30:22 - error TS2702: 'PQueueMod' only refers to a type, but is being used as a namespace here.
30     protected queue: PQueueMod.default;

This PR fixes it..