### PR TITLE
Update docs for passing `apiKey` arg in non-Node envs

### DIFF
--- a/docs/docs/modules/models/chat/integrations.mdx
+++ b/docs/docs/modules/models/chat/integrations.mdx
@@ -12,8 +12,10 @@ LangChain offers a number of Chat Models implementations that integrate with var
 ```typescript
 import { ChatOpenAI } from "langchain/chat_models";
 
-// Expects an OpenAI API key to be set in the env variable OPENAI_API_KEY
-const model = new ChatOpenAI({ temperature: 0.9 });
+const model = new ChatOpenAI({
+  temperature: 0.9,
+  openAIApiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.OPENAI_API_KEY
+});
 ```
 
 ## `Anthropic`
@@ -21,6 +23,8 @@ const model = new ChatOpenAI({ temperature: 0.9 });
 ```typescript
 import { ChatAnthropic } from "langchain/chat_models";
 
-// Expects an Anthropic API key to be set in the env variable ANTHROPIC_API_KEY
-const model = new ChatAnthropic({ temperature: 0.9 });
+const model = new ChatAnthropic({
+  temperature: 0.9,
+  apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.ANTHROPIC_API_KEY
+});
 ```

--- a/docs/docs/modules/models/embeddings/integrations.mdx
+++ b/docs/docs/modules/models/embeddings/integrations.mdx
@@ -14,7 +14,9 @@ The `OpenAIEmbeddings` class uses the OpenAI API to generate embeddings for a gi
 ```typescript
 import { OpenAIEmbeddings } from "langchain/embeddings";
 
-const embeddings = new OpenAIEmbeddings();
+const embeddings = new OpenAIEmbeddings({
+  openAIApiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.OPENAI_API_KEY
+});
 ```
 
 ## `CohereEmbeddings`
@@ -26,5 +28,7 @@ npm install cohere-ai
 ```typescript
 import { CohereEmbeddings } from "langchain/embeddings";
 
-const embeddings = new CohereEmbeddings();
+const embeddings = new CohereEmbeddings({
+  apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.COHERE_API_KEY
+});
 ```

--- a/docs/docs/modules/models/llms/integrations.mdx
+++ b/docs/docs/modules/models/llms/integrations.mdx
@@ -12,7 +12,10 @@ LangChain offers a number of LLM implementations that integrate with various mod
 ```typescript
 import { OpenAI } from "langchain/llms";
 
-const model = new OpenAI({ temperature: 0.9 });
+const model = new OpenAI({
+  temperature: 0.9,
+  openAIApiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.OPENAI_API_KEY
+});
 const res = await model.call(
   "What would be a good company name a company that makes colorful socks?"
 );
@@ -28,7 +31,10 @@ npm install @huggingface/inference
 ```typescript
 import { HuggingFaceInference } from "langchain/llms";
 
-const model = new HuggingFaceInference({ model: "gpt2", apiKey: "YOUR-API-KEY" });
+const model = new HuggingFaceInference({
+  model: "gpt2",
+  apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.HUGGINGFACEHUB_API_KEY
+});
 const res = await model.call("1 + 1 =");
 console.log({ res });
 ```
@@ -42,7 +48,10 @@ npm install cohere-ai
 ```typescript
 import { Cohere } from "langchain/llms";
 
-const model = new Cohere({ maxTokens: 20, apiKey: "YOUR-API-KEY" });
+const model = new Cohere({
+  maxTokens: 20,
+  apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.COHERE_API_KEY
+});
 const res = await model.call(
   "What would be a good company name a company that makes colorful socks?"
 );
@@ -61,7 +70,7 @@ import { Replicate } from "langchain/llms";
 const model = new Replicate({
   model:
     "daanelson/flan-t5:04e422a9b85baed86a4f24981d7f9953e20c5fd82f6103b74ebc431588e1cec8",
-  apiKey: "YOUR-API-KEY"
+  apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.REPLICATE_API_KEY
 });
 const res = await modelA.call(
   "What would be a good company name a company that makes colorful socks?"
@@ -79,7 +88,11 @@ LangChain integrates with PromptLayer for logging and debugging prompts and resp
 2. Create an API token and pass it either as `promptLayerApiKey` argument in the `PromptLayerOpenAI` constructor or in the `PROMPTLAYER_API_KEY` environment variable.
 
 ```typescript
-const model = new PromptLayerOpenAI({ temperature: 0.9 });
+const model = new PromptLayerOpenAI({
+  temperature: 0.9,
+  openAIApiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.OPENAI_API_KEY
+  promptLayerApiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.PROMPTLAYER_API_KEY
+});
 const res = await model.call(
   "What would be a good company name a company that makes colorful socks?"
 );


### PR DESCRIPTION
- [x] Add comment after each saying eg. `In Node this defaults to the value of process.env.X_API_KEY`
- [x] Add this to OpenAI adapter (standardise argument name)
- [x] Add this to chat models and embeddings pages too