### PR TITLE
Merge CallbackManagers when passed through

### DIFF
--- a/langchain/src/agents/executor.ts
+++ b/langchain/src/agents/executor.ts
@@ -83,7 +83,7 @@ export class AgentExecutor extends BaseChain {
       if (this.returnIntermediateSteps) {
         return { ...returnValues, intermediateSteps: steps, ...additional };
       }
-      await this.callbackManager.handleAgentEnd(
+      await callbackManager?.handleAgentEnd(
         finishStep,
         runId ?? "",
         this.verbose
@@ -92,11 +92,15 @@ export class AgentExecutor extends BaseChain {
     };
 
     while (this.shouldContinue(iterations)) {
-      const action = await this.agent.plan(steps, inputs, callbackManager?.getChild());
+      const action = await this.agent.plan(
+        steps,
+        inputs,
+        callbackManager?.getChild()
+      );
       if ("returnValues" in action) {
         return getOutput(action);
       }
-      await this.callbackManager.handleAgentAction(
+      await callbackManager?.handleAgentAction(
         action,
         runId ?? "",
         this.verbose
@@ -104,7 +108,11 @@ export class AgentExecutor extends BaseChain {
 
       const tool = toolsByName[action.tool.toLowerCase()];
       const observation = tool
-        ? await tool.call(action.toolInput, this.verbose, callbackManager?.getChild())
+        ? await tool.call(
+            action.toolInput,
+            this.verbose,
+            callbackManager?.getChild()
+          )
         : `${action.tool} is not a valid tool, try another one.`;
       steps.push({ action, observation });
       if (tool?.returnDirect) {

--- a/langchain/src/agents/tools/base.ts
+++ b/langchain/src/agents/tools/base.ts
@@ -28,7 +28,10 @@ export abstract class Tool {
     callbackManager?: CallbackManager
   ): Promise<string> {
     const verbose_ = verbose ?? this.verbose;
-    const callbackManager_ = callbackManager ?? this.callbackManager;
+    const callbackManager_ = callbackManager?.copy() ?? new CallbackManager();
+    for (const handler of this.callbackManager.handlers) {
+      callbackManager_.addHandler(handler);
+    }
     const runId = await callbackManager_.handleToolStart(
       { name: this.name },
       arg,

--- a/langchain/src/agents/tools/base.ts
+++ b/langchain/src/agents/tools/base.ts
@@ -28,7 +28,9 @@ export abstract class Tool {
     callbackManager?: CallbackManager
   ): Promise<string> {
     const verbose_ = verbose ?? this.verbose;
-    const callbackManager_ = callbackManager?.copy() ?? new CallbackManager();
+    const callbackManager_ =
+      callbackManager?.copy(this.callbackManager.handlers) ??
+      this.callbackManager;
     for (const handler of this.callbackManager.handlers) {
       callbackManager_.addHandler(handler);
     }

--- a/langchain/src/callbacks/base.ts
+++ b/langchain/src/callbacks/base.ts
@@ -510,6 +510,12 @@ export class CallbackManager extends BaseCallbackManager {
     return manager;
   }
 
+  copy(): CallbackManager {
+    const manager = new CallbackManager(this._parentRunId);
+    manager.setHandlers(this.handlers);
+    return manager;
+  }
+
   static fromHandlers(handlers: BaseCallbackHandlerMethods) {
     class Handler extends BaseCallbackHandler {
       alwaysVerbose = true;

--- a/langchain/src/callbacks/base.ts
+++ b/langchain/src/callbacks/base.ts
@@ -510,9 +510,9 @@ export class CallbackManager extends BaseCallbackManager {
     return manager;
   }
 
-  copy(): CallbackManager {
+  copy(additionalHandlers: BaseCallbackHandler[] = []): CallbackManager {
     const manager = new CallbackManager(this._parentRunId);
-    manager.setHandlers(this.handlers);
+    manager.setHandlers([...this.handlers, ...additionalHandlers]);
     return manager;
   }
 

--- a/langchain/src/chains/base.ts
+++ b/langchain/src/chains/base.ts
@@ -84,7 +84,10 @@ export abstract class BaseChain implements ChainInputs {
     callbackManager?: CallbackManager
   ): Promise<ChainValues> {
     const fullValues = { ...values } as typeof values;
-    const callbackManager_ = callbackManager ?? this.callbackManager;
+    const callbackManager_ = callbackManager?.copy() ?? new CallbackManager();
+    for (const handler of this.callbackManager.handlers) {
+      callbackManager_.addHandler(handler);
+    }
     if (!(this.memory == null)) {
       const newValues = await this.memory.loadMemoryVariables(values);
       for (const [key, value] of Object.entries(newValues)) {

--- a/langchain/src/chains/base.ts
+++ b/langchain/src/chains/base.ts
@@ -84,10 +84,9 @@ export abstract class BaseChain implements ChainInputs {
     callbackManager?: CallbackManager
   ): Promise<ChainValues> {
     const fullValues = { ...values } as typeof values;
-    const callbackManager_ = callbackManager?.copy() ?? new CallbackManager();
-    for (const handler of this.callbackManager.handlers) {
-      callbackManager_.addHandler(handler);
-    }
+    const callbackManager_ =
+      callbackManager?.copy(this.callbackManager.handlers) ??
+      this.callbackManager;
     if (!(this.memory == null)) {
       const newValues = await this.memory.loadMemoryVariables(values);
       for (const [key, value] of Object.entries(newValues)) {

--- a/langchain/src/chat_models/base.ts
+++ b/langchain/src/chat_models/base.ts
@@ -37,10 +37,9 @@ export abstract class BaseChatModel extends BaseLanguageModel {
     const messageStrings: string[] = messages.map((messageList) =>
       getBufferString(messageList)
     );
-    const callbackManager_ = callbackManager?.copy() ?? new CallbackManager();
-    for (const handler of this.callbackManager.handlers) {
-      callbackManager_.addHandler(handler);
-    }
+    const callbackManager_ =
+      callbackManager?.copy(this.callbackManager.handlers) ??
+      this.callbackManager;
     const runId = await callbackManager_.handleLLMStart(
       { name: this._llmType() },
       messageStrings,

--- a/langchain/src/chat_models/base.ts
+++ b/langchain/src/chat_models/base.ts
@@ -37,7 +37,10 @@ export abstract class BaseChatModel extends BaseLanguageModel {
     const messageStrings: string[] = messages.map((messageList) =>
       getBufferString(messageList)
     );
-    const callbackManager_ = callbackManager ?? new CallbackManager();
+    const callbackManager_ = callbackManager?.copy() ?? new CallbackManager();
+    for (const handler of this.callbackManager.handlers) {
+      callbackManager_.addHandler(handler);
+    }
     const runId = await callbackManager_.handleLLMStart(
       { name: this._llmType() },
       messageStrings,

--- a/langchain/src/llms/base.ts
+++ b/langchain/src/llms/base.ts
@@ -79,7 +79,10 @@ export abstract class BaseLLM extends BaseLanguageModel {
     stop?: string[],
     callbackManager?: CallbackManager
   ): Promise<LLMResult> {
-    const callbackManager_ = callbackManager ?? this.callbackManager;
+    const callbackManager_ = callbackManager?.copy() ?? new CallbackManager();
+    for (const handler of this.callbackManager.handlers) {
+      callbackManager_.addHandler(handler);
+    }
     const runId = await callbackManager_.handleLLMStart(
       { name: this._llmType() },
       prompts,

--- a/langchain/src/llms/base.ts
+++ b/langchain/src/llms/base.ts
@@ -79,10 +79,9 @@ export abstract class BaseLLM extends BaseLanguageModel {
     stop?: string[],
     callbackManager?: CallbackManager
   ): Promise<LLMResult> {
-    const callbackManager_ = callbackManager?.copy() ?? new CallbackManager();
-    for (const handler of this.callbackManager.handlers) {
-      callbackManager_.addHandler(handler);
-    }
+    const callbackManager_ =
+      callbackManager?.copy(this.callbackManager.handlers) ??
+      this.callbackManager;
     const runId = await callbackManager_.handleLLMStart(
       { name: this._llmType() },
       prompts,


### PR DESCRIPTION
I think it will be really hard to get rid of self.callback_manager / this.callbackManager the way things are set up now, because sometimes we only want certain callbacks on certain objects (like we in the case of the ConversationalRetrievalChain , we want the llm associated with the QA chain to hit the on_llm_new_token callback and not the question gen one).