### PR TITLE
Adds JavascriptTextSplitter and GenericCodeSplitter

### DIFF
--- a/langchain/src/tests/text_splitter.test.ts
+++ b/langchain/src/tests/text_splitter.test.ts
@@ -2,6 +2,10 @@ import { test, expect } from "@jest/globals";
 import { Document } from "../document.js";
 import {
   CharacterTextSplitter,
+  GenericCodeSplitter,
+  JavascriptClassTextSplitter,
+  JavascriptFunctionTextSplitter,
+  JavascriptTextSplitter,
   MarkdownTextSplitter,
   RecursiveCharacterTextSplitter,
   TokenTextSplitter,
@@ -205,4 +209,306 @@ test("Test lines loc on iterative text splitter.", async () => {
   ];
 
   expect(docs).toEqual(expectedDocs);
+});
+
+test("Test javascript function splitter.", async () => {
+  const text = `
+  import { test, expect } from "@jest/globals";
+  import { Document } from "../document.js";
+  import {
+    CharacterTextSplitter,
+    MarkdownTextSplitter,
+    RecursiveCharacterTextSplitter,
+    TokenTextSplitter,
+  } from "../text_splitter.js";
+
+  export interface SomeInterface {
+    someParam: string
+    someOtherParam: string
+
+    function someMethod(): string
+  }
+
+  abstract class SomeAbstractClass {
+    abstract function someMethod(): string
+  }
+
+  export class SomeRandomClass {
+    static someParam
+    const someOtherParam
+    let aVar = "test"
+
+    // Constructor is wrongly documented, but thats okay
+    // A second line
+    constructor() {
+      this.someParam = "test"
+      this.someOtherParam = "anotherTest"
+    }
+
+    // A random inline comment
+
+    async function someMethod() {
+      return this.someParam
+    }
+
+    /* The earlier method was documented, but this one isn't! */
+    function anotherMethod() {
+      throw new Error("Method not yet implemented.")
+    }
+  }
+  `;
+
+  const splitter = new JavascriptFunctionTextSplitter({
+    chunkSize: 1,
+    chunkOverlap: 0,
+  });
+  const docs = await splitter.createDocuments([text]);
+
+  expect(docs.length).toBe(6);
+});
+
+test("Test javascript class splitter.", async () => {
+  const text = `
+  import { test, expect } from "@jest/globals";
+  import { Document } from "../document.js";
+  import {
+    CharacterTextSplitter,
+    MarkdownTextSplitter,
+    RecursiveCharacterTextSplitter,
+    TokenTextSplitter,
+  } from "../text_splitter.js";
+
+  export interface SomeInterface {
+    someParam: string
+    someOtherParam: string
+
+    function someMethod(): string
+  }
+
+  abstract class SomeAbstractClass {
+    abstract function someMethod(): string
+  }
+
+  export class SomeRandomClass {
+    static someParam
+    const someOtherParam
+    let aVar = "test"
+
+    // Constructor is wrongly documented, but thats okay
+    // A second line
+    constructor() {
+      this.someParam = "test"
+      this.someOtherParam = "anotherTest"
+    }
+
+    // A random inline comment
+
+    async function someMethod() {
+      return this.someParam
+    }
+
+    /* The earlier method was documented, but this one isn't! */
+    function anotherMethod() {
+      throw new Error("Method not yet implemented.")
+    }
+  }
+  `;
+
+  const splitter = new JavascriptClassTextSplitter({
+    chunkSize: 1,
+    chunkOverlap: 0,
+  });
+  const docs = await splitter.createDocuments([text]);
+
+  expect(docs.length).toBe(4);
+});
+
+test("Test javascript splitter.", async () => {
+  const text = `
+  import { test, expect } from "@jest/globals";
+  import { Document } from "../document.js";
+  import {
+    CharacterTextSplitter,
+    MarkdownTextSplitter,
+    RecursiveCharacterTextSplitter,
+    TokenTextSplitter,
+  } from "../text_splitter.js";
+
+  export interface SomeInterface {
+    someParam: string
+    someOtherParam: string
+
+    function someMethod(): string
+  }
+
+  abstract class SomeAbstractClass {
+    abstract function someMethod(): string
+  }
+
+  export class SomeRandomClass {
+    static someParam
+    const someOtherParam
+    let aVar = "test"
+
+    // Constructor is wrongly documented, but thats okay
+    // A second line
+    constructor() {
+      this.someParam = "test"
+      this.someOtherParam = "anotherTest"
+    }
+
+    // A random inline comment
+
+    async function someMethod() {
+      return this.someParam
+    }
+
+    /* The earlier method was documented, but this one isn't! */
+    function anotherMethod() {
+      throw new Error("Method not yet implemented.")
+    }
+  }
+  `;
+
+  const splitter = new JavascriptTextSplitter({
+    chunkSize: 1,
+    chunkOverlap: 0,
+  });
+  const docs = await splitter.createDocuments([text]);
+
+  expect(docs.length).toBe(9);
+});
+
+test("Test generic splitter.", async () => {
+  const text = `
+  contract Dai is LibNote {
+    // --- Auth ---
+    mapping (address => uint) public wards;
+    function rely(address guy) external note auth { wards[guy] = 1; }
+    function deny(address guy) external note auth { wards[guy] = 0; }
+    modifier auth {
+        require(wards[msg.sender] == 1, "Dai/not-authorized");
+        _;
+    }
+
+    // --- ERC20 Data ---
+    string  public constant name     = "Dai Stablecoin";
+    string  public constant symbol   = "DAI";
+    string  public constant version  = "1";
+    uint8   public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping (address => uint)                      public balanceOf;
+    mapping (address => mapping (address => uint)) public allowance;
+    mapping (address => uint)                      public nonces;
+
+    event Approval(address indexed src, address indexed guy, uint wad);
+    event Transfer(address indexed src, address indexed dst, uint wad);
+
+    // --- Math ---
+    function add(uint x, uint y) internal pure returns (uint z) {
+        require((z = x + y) >= x);
+    }
+    function sub(uint x, uint y) internal pure returns (uint z) {
+        require((z = x - y) <= x);
+    }
+
+    // --- EIP712 niceties ---
+    bytes32 public DOMAIN_SEPARATOR;
+    // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
+    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+
+    constructor(uint256 chainId_) public {
+        wards[msg.sender] = 1;
+        DOMAIN_SEPARATOR = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes(name)),
+            keccak256(bytes(version)),
+            chainId_,
+            address(this)
+        ));
+    }
+
+    // --- Token ---
+    function transfer(address dst, uint wad) external returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+    function transferFrom(address src, address dst, uint wad)
+        public returns (bool)
+    {
+        require(balanceOf[src] >= wad, "Dai/insufficient-balance");
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[src][msg.sender] = sub(allowance[src][msg.sender], wad);
+        }
+        balanceOf[src] = sub(balanceOf[src], wad);
+        balanceOf[dst] = add(balanceOf[dst], wad);
+        emit Transfer(src, dst, wad);
+        return true;
+    }
+    function mint(address usr, uint wad) external auth {
+        balanceOf[usr] = add(balanceOf[usr], wad);
+        totalSupply    = add(totalSupply, wad);
+        emit Transfer(address(0), usr, wad);
+    }
+    function burn(address usr, uint wad) external {
+        require(balanceOf[usr] >= wad, "Dai/insufficient-balance");
+        if (usr != msg.sender && allowance[usr][msg.sender] != uint(-1)) {
+            require(allowance[usr][msg.sender] >= wad, "Dai/insufficient-allowance");
+            allowance[usr][msg.sender] = sub(allowance[usr][msg.sender], wad);
+        }
+        balanceOf[usr] = sub(balanceOf[usr], wad);
+        totalSupply    = sub(totalSupply, wad);
+        emit Transfer(usr, address(0), wad);
+    }
+    function approve(address usr, uint wad) external returns (bool) {
+        allowance[msg.sender][usr] = wad;
+        emit Approval(msg.sender, usr, wad);
+        return true;
+    }
+
+    // --- Alias ---
+    function push(address usr, uint wad) external {
+        transferFrom(msg.sender, usr, wad);
+    }
+    function pull(address usr, uint wad) external {
+        transferFrom(usr, msg.sender, wad);
+    }
+    function move(address src, address dst, uint wad) external {
+        transferFrom(src, dst, wad);
+    }
+
+    // --- Approve by signature ---
+    function permit(address holder, address spender, uint256 nonce, uint256 expiry,
+                    bool allowed, uint8 v, bytes32 r, bytes32 s) external
+    {
+        bytes32 digest =
+            keccak256(abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR,
+                keccak256(abi.encode(PERMIT_TYPEHASH,
+                                     holder,
+                                     spender,
+                                     nonce,
+                                     expiry,
+                                     allowed))
+        ));
+
+        require(holder != address(0), "Dai/invalid-address-0");
+        require(holder == ecrecover(digest, v, r, s), "Dai/invalid-permit");
+        require(expiry == 0 || now <= expiry, "Dai/permit-expired");
+        require(nonce == nonces[holder]++, "Dai/invalid-nonce");
+        uint wad = allowed ? uint(-1) : 0;
+        allowance[holder][spender] = wad;
+        emit Approval(holder, spender, wad);
+    }
+}`;
+
+  const splitter = new GenericCodeSplitter(
+    ["contract", "mapping", "modifier", "function"],
+    { chunkSize: 10, chunkOverlap: 0 }
+  );
+  const docs = await splitter.createDocuments([text]);
+
+  expect(docs.length).toBe(19);
 });

--- a/langchain/src/tests/text_splitter.test.ts
+++ b/langchain/src/tests/text_splitter.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@jest/globals";
 import { Document } from "../document.js";
 import {
   CharacterTextSplitter,
-  GenericCodeSplitter,
+  GenericCodeTextSplitter,
   JavascriptClassTextSplitter,
   JavascriptFunctionTextSplitter,
   JavascriptTextSplitter,
@@ -504,7 +504,7 @@ test("Test generic splitter.", async () => {
     }
 }`;
 
-  const splitter = new GenericCodeSplitter(
+  const splitter = new GenericCodeTextSplitter(
     ["contract", "mapping", "modifier", "function"],
     { chunkSize: 10, chunkOverlap: 0 }
   );

--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -449,7 +449,7 @@ export abstract class BaseCodeSplitter extends TextSplitter {
   }
 }
 
-export class GenericCodeSplitter extends BaseCodeSplitter {
+export class GenericCodeTextSplitter extends BaseCodeSplitter {
   constructor(keywords: string[], fields?: Partial<TextSplitterParams>) {
     super(fields);
 

--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -407,8 +407,6 @@ export abstract class BaseCodeSplitter extends TextSplitter {
 
     // find our first match
     while (match && match[0]) {
-      console.log("match", match);
-
       // find and remove our first match - this is the start of our string
       // it should be index 0
       // only do this if this isn't our first run through or if we have an immediate match
@@ -442,8 +440,6 @@ export abstract class BaseCodeSplitter extends TextSplitter {
         results.push((matchingText + remainingText).trim());
       }
     }
-
-    console.log(results);
 
     return results;
   }

--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -330,3 +330,139 @@ export class MarkdownTextSplitter
     super(fields);
   }
 }
+
+export abstract class JavascriptBaseTextSplitter extends TextSplitter {
+  abstract regex: RegExp;
+
+  async splitText(text: string): Promise<string[]> {
+    // use regex to split among all js and ts style function definitions
+
+    const results: string[] = [];
+
+    let remainingText = text;
+    let match = remainingText.match(this.regex);
+
+    // find our first match
+    while (match && match[0]) {
+      // find and remove our first match - this is the start of our string
+      // it should be index 0
+      // only do this if this isn't our first run through
+
+      let matchingText = "";
+
+      if (text !== remainingText) {
+        [matchingText] = match;
+        const matchingIndex = match.indexOf(matchingText);
+
+        if (matchingIndex !== 0)
+          throw new Error(
+            `Unexpected matching index - should be zero. Got ${matchingIndex}`
+          );
+
+        // remove the matching text from the remaining text
+        remainingText = remainingText.slice(matchingText.length);
+      }
+
+      // find the next match
+      match = remainingText.match(this.regex);
+
+      if (match && match[0]) {
+        const nextIndex = match.index;
+        // add text up to the next index & remove from remaining text
+        const result = matchingText + remainingText.slice(0, nextIndex);
+        results.push(result.trim());
+        remainingText = remainingText.slice(nextIndex);
+      } else {
+        // If not another match, add all remaining text. We're done.
+        results.push((matchingText + remainingText).trim());
+      }
+    }
+
+    return results;
+  }
+}
+
+export class JavascriptClassTextSplitter extends JavascriptBaseTextSplitter {
+  regex = /(((.*\/\/.*\n)*)|(.*\/\*.*\n))(.*((class)|(interface)).*)/;
+}
+export class JavascriptFunctionTextSplitter extends JavascriptBaseTextSplitter {
+  regex = /(((.*\/\/.*\n)*)|(.*\/\*.*\n))(.*((function)|(constructor)).*)/;
+}
+
+export class JavascriptTextSplitter extends JavascriptBaseTextSplitter {
+  regex =
+    /(((.*\/\/.*\n)*)|(.*\/\*.*\n))(.*((function)|(constructor)|(class)|(interface)).*)/;
+}
+
+export abstract class BaseCodeSplitter extends TextSplitter {
+  public regex: RegExp;
+
+  async splitText(text: string): Promise<string[]> {
+    // use regex to split among all js and ts style function definitions
+
+    const results: string[] = [];
+
+    let remainingText = text;
+    let match = remainingText.match(this.regex);
+
+    // find our first match
+    while (match && match[0]) {
+      console.log("match", match);
+
+      // find and remove our first match - this is the start of our string
+      // it should be index 0
+      // only do this if this isn't our first run through or if we have an immediate match
+
+      let matchingText = "";
+
+      if (text !== remainingText || match.indexOf(match[0]) === 0) {
+        [matchingText] = match;
+        const matchingIndex = match.indexOf(matchingText);
+
+        if (matchingIndex !== 0)
+          throw new Error(
+            `Unexpected matching index - should be zero. Got ${matchingIndex}`
+          );
+
+        // remove the matching text from the remaining text
+        remainingText = remainingText.slice(matchingText.length);
+      }
+
+      // find the next match
+      match = remainingText.match(this.regex);
+
+      if (match && match[0]) {
+        const nextIndex = match.index;
+        // add text up to the next index & remove from remaining text
+        const result = matchingText + remainingText.slice(0, nextIndex);
+        results.push(result.trim());
+        remainingText = remainingText.slice(nextIndex);
+      } else {
+        // If not another match, add all remaining text. We're done.
+        results.push((matchingText + remainingText).trim());
+      }
+    }
+
+    console.log(results);
+
+    return results;
+  }
+}
+
+export class GenericCodeSplitter extends BaseCodeSplitter {
+  constructor(keywords: string[], fields?: Partial<TextSplitterParams>) {
+    super(fields);
+
+    let partialRegex = "";
+    for (const keyword of keywords) {
+      partialRegex += `(${keyword})|`;
+    }
+
+    partialRegex = partialRegex.slice(0, partialRegex.length - 1);
+
+    this.regex = new RegExp(
+      `(((.*//.*\n)*)|(.*/*.*\n))(.*(${partialRegex}).*)`
+    );
+    console.log(this.regex);
+  }
+}

--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -461,8 +461,7 @@ export class GenericCodeSplitter extends BaseCodeSplitter {
     partialRegex = partialRegex.slice(0, partialRegex.length - 1);
 
     this.regex = new RegExp(
-      `(((.*//.*\n)*)|(.*/*.*\n))(.*(${partialRegex}).*)`
+      `(((.*\\/\\/.*\n)*)|(.*\\/\\*.*\n))(.*(${partialRegex}).*)`
     );
-    console.log(this.regex);
   }
 }


### PR DESCRIPTION
Adds an abstract splitter `JavascriptBaseTextSplitter` which splits on regex, implemented by:

`JavascriptClassTextSplitter` - which splits right before class and interface declarations (and any comments for them)
`JavascriptFunctionTextSplitter` - which splits right before function and constructor declarations (and any comments for them)
`JavascriptTextSplitter` - combines the above two

Adds a `GenericCodeTextSplitter` which splits on provided keywords, and any comments that immediately precede them.

These classes split text *right before* the keywords they're looking for, where *right before* means "immediately before the first comment that is immediately line-adjacent to the keyword in question"