### PR TITLE
Instructions for running Pinecone example

### DIFF
--- a/examples/src/indexes/vector_stores/pinecone.ts
+++ b/examples/src/indexes/vector_stores/pinecone.ts
@@ -2,6 +2,11 @@ import { PineconeClient } from "@pinecone-database/pinecone";
 import { OpenAIEmbeddings } from "langchain/embeddings";
 import { PineconeStore } from "langchain/vectorstores";
 
+// To run this example, first [create a Pinecone index](https://app.pinecone.io/organizations)
+// It must have 1536 dimensions, to match the OpenAI embedding size.
+// It should use the metric "cosine" to get the results below.
+// Point to this index from your .env.
+
 export const run = async () => {
   if (
     !process.env.PINECONE_API_KEY ||


### PR DESCRIPTION
Using default Pinecone indexes results in error due to dimension mismatch.