### PR TITLE
docs: add missing 's'

### DIFF
--- a/docs/docs/ecosystem/unstructured.md
+++ b/docs/docs/ecosystem/unstructured.md
@@ -24,7 +24,7 @@ If you are running the container locally, switch the url to
 `https://api.unstructured.io/general/v0/general`.
 
 ```typescript
-import { UnstructuredLoader } from "langchain/document_loader";
+import { UnstructuredLoader } from "langchain/document_loaders";
 
 const loader = new UnstructuredLoader(
   "https://api.unstructured.io/general/v0/general",

--- a/docs/docs/ecosystem/unstructured.md
+++ b/docs/docs/ecosystem/unstructured.md
@@ -24,7 +24,7 @@ If you are running the container locally, switch the url to
 `https://api.unstructured.io/general/v0/general`.
 
 ```typescript
-import { UnstructuredLoader } from "langchain/document_loaders";
+import { UnstructuredLoader } from "langchain/document_loaders/fs/unstructured";
 
 const loader = new UnstructuredLoader(
   "https://api.unstructured.io/general/v0/general",


### PR DESCRIPTION
the code which import UnstructuredLoader in docs, missing a 's'

```javascript
import { UnstructuredLoader } from "langchain/document_loader";
```

should be:

```javascript
import { UnstructuredLoader } from "langchain/document_loaders";
```

or it will get type error
