### PR TITLE
Adds `returnDirect` to DynamicTool

### DIFF
--- a/langchain/src/tools/dynamic.ts
+++ b/langchain/src/tools/dynamic.ts
@@ -11,11 +11,13 @@ export class DynamicTool extends Tool {
     name: string;
     description: string;
     func: (arg1: string) => Promise<string>;
+    returnDirect?: boolean;
   }) {
     super();
     this.name = fields.name;
     this.description = fields.description;
     this.func = fields.func;
+    this.returnDirect = fields.returnDirect ?? this.returnDirect;
   }
 
   async _call(input: string): Promise<string> {


### PR DESCRIPTION
DynamicTool is missing the option to return direct the output of the tool.