### PR TITLE
Improve pgvector docs

### DIFF
--- a/docs/docs/modules/indexes/retrievers/supabase-hybrid.mdx
+++ b/docs/docs/modules/indexes/retrievers/supabase-hybrid.mdx
@@ -52,11 +52,6 @@ begin
 end;
 $$;
 
--- Create an index to be used by the similarity search function
-create index on documents
-  using ivfflat (embedding vector_cosine_ops)
-  with (lists = 100);
-
 -- Create a function to keyword search for documents
 create function kw_match_documents(query_text text, match_count int)
 returns table (id bigint, content text, metadata jsonb, similarity real)

--- a/docs/docs/modules/indexes/vector_stores/integrations/supabase.mdx
+++ b/docs/docs/modules/indexes/vector_stores/integrations/supabase.mdx
@@ -51,11 +51,6 @@ begin
   limit match_count;
 end;
 $$;
-
--- Create an index to be used by the search function
-create index on documents
-  using ivfflat (embedding vector_cosine_ops)
-  with (lists = 100);
 ```
 
 ## Usage


### PR DESCRIPTION
Hi, thanks for adding pgvector to the LangChain ecosystem!

The docs currently instruct users to run `CREATE INDEX` right after creating the table. However, this will lead to poor recall. I think it'd be better for users to use exact nearest neighbor search (for perfect recall) and only add an index when querying becomes slow (and the table has data).

More info: https://github.com/pgvector/pgvector#indexing
