### PR TITLE
serpapi results coming back in another region/languge

### DIFF
--- a/docs/docs/getting-started/guide-chat.mdx
+++ b/docs/docs/getting-started/guide-chat.mdx
@@ -281,6 +281,8 @@ And finally, we can use the AgentExecutor to run an agent:
 const tools = [
   new SerpAPI(process.env.SERPAPI_API_KEY, {
     location: "Austin,Texas,United States",
+    hl: "en",
+    gl: "us",
   }),
 ];
 // Create the agent from the chat model and the tools

--- a/docs/docs/getting-started/guide-chat.mdx
+++ b/docs/docs/getting-started/guide-chat.mdx
@@ -278,7 +278,11 @@ And finally, we can use the AgentExecutor to run an agent:
 
 ```typescript
 // Define the list of tools the agent can use
-const tools = [new SerpAPI()];
+const tools = [
+  new SerpAPI(process.env.SERPAPI_API_KEY, {
+    location: "Austin,Texas,United States",
+  }),
+];
 // Create the agent from the chat model and the tools
 const agent = ChatAgent.fromLLMAndTools(new ChatOpenAI(), tools);
 // Create an executor, which calls to the agent until an answer is found

--- a/docs/docs/getting-started/guide-llm.mdx
+++ b/docs/docs/getting-started/guide-llm.mdx
@@ -174,6 +174,8 @@ const model = new OpenAI({ temperature: 0 });
 const tools = [
   new SerpAPI(process.env.SERPAPI_API_KEY, {
     location: "Austin,Texas,United States",
+    hl: "en",
+    gl: "us",
   }),
   new Calculator(),
 ];

--- a/docs/docs/getting-started/guide-llm.mdx
+++ b/docs/docs/getting-started/guide-llm.mdx
@@ -171,7 +171,12 @@ import { SerpAPI } from "langchain/tools";
 import { Calculator } from "langchain/tools/calculator";
 
 const model = new OpenAI({ temperature: 0 });
-const tools = [new SerpAPI(), new Calculator()];
+const tools = [
+  new SerpAPI(process.env.SERPAPI_API_KEY, {
+    location: "Austin,Texas,United States",
+  }),
+  new Calculator(),
+];
 
 const executor = await initializeAgentExecutor(
   tools,

--- a/docs/docs/modules/agents/executor/getting-started.md
+++ b/docs/docs/modules/agents/executor/getting-started.md
@@ -30,7 +30,12 @@ import { SerpAPI } from "langchain/tools";
 import { Calculator } from "langchain/tools/calculator";
 
 const model = new OpenAI({ temperature: 0 });
-const tools = [new SerpAPI(), new Calculator()];
+const tools = [
+  new SerpAPI(process.env.SERPAPI_API_KEY, {
+    location: "Austin,Texas,United States",
+  }),
+  new Calculator(),
+];
 
 const executor = await initializeAgentExecutor(
   tools,

--- a/docs/docs/modules/agents/executor/getting-started.md
+++ b/docs/docs/modules/agents/executor/getting-started.md
@@ -33,6 +33,8 @@ const model = new OpenAI({ temperature: 0 });
 const tools = [
   new SerpAPI(process.env.SERPAPI_API_KEY, {
     location: "Austin,Texas,United States",
+    hl: "en",
+    gl: "us",
   }),
   new Calculator(),
 ];

--- a/docs/docs/modules/agents/tools/agents_with_vectorstores.md
+++ b/docs/docs/modules/agents/tools/agents_with_vectorstores.md
@@ -47,7 +47,13 @@ const qaTool = new ChainTool({
 Now you can construct and using the tool just as you would any other!
 
 ```typescript
-const tools = [new SerpAPI(), new Calculator(), qaTool];
+const tools = [
+  new SerpAPI(process.env.SERPAPI_API_KEY, {
+    location: "Austin,Texas,United States",
+  }),
+  new Calculator(),
+  qaTool,
+];
 
 const executor = await initializeAgentExecutor(
   tools,

--- a/docs/docs/modules/agents/tools/agents_with_vectorstores.md
+++ b/docs/docs/modules/agents/tools/agents_with_vectorstores.md
@@ -50,6 +50,8 @@ Now you can construct and using the tool just as you would any other!
 const tools = [
   new SerpAPI(process.env.SERPAPI_API_KEY, {
     location: "Austin,Texas,United States",
+    hl: "en",
+    gl: "us",
   }),
   new Calculator(),
   qaTool,

--- a/docs/docs/production/tracing.md
+++ b/docs/docs/production/tracing.md
@@ -21,6 +21,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];
@@ -63,6 +65,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];
@@ -103,6 +107,8 @@ export const run = async () => {
     const tools = [
       new SerpAPI(process.env.SERPAPI_API_KEY, {
         location: "Austin,Texas,United States",
+        hl: "en",
+        gl: "us",
       }),
       new Calculator(),
     ];

--- a/docs/docs/production/tracing.md
+++ b/docs/docs/production/tracing.md
@@ -18,7 +18,12 @@ import process from "process";
 export const run = async () => {
   process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new OpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,
@@ -55,7 +60,12 @@ import {
 export const run = async () => {
   process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new OpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,
@@ -90,7 +100,12 @@ export const run = async () => {
     callbackManager.addHandler(new LangChainTracer());
 
     const model = new OpenAI({ temperature: 0, callbackManager });
-    const tools = [new SerpAPI(), new Calculator()];
+    const tools = [
+      new SerpAPI(process.env.SERPAPI_API_KEY, {
+        location: "Austin,Texas,United States",
+      }),
+      new Calculator(),
+    ];
     for (const tool of tools) {
       tool.callbackManager = callbackManager;
     }

--- a/examples/src/agents/chat_convo_with_tracing.ts
+++ b/examples/src/agents/chat_convo_with_tracing.ts
@@ -7,7 +7,12 @@ import { BufferMemory } from "langchain/memory";
 export const run = async () => {
   process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new ChatOpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,

--- a/examples/src/agents/chat_convo_with_tracing.ts
+++ b/examples/src/agents/chat_convo_with_tracing.ts
@@ -10,6 +10,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/examples/src/agents/chat_mrkl.ts
+++ b/examples/src/agents/chat_mrkl.ts
@@ -8,6 +8,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/examples/src/agents/chat_mrkl.ts
+++ b/examples/src/agents/chat_mrkl.ts
@@ -5,7 +5,12 @@ import { Calculator } from "langchain/tools/calculator";
 
 export const run = async () => {
   const model = new ChatOpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,

--- a/examples/src/agents/chat_mrkl_with_tracing.ts
+++ b/examples/src/agents/chat_mrkl_with_tracing.ts
@@ -9,6 +9,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/examples/src/agents/chat_mrkl_with_tracing.ts
+++ b/examples/src/agents/chat_mrkl_with_tracing.ts
@@ -6,7 +6,12 @@ import { Calculator } from "langchain/tools/calculator";
 export const run = async () => {
   process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new ChatOpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,

--- a/examples/src/agents/concurrent_mrkl.ts
+++ b/examples/src/agents/concurrent_mrkl.ts
@@ -12,7 +12,12 @@ import {
 export const run = async () => {
   process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new OpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,
@@ -47,7 +52,12 @@ export const run = async () => {
     callbackManager.addHandler(new LangChainTracer());
 
     const model = new OpenAI({ temperature: 0, callbackManager });
-    const tools = [new SerpAPI(), new Calculator()];
+    const tools = [
+      new SerpAPI(process.env.SERPAPI_API_KEY, {
+        location: "Austin,Texas,United States",
+      }),
+      new Calculator(),
+    ];
     for (const tool of tools) {
       tool.callbackManager = callbackManager;
     }

--- a/examples/src/agents/concurrent_mrkl.ts
+++ b/examples/src/agents/concurrent_mrkl.ts
@@ -15,6 +15,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];
@@ -55,6 +57,8 @@ export const run = async () => {
     const tools = [
       new SerpAPI(process.env.SERPAPI_API_KEY, {
         location: "Austin,Texas,United States",
+        hl: "en",
+        gl: "us",
       }),
       new Calculator(),
     ];

--- a/examples/src/agents/custom_agent.ts
+++ b/examples/src/agents/custom_agent.ts
@@ -6,7 +6,12 @@ import { LLMChain } from "langchain/chains";
 
 export const run = async () => {
   const model = new OpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const prefix = `Answer the following questions as best you can, but speaking as a pirate might speak. You have access to the following tools:`;
   const suffix = `Begin! Remember to speak as a pirate when giving your final answer. Use lots of "Args"

--- a/examples/src/agents/custom_agent.ts
+++ b/examples/src/agents/custom_agent.ts
@@ -9,6 +9,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/examples/src/agents/custom_llm_agent.ts
+++ b/examples/src/agents/custom_llm_agent.ts
@@ -107,7 +107,12 @@ class CustomOutputParser extends AgentActionOutputParser {
 
 export const run = async () => {
   const model = new OpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const llmChain = new LLMChain({
     prompt: new CustomPromptTemplate({

--- a/examples/src/agents/custom_llm_agent.ts
+++ b/examples/src/agents/custom_llm_agent.ts
@@ -110,6 +110,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/examples/src/agents/custom_llm_agent_chat.ts
+++ b/examples/src/agents/custom_llm_agent_chat.ts
@@ -113,6 +113,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/examples/src/agents/custom_llm_agent_chat.ts
+++ b/examples/src/agents/custom_llm_agent_chat.ts
@@ -110,7 +110,12 @@ class CustomOutputParser extends AgentActionOutputParser {
 
 export const run = async () => {
   const model = new ChatOpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const llmChain = new LLMChain({
     prompt: new CustomPromptTemplate({

--- a/examples/src/agents/load_from_hub.ts
+++ b/examples/src/agents/load_from_hub.ts
@@ -9,6 +9,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/examples/src/agents/load_from_hub.ts
+++ b/examples/src/agents/load_from_hub.ts
@@ -6,7 +6,12 @@ import { Calculator } from "langchain/tools/calculator";
 
 export const run = async () => {
   const model = new OpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const agent = await loadAgent(
     "lc://agents/zero-shot-react-description/agent.json",

--- a/examples/src/agents/mrkl.ts
+++ b/examples/src/agents/mrkl.ts
@@ -5,7 +5,12 @@ import { Calculator } from "langchain/tools/calculator";
 
 export const run = async () => {
   const model = new OpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,

--- a/examples/src/agents/mrkl.ts
+++ b/examples/src/agents/mrkl.ts
@@ -8,6 +8,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/examples/src/agents/mrkl_with_tracing.ts
+++ b/examples/src/agents/mrkl_with_tracing.ts
@@ -7,7 +7,12 @@ import process from "process";
 export const run = async () => {
   process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new OpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,

--- a/examples/src/agents/mrkl_with_tracing.ts
+++ b/examples/src/agents/mrkl_with_tracing.ts
@@ -10,6 +10,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/examples/src/chat/agent.ts
+++ b/examples/src/chat/agent.ts
@@ -12,6 +12,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
   ];
 

--- a/examples/src/chat/agent.ts
+++ b/examples/src/chat/agent.ts
@@ -9,7 +9,11 @@ import {
 } from "langchain/prompts";
 
 export const run = async () => {
-  const tools = [new SerpAPI()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+  ];
 
   const prompt = ZeroShotAgent.createPrompt(tools, {
     prefix: `Answer the following questions as best you can, but speaking as a pirate might speak. You have access to the following tools:`,

--- a/examples/src/chat/overview.ts
+++ b/examples/src/chat/overview.ts
@@ -128,6 +128,8 @@ export const run = async () => {
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
   ];
   // Create the agent from the chat model and the tools

--- a/examples/src/chat/overview.ts
+++ b/examples/src/chat/overview.ts
@@ -125,7 +125,11 @@ export const run = async () => {
   // other abilities, such as search, or a calculator
 
   // Define the list of tools the agent can use
-  const tools = [new SerpAPI()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+  ];
   // Create the agent from the chat model and the tools
   const agent = ChatAgent.fromLLMAndTools(new ChatOpenAI(), tools);
   // Create an executor, which calls to the agent until an answer is found

--- a/langchain/src/agents/tests/agent.int.test.ts
+++ b/langchain/src/agents/tests/agent.int.test.ts
@@ -9,7 +9,11 @@ import { initializeAgentExecutor } from "../initialize.js";
 test("Run agent from hub", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-babbage-001" });
   const tools: Tool[] = [
-    new SerpAPI(undefined, { location: "Austin,Texas,United States" }),
+    new SerpAPI(undefined, {
+      location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
+    }),
     new Calculator(),
   ];
   const agent = await loadAgent(
@@ -31,7 +35,11 @@ test("Run agent from hub", async () => {
 test("Run agent locally", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-babbage-001" });
   const tools = [
-    new SerpAPI(undefined, { location: "Austin,Texas,United States" }),
+    new SerpAPI(undefined, {
+      location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
+    }),
     new Calculator(),
   ];
 

--- a/langchain/src/agents/tests/agent.int.test.ts
+++ b/langchain/src/agents/tests/agent.int.test.ts
@@ -8,7 +8,10 @@ import { initializeAgentExecutor } from "../initialize.js";
 
 test("Run agent from hub", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-babbage-001" });
-  const tools: Tool[] = [new SerpAPI(), new Calculator()];
+  const tools: Tool[] = [
+    new SerpAPI(undefined, { location: "Austin,Texas,United States" }),
+    new Calculator(),
+  ];
   const agent = await loadAgent(
     "lc://agents/zero-shot-react-description/agent.json",
     { llm: model, tools }
@@ -27,7 +30,10 @@ test("Run agent from hub", async () => {
 
 test("Run agent locally", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-babbage-001" });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(undefined, { location: "Austin,Texas,United States" }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,

--- a/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
+++ b/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
@@ -28,8 +28,10 @@ test.skip("Test Traced Agent with concurrency (skipped until we fix concurrency)
   process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new OpenAI({ temperature: 0 });
   const tools = [
-    new SerpAPI(process.env.SERPAPI_API_KEY, {
+    new SerpAPI(undefined, {
       location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
     }),
     new Calculator(),
   ];

--- a/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
+++ b/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
@@ -27,7 +27,12 @@ test("Test LangChain tracer", async () => {
 test.skip("Test Traced Agent with concurrency (skipped until we fix concurrency)", async () => {
   process.env.LANGCHAIN_HANDLER = "langchain";
   const model = new OpenAI({ temperature: 0 });
-  const tools = [new SerpAPI(), new Calculator()];
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+    }),
+    new Calculator(),
+  ];
 
   const executor = await initializeAgentExecutor(
     tools,

--- a/langchain/src/tools/serpapi.ts
+++ b/langchain/src/tools/serpapi.ts
@@ -43,9 +43,13 @@ interface GoogleParameters extends BaseParameters {
   q: string;
   /**
    * Location
-   * Parameter defines from where you want the search to originate. If several
-   * locations match the location requested, we'll pick the most popular one. Head to
-   * the [/locations.json API](https://serpapi.com/locations-api) if you need more
+   * Parameter defines from where you want the search to originate. Serpapi advises
+   * that if you do not provide a location, any location from around the world might
+   * be used including a different region and language. Location can be a canonical
+   * name (e.g., "Austin,Texas,United States") or the location id
+   * (e.g., "585069efee19ad271e9c9b36") If several locations match the location
+   * requested, we'll pick the most popular one. Head to the
+   * [/locations.json API](https://serpapi.com/locations-api) if you need more
    * precise control. location and uule parameters can't be used together. Avoid
    * utilizing location when setting the location outside the U.S. when using Google
    * Shopping and/or Google Product API.

--- a/langchain/src/tools/serpapi.ts
+++ b/langchain/src/tools/serpapi.ts
@@ -5,6 +5,9 @@ import { Tool } from "./base.js";
  * when used in `jest` tests. Part of the issue seems to be that the `serpapi`
  * package imports a wasm module to use instead of native `fetch`, which we
  * don't want anyway.
+ *
+ * NOTE: you must provide location, gl and hl or your region and language will
+ * may not match your location, and will not be deterministic.
  */
 
 // Copied over from `serpapi` package
@@ -43,12 +46,8 @@ interface GoogleParameters extends BaseParameters {
   q: string;
   /**
    * Location
-   * Parameter defines from where you want the search to originate. Serpapi advises
-   * that if you do not provide a location, any location from around the world might
-   * be used including a different region and language. Location can be a canonical
-   * name (e.g., "Austin,Texas,United States") or the location id
-   * (e.g., "585069efee19ad271e9c9b36") If several locations match the location
-   * requested, we'll pick the most popular one. Head to the
+   * Parameter defines from where you want the search to originate. If several
+   * locations match the location requested, we'll pick the most popular one. Head to
    * [/locations.json API](https://serpapi.com/locations-api) if you need more
    * precise control. location and uule parameters can't be used together. Avoid
    * utilizing location when setting the location outside the U.S. when using Google


### PR DESCRIPTION
closes https://github.com/hwchase17/langchainjs/issues/765

![Screenshot from 2023-04-12 11-13-26](https://user-images.githubusercontent.com/455796/231561945-3d36e4b5-e4a6-40ce-b890-9803b8467d92.png)

I contacted support because just going back to a search from last weeks It was all in english (Im in Phoenix USA)
So I dont think we changed anything in the api. 
TLDR is unless you set location (and possibly hl and gl) they dont seem to guarantee anything

Just setting location fixed it for me for now.. It seems like alot to add the hg and gl as well, maybe we can get away without it

Updated all examples with a default location. their docs mention Austin so I just used that

>The first thing I notice is that you have not used any location parameters. For consistent language/location results, you need to specify the location, hl and gl parameters. Without these, your search can take the proxy's location, which may deliver unexpected results. We recommend always using the most specific location parameters possible in order to simulate a real user's search.
I understand that you have not experienced this before, and your parameters may not have changed. However, by not using these parameters you are not exercising control over the location for which the results are delivered.
Let me know if you continue to experience this after including location parameters.

> For best results I would still recommend using the hl and gl as well, however you may not notice the difference, I can't say for sure.

