### PR TITLE
fix: printSchema in StructuredOutputParser failing when using Zod

### DIFF
--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -64,7 +64,7 @@ ${Object.entries(shape)
 ${indent}}`;
   }
 
-  throw new Error(`Unsupported type: ${schema._def.innerType.typeName}`);
+  throw new Error(`Unsupported type: ${schema._def.typeName}`);
 }
 
 export class StructuredOutputParser<

--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -48,8 +48,10 @@ function printSchema(schema: z.ZodTypeAny, depth = 0): string {
   if (schema instanceof z.ZodObject || schema._def.typeName === "ZodObject") {
     const indent = "\t".repeat(depth);
     const indentIn = "\t".repeat(depth + 1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { shape } = schema as z.ZodObject<any>;
     return `{${schema._def.description ? ` // ${schema._def.description}` : ""}
-${Object.entries((schema as z.ZodObject<any>).shape)
+${Object.entries(shape)
   .map(
     ([key, value]) =>
       `${indentIn}"${key}": ${printSchema(value as z.ZodTypeAny, depth + 1)}${

--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -5,40 +5,51 @@ import { BaseOutputParser, OutputParserException } from "../schema/index.js";
 
 function printSchema(schema: z.ZodTypeAny, depth = 0): string {
   if (
-    schema instanceof z.ZodString &&
-    schema._def.checks.some((check) => check.kind === "datetime")
+    (schema instanceof z.ZodString || schema._def.typeName === "ZodString") &&
+    (schema as z.ZodString)._def.checks.some(
+      (check) => check.kind === "datetime"
+    )
   ) {
     return "datetime";
   }
-  if (schema instanceof z.ZodString) {
+  if (schema instanceof z.ZodString || schema._def.typeName === "ZodString") {
     return "string";
   }
-  if (schema instanceof z.ZodNumber) {
+  if (schema instanceof z.ZodNumber || schema._def.typeName === "ZodNumber") {
     return "number";
   }
-  if (schema instanceof z.ZodBoolean) {
+  if (schema instanceof z.ZodBoolean || schema._def.typeName === "ZodBoolean") {
     return "boolean";
   }
-  if (schema instanceof z.ZodDate) {
+  if (schema instanceof z.ZodDate || schema._def.typeName === "ZodDate") {
     return "date";
   }
-  if (schema instanceof z.ZodNullable) {
+  if (
+    schema instanceof z.ZodNullable ||
+    schema._def.typeName === "ZodNullable"
+  ) {
     return `${printSchema(schema._def.innerType, depth)} // Nullable`;
   }
-  if (schema instanceof z.ZodTransformer) {
+  if (
+    schema instanceof z.ZodTransformer ||
+    schema._def.typeName === "ZodTransformer"
+  ) {
     return `${printSchema(schema._def.schema, depth)}`;
   }
-  if (schema instanceof z.ZodOptional) {
+  if (
+    schema instanceof z.ZodOptional ||
+    schema._def.typeName === "ZodOptional"
+  ) {
     return `${printSchema(schema._def.innerType, depth)} // Optional`;
   }
-  if (schema instanceof z.ZodArray) {
+  if (schema instanceof z.ZodArray || schema._def.typeName === "ZodArray") {
     return `${printSchema(schema._def.type, depth)}[]`;
   }
-  if (schema instanceof z.ZodObject) {
+  if (schema instanceof z.ZodObject || schema._def.typeName === "ZodObject") {
     const indent = "\t".repeat(depth);
     const indentIn = "\t".repeat(depth + 1);
     return `{${schema._def.description ? ` // ${schema._def.description}` : ""}
-${Object.entries(schema.shape)
+${Object.entries((schema as z.ZodObject<any>).shape)
   .map(
     ([key, value]) =>
       `${indentIn}"${key}": ${printSchema(value as z.ZodTypeAny, depth + 1)}${


### PR DESCRIPTION
When using `Zod` with the `StructuredOutputParser`, it always fails as the `instanceof` checks never passes as `instanceof` only works when the class used is the exact same one as the one being compared to. This issue occurs when dealing with monorepos where the same package may have multiple instances.

```ts
  const parser = StructuredOutputParser.fromZodSchema(
    z.object({
      name: z.string().describe('The name'),
      artists: z
        .array(z.string())
        .describe('An array of artists'),
    })
  );
```

The error received is:
```
Error: Cannot read properties of undefined (reading 'typeName')
```

So using the `schema._def.typeName` is a lot more reliable in performing these checks.