### PR TITLE
fix: correct collection name for Milvus store to use underscores

### DIFF
--- a/docs/docs/modules/indexes/vector_stores/integrations/milvus.md
+++ b/docs/docs/modules/indexes/vector_stores/integrations/milvus.md
@@ -55,7 +55,7 @@ const vectorStore = await Milvus.fromTexts(
 
 // or alternatively from docs
 const vectorStore = await Milvus.fromDocuments(docs, new OpenAIEmbeddings(), {
-  collectionName: "goldel-escher-bach",
+  collectionName: "goldel_escher_bach",
 });
 
 const response = await vectorStore.similaritySearch("scared", 2);

--- a/docs/docs/modules/indexes/vector_stores/integrations/milvus.md
+++ b/docs/docs/modules/indexes/vector_stores/integrations/milvus.md
@@ -49,7 +49,7 @@ const vectorStore = await Milvus.fromTexts(
   [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
   new OpenAIEmbeddings(),
   {
-    collectionName: "goldel-escher-bach",
+    collectionName: "goldel_escher_bach",
   }
 );
 
@@ -70,7 +70,7 @@ import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 const vectorStore = await Milvus.fromExistingCollection(
   new OpenAIEmbeddings(),
   {
-    collectionName: "goldel-escher-bach",
+    collectionName: "goldel_escher_bach",
   }
 );
 


### PR DESCRIPTION
Current name produces an error when using Milvus 2.3.0

```
Invalid collection name: goldel-escher-bach.  collection name can only contain numbers, letters and underscores
```