### PR TITLE
Improve bing search tool results

### DIFF
--- a/langchain/src/tools/bingserpapi.ts
+++ b/langchain/src/tools/bingserpapi.ts
@@ -45,10 +45,14 @@ class BingSerpAPI extends Tool {
     }
 
     const res = await response.json();
+    const results:[] = res.webPages.value;
 
-    const myresponse = res.webPages.value[0].snippet;
-
-    return myresponse;
+    if (results.length === 0) {
+        return "No good results found.";
+    }
+    const snippets = results.map((result)=>result["snippet"]).join(" ")
+    
+    return snippets;
   }
 }
 

--- a/langchain/src/tools/bingserpapi.ts
+++ b/langchain/src/tools/bingserpapi.ts
@@ -45,13 +45,15 @@ class BingSerpAPI extends Tool {
     }
 
     const res = await response.json();
-    const results:[] = res.webPages.value;
+    const results: [] = res.webPages.value;
 
     if (results.length === 0) {
-        return "No good results found.";
+      return "No good results found.";
     }
-    const snippets = results.map((result)=>result["snippet"]).join(" ")
-    
+    const snippets = results
+      .map((result: { snippet: string }) => result.snippet)
+      .join(" ");
+
     return snippets;
   }
 }


### PR DESCRIPTION
The search behavior of the langchainjs `BingSerpAPI` tool is different from the Python version of langchain. This may cause the chain or agent available in Python version to fail when ported to `LangChainJS`. This improvement makes the execution results of both to be as consistent as possible.

### Differences between js and python version
```python
# langchain/utilities/bing_search.py BingSearchAPIWrapper.run

def run(self, query: str) -> str:
    # ...
    
    # In pyhton verison: Connected snippets from all results
    for result in results:
        snippets.append(result["snippet"])

    return " ".join(snippets)

```


```typescript
//langchain/src/tools/bingserpapi.ts
async _call(input: string): Promise<string> {
  // ...

  // In typescript version: Only returned the snippet of the first result here
  const myresponse = res.webPages.value[0].snippet;

  return myresponse;
}
```