### PR TITLE
Use workspace TS version in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   ],
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": "./.github/workflows/deploy.yml"
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
By default, VSCode uses its built-in TypeScript version, which is currently 5.x, however langchainjs is using 4.x for its build, so it's possible for contributors to see errors in their editor that don't match the output from the build, or vice-versa.

This default behavior surprised me; it bit me a few times while working on an [experiment](https://github.com/namuol/langchainjs/pull/1) to improve type-coverage for prompts, as there were changes to how types are inferred in TS 5.

This PR modifies the VSCode workspace settings to use the version from the workspace (4.x), rather than VSCode's built-in version, which should hopefully save contributors the same frustrations.

To do this I just used the `Select TypeScript version` command from VSCode, like so:

https://user-images.githubusercontent.com/444629/232245720-e1347145-7dca-4b5f-84a2-bdf5d92dbdfc.mov


