### PR TITLE
Suggestion on how to make callback managers more type safe and harder to misuse

### DIFF
--- a/langchain/src/base_language/index.ts
+++ b/langchain/src/base_language/index.ts
@@ -26,20 +26,24 @@ export abstract class BaseLangChain {
   protected configureCallbackManager(
     callbackManager?: CallbackManager
   ): CallbackManager | undefined {
-    let callbackManager_ =
-      callbackManager?.copy(this.callbackManager?.handlers) ??
-      this.callbackManager;
+    let callbackManager_;
+    if (callbackManager) {
+      callbackManager_ = callbackManager.copy(
+        this.callbackManager?.handlers,
+        false
+      );
+    } else {
+      callbackManager_ = new CallbackManager();
+      callbackManager_.setHandlers(this.callbackManager?.handlers ?? [], false);
+    }
     if (this.verbose) {
-      if (!callbackManager_) {
-        callbackManager_ = new CallbackManager();
-      }
       const consoleHandler = new ConsoleCallbackHandler();
       if (
         !callbackManager_.handlers.some(
           (handler) => handler.name === consoleHandler.name
         )
       ) {
-        callbackManager_.addHandler(consoleHandler);
+        callbackManager_.addHandler(consoleHandler, false);
       }
     }
     return callbackManager_;

--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -28,7 +28,7 @@ export abstract class BaseCallbackManager {
 export class CallbackManagerForLLMRun {
   constructor(
     private handlers: BaseCallbackHandler[],
-    private _currentRunId: string,
+    public runId: string,
     private _parentRunId?: string
   ) {}
 
@@ -39,7 +39,7 @@ export class CallbackManagerForLLMRun {
           try {
             await handler.handleLLMNewToken?.(
               token,
-              this._currentRunId ?? uuidv4(),
+              this.runId,
               this._parentRunId
             );
           } catch (err) {
@@ -57,11 +57,7 @@ export class CallbackManagerForLLMRun {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM) {
           try {
-            await handler.handleLLMError?.(
-              err,
-              this._currentRunId ?? uuidv4(),
-              this._parentRunId
-            );
+            await handler.handleLLMError?.(err, this.runId, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMError: ${err}`
@@ -77,11 +73,7 @@ export class CallbackManagerForLLMRun {
       this.handlers.map(async (handler) => {
         if (!handler.ignoreLLM) {
           try {
-            await handler.handleLLMEnd?.(
-              output,
-              this._currentRunId ?? uuidv4(),
-              this._parentRunId
-            );
+            await handler.handleLLMEnd?.(output, this.runId, this._parentRunId);
           } catch (err) {
             console.error(
               `Error in handler ${handler.constructor.name}, handleLLMEnd: ${err}`

--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -103,6 +103,7 @@ export class CallbackManagerForLLMRun extends BaseRunManager {
 
 export class CallbackManagerForChainRun extends BaseRunManager {
   getChild(): CallbackManager {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const manager = new CallbackManager(this.runId);
     manager.setHandlers(this.handlers);
     return manager;
@@ -191,6 +192,7 @@ export class CallbackManagerForChainRun extends BaseRunManager {
 
 export class CallbackManagerForToolRun extends BaseRunManager {
   getChild(): CallbackManager {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const manager = new CallbackManager(this.runId);
     manager.setHandlers(this.handlers);
     return manager;

--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -47,7 +47,10 @@ class BaseRunManager {
   }
 }
 
-export class CallbackManagerForLLMRun extends BaseRunManager {
+export class CallbackManagerForLLMRun
+  extends BaseRunManager
+  implements BaseCallbackManagerMethods
+{
   async handleLLMNewToken(token: string): Promise<void> {
     await Promise.all(
       this.handlers.map(async (handler) => {
@@ -101,7 +104,10 @@ export class CallbackManagerForLLMRun extends BaseRunManager {
   }
 }
 
-export class CallbackManagerForChainRun extends BaseRunManager {
+export class CallbackManagerForChainRun
+  extends BaseRunManager
+  implements BaseCallbackManagerMethods
+{
   getChild(): CallbackManager {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const manager = new CallbackManager(this.runId);
@@ -190,7 +196,10 @@ export class CallbackManagerForChainRun extends BaseRunManager {
   }
 }
 
-export class CallbackManagerForToolRun extends BaseRunManager {
+export class CallbackManagerForToolRun
+  extends BaseRunManager
+  implements BaseCallbackManagerMethods
+{
   getChild(): CallbackManager {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const manager = new CallbackManager(this.runId);

--- a/langchain/src/callbacks/tests/callbacks.test.ts
+++ b/langchain/src/callbacks/tests/callbacks.test.ts
@@ -129,7 +129,7 @@ test("CallbackManager", async () => {
   const toolCb = await manager.handleToolStart({ name: "test" }, "test");
   await toolCb.handleToolEnd("test");
   await toolCb.handleToolError(new Error("test"));
-  await manager.handleText("test");
+  await chainCb.handleText("test");
   await chainCb.handleAgentAction({
     tool: "test",
     toolInput: "test",

--- a/langchain/src/callbacks/tests/callbacks.test.ts
+++ b/langchain/src/callbacks/tests/callbacks.test.ts
@@ -126,9 +126,9 @@ test("CallbackManager", async () => {
   );
   await chainCb.handleChainEnd({ test: "test" });
   await chainCb.handleChainError(new Error("test"));
-  await manager.handleToolStart({ name: "test" }, "test");
-  await manager.handleToolEnd("test");
-  await manager.handleToolError(new Error("test"));
+  const toolCb = await manager.handleToolStart({ name: "test" }, "test");
+  await toolCb.handleToolEnd("test");
+  await toolCb.handleToolError(new Error("test"));
   await manager.handleText("test");
   await chainCb.handleAgentAction({
     tool: "test",
@@ -198,9 +198,9 @@ test("CallbackHandler with ignoreAgent", async () => {
   });
   const manager = new CallbackManager();
   manager.addHandler(handler);
-  await manager.handleToolStart({ name: "test" }, "test");
-  await manager.handleToolEnd("test");
-  await manager.handleToolError(new Error("test"));
+  const toolCb = await manager.handleToolStart({ name: "test" }, "test");
+  await toolCb.handleToolEnd("test");
+  await toolCb.handleToolError(new Error("test"));
   const chainCb = await manager.handleChainStart(
     { name: "agent_executor" },
     {}

--- a/langchain/src/callbacks/tests/callbacks.test.ts
+++ b/langchain/src/callbacks/tests/callbacks.test.ts
@@ -116,10 +116,10 @@ test("CallbackManager", async () => {
   manager.addHandler(handler1);
   manager.addHandler(handler2);
 
-  await manager.handleLLMStart({ name: "test" }, ["test"]);
-  await manager.handleLLMEnd({ generations: [] });
-  await manager.handleLLMNewToken("test");
-  await manager.handleLLMError(new Error("test"));
+  const llmCb = await manager.handleLLMStart({ name: "test" }, ["test"]);
+  await llmCb.handleLLMEnd({ generations: [] });
+  await llmCb.handleLLMNewToken("test");
+  await llmCb.handleLLMError(new Error("test"));
   await manager.handleChainStart({ name: "test" }, { test: "test" });
   await manager.handleChainEnd({ test: "test" });
   await manager.handleChainError(new Error("test"));
@@ -156,10 +156,10 @@ test("CallbackHandler with ignoreLLM", async () => {
   });
   const manager = new CallbackManager();
   manager.addHandler(handler);
-  await manager.handleLLMStart({ name: "test" }, ["test"]);
-  await manager.handleLLMEnd({ generations: [] });
-  await manager.handleLLMNewToken("test");
-  await manager.handleLLMError(new Error("test"));
+  const llmCb = await manager.handleLLMStart({ name: "test" }, ["test"]);
+  await llmCb.handleLLMEnd({ generations: [] });
+  await llmCb.handleLLMNewToken("test");
+  await llmCb.handleLLMError(new Error("test"));
 
   expect(handler.starts).toBe(0);
   expect(handler.ends).toBe(0);

--- a/langchain/src/chains/llm_chain.ts
+++ b/langchain/src/chains/llm_chain.ts
@@ -12,6 +12,7 @@ import {
 } from "../schema/index.js";
 import { SerializedLLMChain } from "./serde.js";
 import { CallbackManager } from "../callbacks/index.js";
+import { CallbackManagerForChainRun } from "../callbacks/manager.js";
 
 export interface LLMChainInput extends ChainInputs {
   /** Prompt object to use */
@@ -85,7 +86,7 @@ export class LLMChain extends BaseChain implements LLMChainInput {
 
   async _call(
     values: ChainValues,
-    callbackManager?: CallbackManager
+    runManager?: CallbackManagerForChainRun
   ): Promise<ChainValues> {
     let stop;
     if ("stop" in values && Array.isArray(values.stop)) {
@@ -95,7 +96,7 @@ export class LLMChain extends BaseChain implements LLMChainInput {
     const { generations } = await this.llm.generatePrompt(
       [promptValue],
       stop,
-      callbackManager?.getChild()
+      runManager?.getChild()
     );
     return {
       [this.outputKey]: await this._getFinalOutput(generations[0], promptValue),

--- a/langchain/src/chat_models/anthropic.ts
+++ b/langchain/src/chat_models/anthropic.ts
@@ -13,7 +13,7 @@ import {
   ChatResult,
   MessageType,
 } from "../schema/index.js";
-import { CallbackManager } from "../callbacks/manager.js";
+import { CallbackManagerForLLMRun } from "../callbacks/manager.js";
 
 function getAnthropicPromptFromMessage(type: MessageType): string {
   switch (type) {
@@ -224,7 +224,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
   async _generate(
     messages: BaseChatMessage[],
     stopSequences?: string[],
-    callbackManager?: CallbackManager
+    callbackManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     if (this.stopSequences && stopSequences) {
       throw new Error(
@@ -260,7 +260,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
   /** @ignore */
   async completionWithRetry(
     request: SamplingParameters & Kwargs,
-    callbackManager?: CallbackManager
+    callbackManager?: CallbackManagerForLLMRun
   ): Promise<CompletionResponse> {
     if (!this.apiKey) {
       throw new Error("Missing Anthropic API key.");
@@ -282,9 +282,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
               const delta = part.slice(currentCompletion.length);
               currentCompletion += delta ?? "";
               // eslint-disable-next-line no-void
-              void this.configureCallbackManager(
-                callbackManager
-              )?.handleLLMNewToken(delta ?? "");
+              void callbackManager?.handleLLMNewToken(delta ?? "");
             }
           },
         });

--- a/langchain/src/chat_models/anthropic.ts
+++ b/langchain/src/chat_models/anthropic.ts
@@ -224,7 +224,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
   async _generate(
     messages: BaseChatMessage[],
     stopSequences?: string[],
-    callbackManager?: CallbackManagerForLLMRun
+    runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     if (this.stopSequences && stopSequences) {
       throw new Error(
@@ -242,7 +242,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
         ...params,
         prompt: this.formatMessagesAsPrompt(messages),
       },
-      callbackManager
+      runManager
     );
 
     const generations: ChatGeneration[] = response.completion

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -21,7 +21,7 @@ import {
   SystemChatMessage,
 } from "../schema/index.js";
 import { getModelNameForTiktoken } from "../base_language/count_tokens.js";
-import { CallbackManager } from "../callbacks/manager.js";
+import { CallbackManagerForLLMRun } from "../callbacks/manager.js";
 
 interface TokenUsage {
   completionTokens?: number;
@@ -260,7 +260,7 @@ export class ChatOpenAI extends BaseChatModel implements OpenAIInput {
   async _generate(
     messages: BaseChatMessage[],
     stop?: string[],
-    callbackManager?: CallbackManager
+    callbackManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     const tokenUsage: TokenUsage = {};
     if (this.stop && stop) {
@@ -340,9 +340,9 @@ export class ChatOpenAI extends BaseChatModel implements OpenAIInput {
 
                     choice.message.content += part.delta?.content ?? "";
                     // eslint-disable-next-line no-void
-                    void this.configureCallbackManager(
-                      callbackManager
-                    )?.handleLLMNewToken(part.delta?.content ?? "");
+                    void callbackManager?.handleLLMNewToken(
+                      part.delta?.content ?? ""
+                    );
                   }
                 }
               },

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -260,7 +260,7 @@ export class ChatOpenAI extends BaseChatModel implements OpenAIInput {
   async _generate(
     messages: BaseChatMessage[],
     stop?: string[],
-    callbackManager?: CallbackManagerForLLMRun
+    runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     const tokenUsage: TokenUsage = {};
     if (this.stop && stop) {
@@ -340,7 +340,7 @@ export class ChatOpenAI extends BaseChatModel implements OpenAIInput {
 
                     choice.message.content += part.delta?.content ?? "";
                     // eslint-disable-next-line no-void
-                    void callbackManager?.handleLLMNewToken(
+                    void runManager?.handleLLMNewToken(
                       part.delta?.content ?? ""
                     );
                   }

--- a/langchain/src/llms/base.ts
+++ b/langchain/src/llms/base.ts
@@ -62,7 +62,7 @@ export abstract class BaseLLM extends BaseLanguageModel {
   abstract _generate(
     prompts: string[],
     stop?: string[],
-    callbackManager?: CallbackManagerForLLMRun
+    runManager?: CallbackManagerForLLMRun
   ): Promise<LLMResult>;
 
   /** @ignore */
@@ -71,18 +71,18 @@ export abstract class BaseLLM extends BaseLanguageModel {
     stop?: string[],
     callbackManager?: CallbackManager
   ): Promise<LLMResult> {
-    const localCallbackManager = await this.configureCallbackManager(
+    const runManager = await this.configureCallbackManager(
       callbackManager
     )?.handleLLMStart({ name: this._llmType() }, prompts);
     let output;
     try {
-      output = await this._generate(prompts, stop, localCallbackManager);
+      output = await this._generate(prompts, stop, runManager);
     } catch (err) {
-      await localCallbackManager?.handleLLMError(err);
+      await runManager?.handleLLMError(err);
       throw err;
     }
 
-    await localCallbackManager?.handleLLMEnd(output);
+    await runManager?.handleLLMEnd(output);
     return output;
   }
 
@@ -214,17 +214,17 @@ export abstract class LLM extends BaseLLM {
   abstract _call(
     prompt: string,
     stop?: string[],
-    callbackManager?: CallbackManagerForLLMRun
+    runManager?: CallbackManagerForLLMRun
   ): Promise<string>;
 
   async _generate(
     prompts: string[],
     stop?: string[],
-    callbackManager?: CallbackManagerForLLMRun
+    runManager?: CallbackManagerForLLMRun
   ): Promise<LLMResult> {
     const generations = [];
     for (let i = 0; i < prompts.length; i += 1) {
-      const text = await this._call(prompts[i], stop, callbackManager);
+      const text = await this._call(prompts[i], stop, runManager);
       generations.push([{ text }]);
     }
     return { generations };

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -210,7 +210,7 @@ export class OpenAIChat extends LLM implements OpenAIInput {
    *
    * @param prompt - The prompt to pass into the model.
    * @param [stop] - Optional list of stop words to use when generating.
-   * @param [callbackManager] - Optional callback manager to use for streaming
+   * @param [runManager] - Optional callback manager to use for streaming
    *
    * @returns The full LLM output.
    *
@@ -224,7 +224,7 @@ export class OpenAIChat extends LLM implements OpenAIInput {
   async _call(
     prompt: string,
     stop?: string[],
-    callbackManager?: CallbackManagerForLLMRun
+    runManager?: CallbackManagerForLLMRun
   ): Promise<string> {
     if (this.stop && stop) {
       throw new Error("Stop found in input and default params");
@@ -296,7 +296,7 @@ export class OpenAIChat extends LLM implements OpenAIInput {
 
                     choice.message.content += part.delta?.content ?? "";
                     // eslint-disable-next-line no-void
-                    void callbackManager?.handleLLMNewToken(
+                    void runManager?.handleLLMNewToken(
                       part.delta?.content ?? ""
                     );
                   }

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -10,7 +10,7 @@ import {
 import type { StreamingAxiosConfiguration } from "../util/axios-types.js";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
 import { BaseLLMParams, LLM } from "./base.js";
-import { CallbackManager } from "../callbacks/manager.js";
+import { CallbackManagerForLLMRun } from "../callbacks/manager.js";
 
 interface ModelParams {
   /** Sampling temperature to use, between 0 and 2, defaults to 1 */
@@ -224,7 +224,7 @@ export class OpenAIChat extends LLM implements OpenAIInput {
   async _call(
     prompt: string,
     stop?: string[],
-    callbackManager?: CallbackManager
+    callbackManager?: CallbackManagerForLLMRun
   ): Promise<string> {
     if (this.stop && stop) {
       throw new Error("Stop found in input and default params");
@@ -296,9 +296,9 @@ export class OpenAIChat extends LLM implements OpenAIInput {
 
                     choice.message.content += part.delta?.content ?? "";
                     // eslint-disable-next-line no-void
-                    void this.configureCallbackManager(
-                      callbackManager
-                    )?.handleLLMNewToken(part.delta?.content ?? "");
+                    void callbackManager?.handleLLMNewToken(
+                      part.delta?.content ?? ""
+                    );
                   }
                 }
               },

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -240,7 +240,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
   async _generate(
     prompts: string[],
     stop?: string[],
-    callbackManager?: CallbackManagerForLLMRun
+    runManager?: CallbackManagerForLLMRun
   ): Promise<LLMResult> {
     const subPrompts = chunkArray(prompts, this.batchSize);
     const choices: CreateCompletionResponseChoicesInner[] = [];
@@ -308,7 +308,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
                       choice.finish_reason = part.finish_reason;
                       choice.logprobs = part.logprobs;
                       // eslint-disable-next-line no-void
-                      void callbackManager?.handleLLMNewToken(part.text ?? "");
+                      void runManager?.handleLLMNewToken(part.text ?? "");
                     }
                   }
                 },

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -14,7 +14,7 @@ import { BaseLLM, BaseLLMParams } from "./base.js";
 import { calculateMaxTokens } from "../base_language/count_tokens.js";
 import { OpenAIChat } from "./openai-chat.js";
 import { LLMResult } from "../schema/index.js";
-import { CallbackManager } from "../callbacks/manager.js";
+import { CallbackManagerForLLMRun } from "../callbacks/manager.js";
 
 interface ModelParams {
   /** Sampling temperature to use */
@@ -240,7 +240,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
   async _generate(
     prompts: string[],
     stop?: string[],
-    callbackManager?: CallbackManager
+    callbackManager?: CallbackManagerForLLMRun
   ): Promise<LLMResult> {
     const subPrompts = chunkArray(prompts, this.batchSize);
     const choices: CreateCompletionResponseChoicesInner[] = [];
@@ -308,9 +308,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput {
                       choice.finish_reason = part.finish_reason;
                       choice.logprobs = part.logprobs;
                       // eslint-disable-next-line no-void
-                      void this.configureCallbackManager(
-                        callbackManager
-                      )?.handleLLMNewToken(part.text ?? "");
+                      void callbackManager?.handleLLMNewToken(part.text ?? "");
                     }
                   }
                 },

--- a/langchain/src/tools/base.ts
+++ b/langchain/src/tools/base.ts
@@ -1,4 +1,7 @@
-import { CallbackManager } from "../callbacks/manager.js";
+import {
+  CallbackManager,
+  CallbackManagerForToolRun,
+} from "../callbacks/manager.js";
 import { BaseLangChain } from "../base_language/index.js";
 
 export interface ToolParams {
@@ -13,7 +16,7 @@ export abstract class Tool extends BaseLangChain {
 
   protected abstract _call(
     arg: string,
-    callbackManager?: CallbackManager
+    callbackManager?: CallbackManagerForToolRun
   ): Promise<string>;
 
   async call(
@@ -21,19 +24,17 @@ export abstract class Tool extends BaseLangChain {
     _verbose?: boolean,
     callbackManager?: CallbackManager
   ): Promise<string> {
-    const localCallbackManager = this.configureCallbackManager(callbackManager);
-    await localCallbackManager?.handleToolStart({ name: this.name }, arg);
-    if (callbackManager) {
-      callbackManager.setCurrentRunId(localCallbackManager?.currentRunId);
-    }
+    const runManager = await this.configureCallbackManager(
+      callbackManager
+    )?.handleToolStart({ name: this.name }, arg);
     let result;
     try {
-      result = await this._call(arg, callbackManager);
+      result = await this._call(arg, runManager);
     } catch (e) {
-      await localCallbackManager?.handleToolError(e);
+      await runManager?.handleToolError(e);
       throw e;
     }
-    await localCallbackManager?.handleToolEnd(result);
+    await runManager?.handleToolEnd(result);
     return result;
   }
 


### PR DESCRIPTION
- A callback manager without a currentRunId does not offer non-start methods 
- A callback manager cannot be mutated to add a currentRunId, to do so create a new specialised instance for that run, by calling the respective handleStart method
- An unbound callback manager does not offer getChild, as you shouldn't be able to create a child manager without before calling start