### PR TITLE
feat: Add minSimilarityScore to VectorStore.similaritySearch

### DIFF
--- a/docs/docs/modules/indexes/vector_stores/index.mdx
+++ b/docs/docs/modules/indexes/vector_stores/index.mdx
@@ -24,7 +24,8 @@ interface VectorStore {
   similaritySearch(
     query: string,
     k?: number,
-    filter?: object | undefined
+    filter?: object,
+    minSimilarityScore?: number
   ): Promise<Document[]>;
 
   /**
@@ -33,8 +34,8 @@ interface VectorStore {
    */
   similaritySearchWithScore(
     query: string,
-    k = 4,
-    filter: object | undefined = undefined
+    k?: number,
+    filter?: object
   ): Promise<[object, number][]>;
 
   /**

--- a/langchain/src/vectorstores/base.ts
+++ b/langchain/src/vectorstores/base.ts
@@ -56,7 +56,8 @@ export abstract class VectorStore {
   async similaritySearch(
     query: string,
     k = 4,
-    filter: this["FilterType"] | undefined = undefined
+    filter: this["FilterType"] | undefined = undefined,
+    minSimilarityScore = -Infinity
   ): Promise<Document[]> {
     const results = await this.similaritySearchVectorWithScore(
       await this.embeddings.embedQuery(query),
@@ -64,7 +65,9 @@ export abstract class VectorStore {
       filter
     );
 
-    return results.map((result) => result[0]);
+    return results
+      .filter((result) => result[1] >= minSimilarityScore)
+      .map((result) => result[0]);
   }
 
   async similaritySearchWithScore(

--- a/langchain/src/vectorstores/tests/base.test.ts
+++ b/langchain/src/vectorstores/tests/base.test.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@jest/globals";
+import { Document } from "document.js";
+import { FakeEmbeddings } from "../../embeddings/fake.js";
+import { VectorStore } from "../base.js";
+
+class MockVectorStore extends VectorStore {
+  mockedSimilaritySearchVectorWithScore: [
+    Document<Record<string, number>>,
+    number
+  ][] = [
+    [{ metadata: { id: 1 }, pageContent: "hello world1" }, 0.7],
+    [{ metadata: { id: 2 }, pageContent: "hello world2" }, 0.5],
+    [{ metadata: { id: 3 }, pageContent: "hello world3" }, 0.1],
+  ];
+
+  async addVectors(
+    _vectors: number[][],
+    _documents: Document<Record<string, number>>[]
+  ): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  async addDocuments(
+    _documents: Document<Record<string, number>>[]
+  ): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  async similaritySearchVectorWithScore(
+    _query: number[],
+    k: number,
+    _filter?: object | undefined
+  ): Promise<[Document<Record<string, number>>, number][]> {
+    return this.mockedSimilaritySearchVectorWithScore.slice(0, k);
+  }
+}
+
+test("Test VectorStore.similaritySearch", async () => {
+  const vectorStore = new MockVectorStore(new FakeEmbeddings(), []);
+
+  const resultOne = await vectorStore.similaritySearch("hello world", 1);
+  const resultOneMetadatas = resultOne.map(({ metadata }) => metadata);
+  expect(resultOneMetadatas).toEqual([{ id: 1 }]);
+
+  const resultTwo = await vectorStore.similaritySearch("hello world", 3);
+  const resultTwoMetadatas = resultTwo.map(({ metadata }) => metadata);
+  expect(resultTwoMetadatas).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const resultThree = await vectorStore.similaritySearch(
+    "hello world",
+    3,
+    undefined,
+    0.5
+  );
+  const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
+  expect(resultThreeMetadatas).toEqual([{ id: 1 }, { id: 2 }]);
+});


### PR DESCRIPTION
Allow users to add a cutoff score to include for similarity search. 
Update `vector_db_qa` chain to support this new parameter