### PR TITLE
reject document which `pageContent` is `undefined`

### DIFF
--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -77,8 +77,11 @@ export abstract class TextSplitter implements TextSplitterParams {
   }
 
   async splitDocuments(documents: Document[]): Promise<Document[]> {
-    const texts = documents.map((doc) => doc.pageContent);
-    const metadatas = documents.map((doc) => doc.metadata);
+    const selectedDocuments = documents.filter(
+      (doc) => doc.pageContent !== undefined
+    );
+    const texts = selectedDocuments.map((doc) => doc.pageContent);
+    const metadatas = selectedDocuments.map((doc) => doc.metadata);
     return this.createDocuments(texts, metadatas);
   }
 


### PR DESCRIPTION
Exclude documents with undefined `pageContent` in `TextSplitter::splitDocuments.`

related: https://github.com/hwchase17/langchainjs/issues/808