### PR TITLE
475/simple sequential chain

### DIFF
--- a/docs/docs/modules/chains/simple_sequential_chain/index.mdx
+++ b/docs/docs/modules/chains/simple_sequential_chain/index.mdx
@@ -1,0 +1,15 @@
+---
+hide_table_of_contents: true
+sidebar_label: SimpleSequentialChain
+---
+
+import CodeBlock from "@theme/CodeBlock";
+import Example from "@examples/chains/simple_sequential_chain.ts";
+
+# Getting Started: SimpleSequentialChain
+
+An `SimpleSequentialChain` is a chain that allows you to join multiple single-input/single-output chains into one chain.
+
+The example below shows a sample usecase. In the first step, given a title, a synopsis of a play is generated. In the second step, based on the generated synopsis, a review of the play is generated.
+
+<CodeBlock language="typescript">{Example}</CodeBlock>

--- a/examples/src/chains/simple_sequential_chain.ts
+++ b/examples/src/chains/simple_sequential_chain.ts
@@ -35,6 +35,7 @@ const overallChain = new SimpleSequentialChain({
   verbose: true,
 });
 const review = await overallChain.run("Tragedy at sunset on the beach");
+console.log(review);
 /*
     variable review contains the generated play review based on the input title and synopsis generated in the first step:
 

--- a/examples/src/chains/simple_sequential_chain.ts
+++ b/examples/src/chains/simple_sequential_chain.ts
@@ -1,0 +1,44 @@
+import { SimpleSequentialChain, LLMChain } from "langchain/chains";
+import { OpenAI } from "langchain/llms/openai";
+import { PromptTemplate } from "langchain/prompts";
+
+// This is an LLMChain to write a synopsis given a title of a play.
+const llm = new OpenAI({ temperature: 0 });
+const template = `You are a playwright. Given the title of play, it is your job to write a synopsis for that title.
+ 
+  Title: {title}
+  Playwright: This is a synopsis for the above play:`;
+const promptTemplate = new PromptTemplate({
+  template,
+  inputVariables: ["title"],
+});
+const synopsisChain = new LLMChain({ llm, prompt: promptTemplate });
+
+// This is an LLMChain to write a review of a play given a synopsis.
+const reviewLLM = new OpenAI({ temperature: 0 });
+const reviewTemplate = `You are a play critic from the New York Times. Given the synopsis of play, it is your job to write a review for that play.
+ 
+  Play Synopsis:
+  {synopsis}
+  Review from a New York Times play critic of the above play:`;
+const reviewPromptTempalte = new PromptTemplate({
+  template: reviewTemplate,
+  inputVariables: ["synopsis"],
+});
+const reviewChain = new LLMChain({
+  llm: reviewLLM,
+  prompt: reviewPromptTempalte,
+});
+
+const overallChain = new SimpleSequentialChain({
+  chains: [synopsisChain, reviewChain],
+  verbose: true,
+});
+const review = await overallChain.run("Tragedy at sunset on the beach");
+/*
+    variable review contains the generated play review based on the input title and synopsis generated in the first step:
+
+    "Tragedy at Sunset on the Beach is a powerful and moving story of love, loss, and redemption. The play follows the story of two young lovers, Jack and Jill, whose plans for a future together are tragically cut short when Jack is killed in a car accident. The play follows Jill as she struggles to cope with her grief and eventually finds solace in the arms of another man. 
+    The play is beautifully written and the performances are outstanding. The actors bring the characters to life with their heartfelt performances, and the audience is taken on an emotional journey as Jill is forced to confront her grief and make a difficult decision between her past and her future. The play culminates in a powerful climax that will leave the audience in tears. 
+    Overall, Tragedy at Sunset on the Beach is a powerful and moving story that will stay with you long after the curtain falls. It is a must-see for anyone looking for an emotionally charged and thought-provoking experience."
+*/

--- a/langchain/src/chains/base.ts
+++ b/langchain/src/chains/base.ts
@@ -124,6 +124,12 @@ export abstract class BaseChain implements ChainInputs {
         const { LLMChain } = await import("./llm_chain.js");
         return LLMChain.deserialize(data);
       }
+      case "simple_sequential_chain": {
+        const { SimpleSequentialChain } = await import(
+          "./simple_sequential_chain.js"
+        );
+        return SimpleSequentialChain.deserialize(data);
+      }
       case "stuff_documents_chain": {
         const { StuffDocumentsChain } = await import("./combine_docs_chain.js");
         return StuffDocumentsChain.deserialize(data);

--- a/langchain/src/chains/index.ts
+++ b/langchain/src/chains/index.ts
@@ -1,5 +1,6 @@
 export { BaseChain, ChainInputs } from "./base.js";
 export { LLMChain, ConversationChain } from "./llm_chain.js";
+export { SimpleSequentialChain } from "./simple_sequential_chain.js";
 export {
   StuffDocumentsChain,
   MapReduceDocumentsChain,
@@ -20,6 +21,7 @@ export { ConversationalRetrievalQAChain } from "./conversational_retrieval_chain
 export { RetrievalQAChain } from "./retrieval_qa.js";
 export {
   SerializedLLMChain,
+  SerializedSimpleSequentialChain,
   SerializedSqlDatabaseChain,
   SerializedAnalyzeDocumentChain,
   SerializedBaseChain,

--- a/langchain/src/chains/serde.ts
+++ b/langchain/src/chains/serde.ts
@@ -8,6 +8,11 @@ export type SerializedLLMChain = {
   prompt?: SerializedBasePromptTemplate;
 };
 
+export type SerializedSimpleSequentialChain = {
+  _type: "simple_sequential_chain";
+  chains: Array<SerializedBaseChain>;
+};
+
 export type SerializedSqlDatabaseChain = {
   _type: "sql_database_chain";
   sql_database: SerializedSqlDatabase;
@@ -51,6 +56,7 @@ export type SerializedAnalyzeDocumentChain = {
 
 export type SerializedBaseChain =
   | SerializedLLMChain
+  | SerializedSimpleSequentialChain
   | SerializedVectorDBQAChain
   | SerializedStuffDocumentsChain
   | SerializedSqlDatabaseChain

--- a/langchain/src/chains/simple_sequential_chain.ts
+++ b/langchain/src/chains/simple_sequential_chain.ts
@@ -1,0 +1,119 @@
+import { BaseChain, ChainInputs } from "./base.js";
+import { ChainValues } from "../schema/index.js";
+import {
+  SerializedBaseChain,
+  SerializedSimpleSequentialChain,
+} from "./serde.js";
+
+export interface SimpleSequentialChainInput extends ChainInputs {
+  /** Array of chains to run as a sequence. The chains are run in order they appear in the array. */
+  chains: Array<BaseChain>;
+  /** Whether or not to trim the intermediate outputs. */
+  trimOutputs?: boolean;
+}
+
+/**
+ * Simple chain where a single string output of one chain is fed directly into the next.
+ * @augments BaseChain
+ * @augments SimpleSequentialChainInput
+ *
+ * @example
+ * ```ts
+ * import { SimpleSequentialChain, LLMChain } from "langchain/chains";
+ * import { OpenAI } from "langchain/llms/openai";
+ * import { PromptTemplate } from "langchain/prompts";
+ *
+ * // This is an LLMChain to write a synopsis given a title of a play.
+ * const llm = new OpenAI({ temperature: 0 });
+ * const template = `You are a playwright. Given the title of play, it is your job to write a synopsis for that title.
+ *
+ * Title: {title}
+ * Playwright: This is a synopsis for the above play:`
+ * const promptTemplate = new PromptTemplate({ template, inputVariables: ["title"] });
+ * const synopsisChain = new LLMChain({ llm, prompt: promptTemplate });
+ *
+ *
+ * // This is an LLMChain to write a review of a play given a synopsis.
+ * const reviewLLM = new OpenAI({ temperature: 0 })
+ * const reviewTemplate = `You are a play critic from the New York Times. Given the synopsis of play, it is your job to write a review for that play.
+ *
+ * Play Synopsis:
+ * {synopsis}
+ * Review from a New York Times play critic of the above play:`
+ * const reviewPromptTempalte = new PromptTemplate({ template: reviewTemplate, inputVariables: ["synopsis"] });
+ * const reviewChain = new LLMChain({ llm: reviewLLM, prompt: reviewPromptTempalte });
+ *
+ * const overallChain = new SimpleSequentialChain({chains: [synopsisChain, reviewChain], verbose:true})
+ * const review = await overallChain.run("Tragedy at sunset on the beach")
+ * // the variable review contains resulting play review.
+ * ```
+ */
+export class SimpleSequentialChain
+  extends BaseChain
+  implements SimpleSequentialChainInput
+{
+  chains: Array<BaseChain>;
+  inputKey = "input";
+  outputKey = "output";
+  trimOutputs: boolean;
+
+  get inputKeys() {
+    return [this.inputKey];
+  }
+
+  constructor(fields: SimpleSequentialChainInput) {
+    super(fields.memory, fields.verbose, fields.callbackManager);
+    this.chains = fields.chains;
+    this.trimOutputs = fields.trimOutputs ?? false;
+    this._validateChains();
+  }
+
+  _validateChains() {
+    for (const chain of this.chains) {
+      if (chain.inputKeys.length !== 1) {
+        throw new Error(
+          `Chains used in SimpleSequentialChain should all have one input, got ${
+            chain.inputKeys.length
+          } for ${chain._chainType()}.`
+        );
+      }
+    }
+  }
+
+  async _call(values: ChainValues): Promise<ChainValues> {
+    let input: string = values[this.inputKey];
+    for (const chain of this.chains) {
+      input = await chain.run(input);
+      if (this.trimOutputs) {
+        input = input.trim();
+      }
+      this.callbackManager.handleText(input, this.verbose);
+    }
+    return { [this.outputKey]: input };
+  }
+
+  _chainType() {
+    return "simple_sequential_chain" as const;
+  }
+
+  static async deserialize(data: SerializedSimpleSequentialChain) {
+    const chains: Array<BaseChain> = [];
+    const serializedChains = data.chains;
+    for (const serializedChain of serializedChains) {
+      const deserializedChain = await BaseChain.deserialize(serializedChain);
+      chains.push(deserializedChain);
+    }
+    return new SimpleSequentialChain({ chains });
+  }
+
+  serialize(): SerializedSimpleSequentialChain {
+    const chains: Array<SerializedBaseChain> = [];
+    for (const chain of this.chains) {
+      chains.push(chain.serialize());
+    }
+    return {
+      _type: this._chainType(),
+      chains,
+    };
+  }
+}

--- a/langchain/src/chains/simple_sequential_chain.ts
+++ b/langchain/src/chains/simple_sequential_chain.ts
@@ -53,8 +53,11 @@ export class SimpleSequentialChain
   implements SimpleSequentialChainInput
 {
   chains: Array<BaseChain>;
+
   inputKey = "input";
+
   outputKey = "output";
+
   trimOutputs: boolean;
 
   get inputKeys() {
@@ -87,7 +90,7 @@ export class SimpleSequentialChain
       if (this.trimOutputs) {
         input = input.trim();
       }
-      this.callbackManager.handleText(input, this.verbose);
+      await this.callbackManager.handleText(input, this.verbose);
     }
     return { [this.outputKey]: input };
   }

--- a/langchain/src/chains/simple_sequential_chain.ts
+++ b/langchain/src/chains/simple_sequential_chain.ts
@@ -64,6 +64,10 @@ export class SimpleSequentialChain
     return [this.inputKey];
   }
 
+  get outputKeys(): string[] {
+    return [this.outputKey];
+  }
+
   constructor(fields: SimpleSequentialChainInput) {
     super(fields.memory, fields.verbose, fields.callbackManager);
     this.chains = fields.chains;
@@ -77,6 +81,13 @@ export class SimpleSequentialChain
         throw new Error(
           `Chains used in SimpleSequentialChain should all have one input, got ${
             chain.inputKeys.length
+          } for ${chain._chainType()}.`
+        );
+      }
+      if (chain.outputKeys.length !== 1) {
+        throw new Error(
+          `Chains used in SimpleSequentialChain should all have one output, got ${
+            chain.outputKeys.length
           } for ${chain._chainType()}.`
         );
       }

--- a/langchain/src/chains/tests/simple_sequential_chain.int.test.ts
+++ b/langchain/src/chains/tests/simple_sequential_chain.int.test.ts
@@ -1,0 +1,86 @@
+import { test } from "@jest/globals";
+import { OpenAI } from "../../llms/openai.js";
+import { PromptTemplate } from "../../prompts/index.js";
+import { LLMChain } from "../llm_chain.js";
+import { SimpleSequentialChain } from "../simple_sequential_chain.js";
+import { ChatOpenAI } from "../../chat_models/openai.js";
+
+test("Test SimpleSequentialChain example usage", async () => {
+  // This is an LLMChain to write a synopsis given a title of a play.
+  const llm = new OpenAI({ temperature: 0 });
+  const template = `You are a playwright. Given the title of play, it is your job to write a synopsis for that title.
+    
+     Title: {title}
+     Playwright: This is a synopsis for the above play:`;
+  const promptTemplate = new PromptTemplate({
+    template,
+    inputVariables: ["title"],
+  });
+  const synopsisChain = new LLMChain({ llm, prompt: promptTemplate });
+
+  // This is an LLMChain to write a review of a play given a synopsis.
+  const reviewLLM = new OpenAI({ temperature: 0 });
+  const reviewTemplate = `You are a play critic from the New York Times. Given the synopsis of play, it is your job to write a review for that play.
+    
+     Play Synopsis:
+     {synopsis}
+     Review from a New York Times play critic of the above play:`;
+  const reviewPromptTempalte = new PromptTemplate({
+    template: reviewTemplate,
+    inputVariables: ["synopsis"],
+  });
+  const reviewChain = new LLMChain({
+    llm: reviewLLM,
+    prompt: reviewPromptTempalte,
+  });
+
+  const overallChain = new SimpleSequentialChain({
+    chains: [synopsisChain, reviewChain],
+    verbose: true,
+  });
+  const review = await overallChain.run("Tragedy at sunset on the beach");
+  expect(review.trim()).toMatchInlineSnapshot(`
+    "Tragedy at Sunset on the Beach is a powerful and moving story of love, loss, and redemption. The play follows the story of two young lovers, Jack and Jill, whose plans for a future together are tragically cut short when Jack is killed in a car accident. The play follows Jill as she struggles to cope with her grief and eventually finds solace in the arms of another man. 
+
+    The play is beautifully written and the performances are outstanding. The actors bring the characters to life with their heartfelt performances, and the audience is taken on an emotional journey as Jill is forced to confront her grief and make a difficult decision between her past and her future. The play culminates in a powerful climax that will leave the audience in tears. 
+
+    Overall, Tragedy at Sunset on the Beach is a powerful and moving story that will stay with you long after the curtain falls. It is a must-see for anyone looking for an emotionally charged and thought-provoking experience."
+  `);
+});
+
+test("Test SimpleSequentialChain serialize/deserialize", async () => {
+  const llm1 = new ChatOpenAI();
+  const template1 = `Echo back "{foo}"`;
+  const promptTemplate1 = new PromptTemplate({
+    template: template1,
+    inputVariables: ["foo"],
+  });
+  const chain1 = new LLMChain({ llm: llm1, prompt: promptTemplate1 });
+
+  const llm2 = new ChatOpenAI();
+  const template2 = `Echo back "{bar}"`;
+  const promptTemplate2 = new PromptTemplate({
+    template: template2,
+    inputVariables: ["bar"],
+  });
+  const chain2 = new LLMChain({
+    llm: llm2,
+    prompt: promptTemplate2,
+  });
+
+  const sampleSequentialChain = new SimpleSequentialChain({
+    chains: [chain1, chain2],
+    verbose: true,
+  });
+
+  const serializedChain = sampleSequentialChain.serialize();
+  expect(serializedChain._type).toEqual("simple_sequential_chain");
+  expect(serializedChain.chains.length).toEqual(2);
+  const deserializedChain = await SimpleSequentialChain.deserialize(
+    serializedChain
+  );
+  expect(deserializedChain.chains.length).toEqual(2);
+  expect(deserializedChain._chainType).toEqual("simple_sequential_chain");
+  const review = await deserializedChain.run("test");
+  expect(review.trim()).toMatchInlineSnapshot(`"Test."`);
+});

--- a/langchain/src/chains/tests/simple_sequential_chain.test.ts
+++ b/langchain/src/chains/tests/simple_sequential_chain.test.ts
@@ -4,6 +4,11 @@ import { LLMResult } from "../../schema/index.js";
 import { LLMChain } from "../llm_chain.js";
 import { PromptTemplate } from "../../prompts/index.js";
 import { SimpleSequentialChain } from "../simple_sequential_chain.js";
+import { AnalyzeDocumentChain } from "../analyze_documents_chain.js";
+import { ConversationalRetrievalQAChain } from "../conversational_retrieval_chain.js";
+import { VectorStoreRetriever } from "../../vectorstores/base.js";
+import { FakeEmbeddings } from "../../embeddings/fake.js";
+import { MemoryVectorStore } from "../../vectorstores/memory.js";
 
 class FakeLLM1 extends BaseLLM {
   nrMapCalls = 0;
@@ -63,4 +68,51 @@ test("Test SimpleSequentialChain", async () => {
   const combinedChain = new SimpleSequentialChain({ chains: [chain1, chain2] });
   const response = await combinedChain.run("initial question");
   expect(response).toEqual("final answer");
+});
+
+test("Test SimpleSequentialChain input chains' single input validation", async () => {
+  const model1 = new FakeLLM1({});
+  const model2 = new FakeLLM2({});
+  const template = "Some arbitrary template with fake {input1} and {input2}.";
+  const prompt = new PromptTemplate({
+    template,
+    inputVariables: ["input1", "input2"],
+  });
+  const chain1 = new LLMChain({ llm: model1, prompt });
+  const chain2 = new LLMChain({ llm: model2, prompt });
+  expect(() => {
+    /* eslint-disable no-new */
+    new SimpleSequentialChain({ chains: [chain1, chain2] });
+  }).toThrowErrorMatchingInlineSnapshot(
+    `"Chains used in SimpleSequentialChain should all have one input, got 2 for llm_chain."`
+  );
+});
+
+test("Test SimpleSequentialChain input chains' single ouput validation", async () => {
+  const model1 = new FakeLLM1({});
+  const fakeEmbeddings = new FakeEmbeddings();
+  const anyStore = new MemoryVectorStore(fakeEmbeddings);
+  const retriever = new VectorStoreRetriever({
+    vectorStore: anyStore,
+  });
+  const template = "Some arbitrary template with fake {input}.";
+  const prompt = new PromptTemplate({ template, inputVariables: ["input"] });
+  const chain1 = new LLMChain({ llm: model1, prompt });
+  const chain2 = new ConversationalRetrievalQAChain({
+    retriever,
+    combineDocumentsChain: chain1,
+    questionGeneratorChain: chain1,
+    returnSourceDocuments: true,
+  });
+  // Chain below is is not meant to work in a real-life scenario.
+  // It's only combined this way to get one input/multiple outputs chain.
+  const multipleOutputChain = new AnalyzeDocumentChain({
+    combineDocumentsChain: chain2,
+  });
+  expect(() => {
+    /* eslint-disable no-new */
+    new SimpleSequentialChain({ chains: [chain1, multipleOutputChain] });
+  }).toThrowErrorMatchingInlineSnapshot(
+    `"Chains used in SimpleSequentialChain should all have one output, got 2 for analyze_document_chain."`
+  );
 });

--- a/langchain/src/chains/tests/simple_sequential_chain.test.ts
+++ b/langchain/src/chains/tests/simple_sequential_chain.test.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@jest/globals";
+import { BaseLLM } from "../../llms/base.js";
+import { LLMResult } from "../../schema/index.js";
+import { LLMChain } from "../llm_chain.js";
+import { PromptTemplate } from "../../prompts/index.js";
+import { SimpleSequentialChain } from "../simple_sequential_chain.js";
+
+class FakeLLM1 extends BaseLLM {
+  nrMapCalls = 0;
+
+  nrReduceCalls = 0;
+
+  _llmType(): string {
+    return "fake_1";
+  }
+
+  async _generate(_prompts: string[], _?: string[]): Promise<LLMResult> {
+    return {
+      generations: [
+        [
+          {
+            text: "The answer is XXX.",
+          },
+        ],
+      ],
+    };
+  }
+}
+
+class FakeLLM2 extends BaseLLM {
+  nrMapCalls = 0;
+
+  nrReduceCalls = 0;
+
+  _llmType(): string {
+    return "fake_2";
+  }
+
+  async _generate(prompts: string[], _?: string[]): Promise<LLMResult> {
+    let response = "I don't know what you are talking about.";
+    if (prompts[0].includes("XXX")) {
+      response = "final answer";
+    }
+    return {
+      generations: [
+        [
+          {
+            text: response,
+          },
+        ],
+      ],
+    };
+  }
+}
+
+test("Test SimpleSequentialChain", async () => {
+  const model1 = new FakeLLM1({});
+  const model2 = new FakeLLM2({});
+  const template = "Some arbitrary template with fake {input}.";
+  const prompt = new PromptTemplate({ template, inputVariables: ["input"] });
+  const chain1 = new LLMChain({ llm: model1, prompt });
+  const chain2 = new LLMChain({ llm: model2, prompt });
+  const combinedChain = new SimpleSequentialChain({ chains: [chain1, chain2] });
+  const response = await combinedChain.run("initial question");
+  expect(response).toEqual("final answer");
+});


### PR DESCRIPTION
addresses #475 

Added SimpleSequentialChain implementation based on the one from the [python version](https://python.langchain.com/en/latest/_modules/langchain/chains/sequential.html#SimpleSequentialChain)

This is my first PR here so please excuse me if I messed some conventions up. The functionality is there but due to some differences between Python and TS classes, I wasn't sure how should I proceed with the validation that is included in the Python version.

I also added the some example docs site for this specific class as it's done for the `LLM`.

Few things to consider:
1. I added both integration and unit tests for the implementation. I'm not sure if both of them are required because some of them cover the same scenario (i.e. joining two chains together).
2. The original implementation validates the chains before creating the SimpleSequentialChain object i.e. it checks whether there is a single input and output for each chain. In the case of the TS implementation, the property `outputKey` is not available on the `BaseChain` but as a part of some chains (for example `LLMChain`). Because I used `BaseChain` as a type of the `chains` that are passed to the `SimpleSequentialChain` the way to check for this would be to do some casting and then check if the property `outputKey` is available on each chain. I would appreciate some input on how I should proceed with this.
3. The original implementation assumes that both input and output are strings. Should this condition be also preserved when validating the chains?

I would appreciate some hints on this @nfcampos. Thanks in advance for any input!