### PR TITLE
Update s3 loader so that you can provide credentials in class constructor

### DIFF
--- a/docs/docs/modules/indexes/document_loaders/examples/web_loaders/s3.mdx
+++ b/docs/docs/modules/indexes/document_loaders/examples/web_loaders/s3.mdx
@@ -21,6 +21,8 @@ See the docs [here](https://js.langchain.com/docs/modules/indexes/document_loade
 
 Once Unstructured is configured, you can use the S3 loader to load files and then convert them into a Document.
 
+You can optionally provide a s3Config parameter to specify your bucket region, access key, and secret access key. If these are not provided, you will need to have them in your environment (e.g., by running `aws configure`).
+
 import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/document_loaders/s3.ts";
 

--- a/examples/src/document_loaders/s3.ts
+++ b/examples/src/document_loaders/s3.ts
@@ -3,6 +3,11 @@ import { S3Loader } from "langchain/document_loaders/web/s3";
 const loader = new S3Loader({
   bucket: "my-document-bucket-123",
   key: "AccountingOverview.pdf",
+  s3Config: {
+    region: "us-east-1",
+    accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  },
   unstructuredAPIURL: "http://localhost:8000/general/v0/general",
 });
 

--- a/langchain/src/document_loaders/web/s3.ts
+++ b/langchain/src/document_loaders/web/s3.ts
@@ -9,9 +9,16 @@ export interface S3LoaderParams {
   bucket: string;
   key: string;
   unstructuredAPIURL: string;
+  s3Config?: S3Config;
 
   fs?: typeof fsDefault;
   UnstructuredLoader?: typeof UnstructuredLoaderDefault;
+}
+
+interface S3Config {
+  region?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
 }
 
 export class S3Loader extends BaseDocumentLoader {
@@ -21,6 +28,8 @@ export class S3Loader extends BaseDocumentLoader {
 
   private unstructuredAPIURL: string;
 
+  private s3Config: S3Config;
+
   private _fs: typeof fsDefault;
 
   private _UnstructuredLoader: typeof UnstructuredLoaderDefault;
@@ -29,6 +38,7 @@ export class S3Loader extends BaseDocumentLoader {
     bucket,
     key,
     unstructuredAPIURL,
+    s3Config = {},
     fs = fsDefault,
     UnstructuredLoader = UnstructuredLoaderDefault,
   }: S3LoaderParams) {
@@ -36,6 +46,7 @@ export class S3Loader extends BaseDocumentLoader {
     this.bucket = bucket;
     this.key = key;
     this.unstructuredAPIURL = unstructuredAPIURL;
+    this.s3Config = s3Config;
     this._fs = fs;
     this._UnstructuredLoader = UnstructuredLoader;
   }
@@ -50,7 +61,7 @@ export class S3Loader extends BaseDocumentLoader {
     const filePath = path.join(tempDir, this.key);
 
     try {
-      const s3Client = new S3Client({});
+      const s3Client = new S3Client(this.s3Config);
 
       const getObjectCommand = new GetObjectCommand({
         Bucket: this.bucket,


### PR DESCRIPTION
## Summary 
This change allows the access key / secret access key / region of your S3 bucket to be provided in the constructor of `S3Loader`. This means that you do not need to run `aws configure` before using the class, which was an item that had caused some confusion. 

Also updated the documentation to reflect this change. 