### PR TITLE
Use lite version of @dqbd/tiktoken

### DIFF
--- a/langchain/scripts/check-tree-shaking.js
+++ b/langchain/scripts/check-tree-shaking.js
@@ -26,6 +26,7 @@ export function listExternals() {
     ...Object.keys(packageJson.dependencies),
     ...Object.keys(packageJson.peerDependencies),
     /node\:/,
+    /@dqbd\/tiktoken/,
     "axios", // axios is a dependency of openai
     "pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js",
     "@zilliz/milvus2-sdk-node/dist/milvus/const/Milvus.js",

--- a/langchain/src/base_language/index.ts
+++ b/langchain/src/base_language/index.ts
@@ -97,7 +97,7 @@ export abstract class BaseLanguageModel
         // modelName only exists in openai subclasses, but tiktoken only supports
         // openai tokenisers anyway, so for other subclasses we default to gpt2
         if (encoding_for_model) {
-          this._encoding = encoding_for_model(
+          this._encoding = await encoding_for_model(
             "modelName" in this
               ? getModelNameForTiktoken(this.modelName as string)
               : "gpt2"

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedParameters": true,
     "useDefineForClassFields": true,
     "strictPropertyInitialization": false,
+    "resolveJsonModule": true,
     "allowJs": true,
     "strict": true
   },


### PR DESCRIPTION
Use the lite version of @dqbd/tiktoken, fetching the JSON mappings in runtime

- [ ] Switch to cached ranks instead to avoid pummeling OpenAI Azure CDNs etc.
- [ ] Consider importing full blown WASM when not used in edge runtimes for improved performance 
