### PR TITLE
Including import statements

### DIFF
--- a/docs/docs/modules/schema/chat-messages.md
+++ b/docs/docs/modules/schema/chat-messages.md
@@ -7,8 +7,6 @@ sidebar_position: 1
 
 The primary interface through which end users interact with LLMs is a chat interface. For this reason, some model providers have started providing access to the underlying API in a way that expects chat messages. These messages have a content field (which is usually text) and are associated with a user (or role). Right now the supported users are System, Human, and AI.
 
-
-
 ## SystemChatMessage
 
 A chat message representing information that should be instructions to the AI system.

--- a/docs/docs/modules/schema/chat-messages.md
+++ b/docs/docs/modules/schema/chat-messages.md
@@ -7,11 +7,15 @@ sidebar_position: 1
 
 The primary interface through which end users interact with LLMs is a chat interface. For this reason, some model providers have started providing access to the underlying API in a way that expects chat messages. These messages have a content field (which is usually text) and are associated with a user (or role). Right now the supported users are System, Human, and AI.
 
+
+
 ## SystemChatMessage
 
 A chat message representing information that should be instructions to the AI system.
 
 ```typescript
+import { SystemChatMessage } from "langchain/schema";
+
 new SystemChatMessage("You are a nice assistant");
 ```
 
@@ -20,6 +24,8 @@ new SystemChatMessage("You are a nice assistant");
 A chat message representing information coming from a human interacting with the AI system.
 
 ```typescript
+import { HumanChatMessage } from "langchain/schema";
+
 new HumanChatMessage("Hello, how are you?");
 ```
 
@@ -28,5 +34,7 @@ new HumanChatMessage("Hello, how are you?");
 A chat message representing information coming from the AI system.
 
 ```typescript
+import { AIChatMessage } from "langchain/schema";
+
 new AIChatMessage("I am doing well, thank you!");
 ```


### PR DESCRIPTION
It's annoying to research something, only to then have to look somewhere else to figure out how to actually implement it. These improvements follow the example of the "Documents" page in the same section, which explains how to import before using.