### PR TITLE
updating import links.

### DIFF
--- a/docs/docs/modules/models/chat/additional_functionality.mdx
+++ b/docs/docs/modules/models/chat/additional_functionality.mdx
@@ -40,7 +40,7 @@ For example, if you set `maxConcurrency: 5`, then LangChain will only send 5 req
 To use this feature, simply pass `maxConcurrency: <number>` when you instantiate the LLM. For example:
 
 ```typescript
-import { ChatOpenAI } from "langchain/chat_models/openai";
+import { ChatOpenAI } from "langchain/chat_models";
 
 const model = new ChatOpenAI({ maxConcurrency: 5 });
 ```
@@ -50,7 +50,7 @@ const model = new ChatOpenAI({ maxConcurrency: 5 });
 If the model provider returns an error from their API, by default LangChain will retry up to 6 times on an exponential backoff. This enables error recovery without any additional effort from you. If you want to change this behavior, you can pass a `maxRetries` option when you instantiate the model. For example:
 
 ```typescript
-import { ChatOpenAI } from "langchain/chat_models/openai";
+import { ChatOpenAI } from "langchain/chat_models";
 
 const model = new ChatOpenAI({ maxRetries: 10 });
 ```


### PR DESCRIPTION
links were incorrect:

import { ChatOpenAI } from 'langchain/chat_models/openai'; raised errors in execution, until replaced with import { ChatOpenAI } from 'langchain/chat_models';