### PR TITLE
Fix RegexParser including double slashes in prompt

### DIFF
--- a/examples/src/prompts/combining_parser.ts
+++ b/examples/src/prompts/combining_parser.ts
@@ -42,12 +42,14 @@ export const run = async () => {
 
   ```json
   {
-      "answer": string // answer to the user's question
-      "source": string // source used to answer the user's question, should be a website.
+    "answer": string // answer to the user's question
+    "source": string // source used to answer the user's question, should be a website.
   }
   ```
-  Complete that output fully. Then produce another output: Your response should match the following regex: //Confidence: (A|B|C), Explanation: (.*)//
 
+  Including the leading and trailing "```json" and "```"
+
+  Complete that output fully. Then produce another output: Your response should match the following regex: /Confidence: (A|B|C), Explanation: (.*)/
   What is the capital of France?
   */
 
@@ -55,20 +57,20 @@ export const run = async () => {
   /*
   ```json
   {
-      "answer": "Paris",
-      "source": "https://en.wikipedia.org/wiki/France"
+    "answer": "Paris",
+    "source": "https://en.wikipedia.org/wiki/Paris"
   }
   ```
-  //Confidence: A, Explanation: Paris is the capital of France according to Wikipedia.//
+  Confidence: A, Explanation: Paris is the capital of France, according to Wikipedia.
   */
 
   console.log(await parser.parse(response));
   /*
   {
     answer: 'Paris',
-    source: 'https://en.wikipedia.org/wiki/France',
+    source: 'https://en.wikipedia.org/wiki/Paris',
     confidence: 'A',
-    explanation: 'Paris is the capital of France according to Wikipedia.//'
-    }
+    explanation: 'Paris is the capital of France, according to Wikipedia.'
+  }
   */
 };

--- a/examples/src/prompts/regex_parser.ts
+++ b/examples/src/prompts/regex_parser.ts
@@ -1,0 +1,38 @@
+import { OpenAI } from "langchain/llms/openai";
+import { RegexParser } from "langchain/output_parsers";
+import { PromptTemplate } from "langchain/prompts";
+
+export const run = async () => {
+  const parser = new RegexParser(
+    /Humor: ([0-9]+), Sophistication: (A|B|C|D|E)/,
+    ["mark", "grade"],
+    "noConfidence"
+  );
+  const formatInstructions = parser.getFormatInstructions();
+
+  const prompt = new PromptTemplate({
+    template: "Grade the joke.\n\n{format_instructions}\n\nJoke: {joke}",
+    inputVariables: ["joke"],
+    partialVariables: { format_instructions: formatInstructions },
+  });
+
+  const model = new OpenAI({ temperature: 0 });
+
+  const input = await prompt.format({
+    joke: "What time is the appointment? Tooth hurt-y.",
+  });
+  console.log(input);
+  /*
+  Grade the joke.
+
+  Your response should match the following regex: /Humor: ([0-9]+), Sophistication: (A|B|C|D|E)/
+
+  Joke: What time is the appointment? Tooth hurt-y.
+  */
+
+  const response = await model.call(input);
+  console.log(response);
+  /*
+  Humor: 8, Sophistication: D
+  */
+};

--- a/langchain/src/output_parsers/regex.ts
+++ b/langchain/src/output_parsers/regex.ts
@@ -17,7 +17,7 @@ export class RegexParser extends BaseOutputParser {
     defaultOutputKey?: string
   ) {
     super();
-    this.regex = regex;
+    this.regex = typeof regex === "string" ? new RegExp(regex) : regex;
     this.outputKeys = outputKeys;
     this.defaultOutputKey = defaultOutputKey;
   }
@@ -46,6 +46,6 @@ export class RegexParser extends BaseOutputParser {
   }
 
   getFormatInstructions(): string {
-    return `Your response should match the following regex: /${this.regex}/`;
+    return `Your response should match the following regex: ${this.regex}`;
   }
 }


### PR DESCRIPTION
RegexParser was including the /regex/ slashes in its output, but those are already included when converting a RegExp to string. Therefore prompts looked like //0-9//, which is not a common regex notation. Models get confused and include literal // in their responses, which can be seen in the examples.

Fix: remove slashes from RegexParser output, and rely on those from converting RegExp to string.

Also included an example of how to use RegexParser.

Also re-ran examples and pasted output in comments.