### PR TITLE
fix: Motorhead memory needs to use correct keys

### DIFF
--- a/langchain/src/memory/motorhead_memory.ts
+++ b/langchain/src/memory/motorhead_memory.ts
@@ -4,6 +4,7 @@ import {
   OutputValues,
   MemoryVariables,
   getBufferString,
+  getInputValue,
 } from "./base.js";
 import { AsyncCaller, AsyncCallerParams } from "../util/async_caller.js";
 
@@ -101,6 +102,8 @@ export class MotorheadMemory extends BaseChatMemory {
     inputValues: InputValues,
     outputValues: OutputValues
   ): Promise<void> {
+    const input = getInputValue(inputValues, this.inputKey);
+    const output = getInputValue(outputValues, this.outputKey);
     await Promise.all([
       this.caller.call(
         fetch,
@@ -110,8 +113,8 @@ export class MotorheadMemory extends BaseChatMemory {
           method: "POST",
           body: JSON.stringify({
             messages: [
-              { role: "Human", content: `${inputValues.input}` },
-              { role: "AI", content: `${outputValues.response}` },
+              { role: "Human", content: `${input}` },
+              { role: "AI", content: `${output}` },
             ],
           }),
           headers: {


### PR DESCRIPTION
Motorhead memory was not using `getInputValue` to determine the name of the field from which save its contents.

Fixes issue: https://github.com/hwchase17/langchainjs/issues/861
