### PR TITLE
fix: fix document loader examples

### DIFF
--- a/examples/src/document_loaders/cheerio_web.ts
+++ b/examples/src/document_loaders/cheerio_web.ts
@@ -1,4 +1,4 @@
-import { CheerioWebBaseLoader } from "langchain/document_loaders/web/cheerio";
+import { CheerioWebBaseLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new CheerioWebBaseLoader(

--- a/examples/src/document_loaders/college_confidential.ts
+++ b/examples/src/document_loaders/college_confidential.ts
@@ -1,4 +1,4 @@
-import { CollegeConfidentialLoader } from "langchain/document_loaders/web/college_confidential";
+import { CollegeConfidentialLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new CollegeConfidentialLoader(

--- a/examples/src/document_loaders/gitbook.ts
+++ b/examples/src/document_loaders/gitbook.ts
@@ -1,4 +1,4 @@
-import { GitbookLoader } from "langchain/document_loaders/web/gitbook";
+import { GitbookLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new GitbookLoader("https://docs.gitbook.com");

--- a/examples/src/document_loaders/github.ts
+++ b/examples/src/document_loaders/github.ts
@@ -1,4 +1,4 @@
-import { GithubRepoLoader } from "langchain/document_loaders/web/github";
+import { GithubRepoLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new GithubRepoLoader(

--- a/examples/src/document_loaders/hn.ts
+++ b/examples/src/document_loaders/hn.ts
@@ -1,4 +1,4 @@
-import { HNLoader } from "langchain/document_loaders/web/hn";
+import { HNLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new HNLoader("https://news.ycombinator.com/item?id=34817881");

--- a/examples/src/document_loaders/imsdb.ts
+++ b/examples/src/document_loaders/imsdb.ts
@@ -1,4 +1,4 @@
-import { IMSDBLoader } from "langchain/document_loaders/web/imsdb";
+import { IMSDBLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new IMSDBLoader(

--- a/examples/src/document_loaders/notion_markdown.ts
+++ b/examples/src/document_loaders/notion_markdown.ts
@@ -1,4 +1,4 @@
-import { NotionLoader } from "langchain/document_loaders/fs/notion";
+import { NotionLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   /** Provide the directory path of your notion folder */

--- a/examples/src/document_loaders/puppeteer_web.ts
+++ b/examples/src/document_loaders/puppeteer_web.ts
@@ -1,4 +1,4 @@
-import { PuppeteerWebBaseLoader } from "langchain/document_loaders/web/puppeteer";
+import { PuppeteerWebBaseLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new PuppeteerWebBaseLoader("https://www.tabnews.com.br/");

--- a/examples/src/document_loaders/s3.ts
+++ b/examples/src/document_loaders/s3.ts
@@ -1,4 +1,4 @@
-import { S3Loader } from "langchain/document_loaders/web/s3";
+import { S3Loader } from "langchain/document_loaders";
 
 const loader = new S3Loader({
   bucket: "my-document-bucket-123",

--- a/examples/src/document_loaders/srt.ts
+++ b/examples/src/document_loaders/srt.ts
@@ -1,4 +1,4 @@
-import { SRTLoader } from "langchain/document_loaders/fs/srt";
+import { SRTLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new SRTLoader(

--- a/examples/src/document_loaders/text.ts
+++ b/examples/src/document_loaders/text.ts
@@ -1,4 +1,4 @@
-import { TextLoader } from "langchain/document_loaders/fs/text";
+import { TextLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new TextLoader(

--- a/examples/src/document_loaders/unstructured.ts
+++ b/examples/src/document_loaders/unstructured.ts
@@ -1,4 +1,4 @@
-import { UnstructuredLoader } from "langchain/document_loaders/fs/unstructured";
+import { UnstructuredLoader } from "langchain/document_loaders";
 
 export const run = async () => {
   const loader = new UnstructuredLoader(


### PR DESCRIPTION
hi
document loader refer has been changed to "langchain/document_loaders" 
but examples are not, so fix it. 