### PR TITLE
added ignoreFiles on github document loader

### DIFF
--- a/langchain/src/document_loaders/web/github.ts
+++ b/langchain/src/document_loaders/web/github.ts
@@ -113,8 +113,10 @@ export class GithubRepoLoader
     return this.ignoreFiles.some((pattern) => {
       if (typeof pattern === "string") {
         return path === pattern;
-      } else {
+      } else (pattern instanceof RegExp) {
         return pattern.test(path);
+      } else {
+        throw new Error(`Invalid ignore files pattern: ${pattern}`);
       }
     });
   }

--- a/langchain/src/document_loaders/web/github.ts
+++ b/langchain/src/document_loaders/web/github.ts
@@ -113,11 +113,13 @@ export class GithubRepoLoader
     return this.ignoreFiles.some((pattern) => {
       if (typeof pattern === "string") {
         return path === pattern;
-      } else (pattern instanceof RegExp) {
-        return pattern.test(path);
-      } else {
-        throw new Error(`Invalid ignore files pattern: ${pattern}`);
-      }
+      } 
+        try {
+          return pattern.test(path);
+        } catch {
+          throw new Error(`Unknown ignore file pattern: ${pattern}`);
+        }
+
     });
   }
 

--- a/langchain/src/document_loaders/web/github.ts
+++ b/langchain/src/document_loaders/web/github.ts
@@ -113,13 +113,13 @@ export class GithubRepoLoader
     return this.ignoreFiles.some((pattern) => {
       if (typeof pattern === "string") {
         return path === pattern;
-      } 
-        try {
-          return pattern.test(path);
-        } catch {
-          throw new Error(`Unknown ignore file pattern: ${pattern}`);
-        }
+      }
 
+      try {
+        return pattern.test(path);
+      } catch {
+        throw new Error(`Unknown ignore file pattern: ${pattern}`);
+      }
     });
   }
 


### PR DESCRIPTION
added ignoreFiles parameter on GithubRepoLoader constructor so it can ignore irrelevant large files (e.g. package-lock.json). It accepts array of strings or RegExp to test path name.