### PR TITLE
feat(tools): fix WebBrowser and AWSLambda export

### DIFF
--- a/langchain/src/tools/index.ts
+++ b/langchain/src/tools/index.ts
@@ -27,3 +27,5 @@ export {
 } from "./zapier.js";
 export { Serper, SerperParameters } from "./serper.js";
 export { AIPluginTool } from "./aiplugin.js";
+export { WebBrowser, WebBrowserArgs } from "./webbrowser.js";
+export { AWSLambda } from "./aws_lambda.js";


### PR DESCRIPTION
When I see the documentation at https://js.langchain.com/docs/modules/agents/tools/webbrowser, I can't use webbrowser at 0.0.59 version, and I fix it