### PR TITLE
feat: getDefaultOutputParser fields

### DIFF
--- a/langchain/src/agents/agent.ts
+++ b/langchain/src/agents/agent.ts
@@ -17,6 +17,9 @@ import {
   StoppingMethod,
 } from "./types.js";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OutputParserArgs = Record<string, any>;
+
 class ParseError extends Error {
   output: string;
 
@@ -213,7 +216,9 @@ export abstract class Agent extends BaseSingleActionAgent {
   /**
    * Get the default output parser for this agent.
    */
-  static getDefaultOutputParser(): AgentActionOutputParser {
+  static getDefaultOutputParser(
+    _fields?: OutputParserArgs
+  ): AgentActionOutputParser {
     throw new Error("Not implemented");
   }
 

--- a/langchain/src/agents/chat/index.ts
+++ b/langchain/src/agents/chat/index.ts
@@ -8,7 +8,7 @@ import {
 import { AgentStep } from "../../schema/index.js";
 import { Tool } from "../../tools/base.js";
 import { Optional } from "../../types/type-utils.js";
-import { Agent, AgentArgs } from "../agent.js";
+import { Agent, AgentArgs, OutputParserArgs } from "../agent.js";
 import { AgentInput } from "../types.js";
 import { ChatAgentOutputParser } from "./outputParser.js";
 import { FORMAT_INSTRUCTIONS, PREFIX, SUFFIX } from "./prompt.js";
@@ -61,7 +61,7 @@ export class ChatAgent extends Agent {
     }
   }
 
-  static getDefaultOutputParser() {
+  static getDefaultOutputParser(_fields?: OutputParserArgs) {
     return new ChatAgentOutputParser();
   }
 

--- a/langchain/src/agents/chat/outputParser.ts
+++ b/langchain/src/agents/chat/outputParser.ts
@@ -1,4 +1,4 @@
-import { AgentActionOutputParser } from "../../agents/types.js";
+import { AgentActionOutputParser } from "../types.js";
 import { AgentFinish } from "../../schema/index.js";
 import { FORMAT_INSTRUCTIONS } from "./prompt.js";
 

--- a/langchain/src/agents/chat_convo/index.ts
+++ b/langchain/src/agents/chat_convo/index.ts
@@ -15,7 +15,7 @@ import {
 } from "../../schema/index.js";
 import { Tool } from "../../tools/base.js";
 import { Optional } from "../../types/type-utils.js";
-import { Agent, AgentArgs } from "../agent.js";
+import { Agent, AgentArgs, OutputParserArgs } from "../agent.js";
 import { AgentActionOutputParser, AgentInput } from "../types.js";
 import { ChatConversationalAgentOutputParser } from "./outputParser.js";
 import {
@@ -90,7 +90,9 @@ export class ChatConversationalAgent extends Agent {
     return thoughts;
   }
 
-  static getDefaultOutputParser(): AgentActionOutputParser {
+  static getDefaultOutputParser(
+    _fields?: OutputParserArgs
+  ): AgentActionOutputParser {
     return new ChatConversationalAgentOutputParser();
   }
 

--- a/langchain/src/agents/chat_convo/outputParser.ts
+++ b/langchain/src/agents/chat_convo/outputParser.ts
@@ -1,4 +1,4 @@
-import { AgentActionOutputParser } from "../../agents/types.js";
+import { AgentActionOutputParser } from "../types.js";
 import { FORMAT_INSTRUCTIONS } from "./prompt.js";
 
 export class ChatConversationalAgentOutputParser extends AgentActionOutputParser {

--- a/langchain/src/agents/index.ts
+++ b/langchain/src/agents/index.ts
@@ -4,6 +4,7 @@ export {
   BaseSingleActionAgent,
   LLMSingleActionAgent,
   LLMSingleActionAgentInput,
+  OutputParserArgs,
 } from "./agent.js";
 export {
   JsonToolkit,

--- a/langchain/src/agents/mrkl/index.ts
+++ b/langchain/src/agents/mrkl/index.ts
@@ -4,7 +4,7 @@ import { PromptTemplate } from "../../prompts/prompt.js";
 import { renderTemplate } from "../../prompts/template.js";
 import { Tool } from "../../tools/base.js";
 import { Optional } from "../../types/type-utils.js";
-import { Agent, AgentArgs } from "../agent.js";
+import { Agent, AgentArgs, OutputParserArgs } from "../agent.js";
 import { deserializeHelper } from "../helpers.js";
 import {
   AgentInput,
@@ -32,7 +32,8 @@ export type ZeroShotAgentInput = Optional<AgentInput, "outputParser">;
 export class ZeroShotAgent extends Agent {
   constructor(input: ZeroShotAgentInput) {
     const outputParser =
-      input?.outputParser ?? ZeroShotAgent.getDefaultOutputParser();
+      input?.outputParser ??
+      ZeroShotAgent.getDefaultOutputParser({ finishToolName: "Final Answer:" });
     super({ ...input, outputParser });
   }
 
@@ -48,8 +49,8 @@ export class ZeroShotAgent extends Agent {
     return "Thought:";
   }
 
-  static getDefaultOutputParser() {
-    return new ZeroShotAgentOutputParser();
+  static getDefaultOutputParser(fields?: OutputParserArgs) {
+    return new ZeroShotAgentOutputParser(fields);
   }
 
   static validateTools(tools: Tool[]) {

--- a/langchain/src/agents/mrkl/index.ts
+++ b/langchain/src/agents/mrkl/index.ts
@@ -32,8 +32,7 @@ export type ZeroShotAgentInput = Optional<AgentInput, "outputParser">;
 export class ZeroShotAgent extends Agent {
   constructor(input: ZeroShotAgentInput) {
     const outputParser =
-      input?.outputParser ??
-      ZeroShotAgent.getDefaultOutputParser({ finishToolName: "Final Answer:" });
+      input?.outputParser ?? ZeroShotAgent.getDefaultOutputParser();
     super({ ...input, outputParser });
   }
 

--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -1,12 +1,20 @@
+import { OutputParserArgs } from "agents/index.js";
 import { AgentActionOutputParser } from "../../agents/types.js";
 
 import { FORMAT_INSTRUCTIONS } from "./prompt.js";
 
 export const FINAL_ANSWER_ACTION = "Final Answer:";
 export class ZeroShotAgentOutputParser extends AgentActionOutputParser {
+  finishToolName: string;
+
+  constructor(fields?: OutputParserArgs) {
+    super();
+    this.finishToolName = fields?.finishToolName || FINAL_ANSWER_ACTION;
+  }
+
   async parse(text: string) {
-    if (text.includes(FINAL_ANSWER_ACTION)) {
-      const parts = text.split(FINAL_ANSWER_ACTION);
+    if (text.includes(this.finishToolName)) {
+      const parts = text.split(this.finishToolName);
       const output = parts[parts.length - 1].trim();
       return {
         returnValues: { output },

--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -1,4 +1,4 @@
-import { OutputParserArgs } from "agents/index.js";
+import { OutputParserArgs } from "agents/agent.js";
 import { AgentActionOutputParser } from "../../agents/types.js";
 
 import { FORMAT_INSTRUCTIONS } from "./prompt.js";

--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -1,5 +1,5 @@
-import { OutputParserArgs } from "agents/agent.js";
-import { AgentActionOutputParser } from "../../agents/types.js";
+import { OutputParserArgs } from "../agent.js";
+import { AgentActionOutputParser } from "../types.js";
 
 import { FORMAT_INSTRUCTIONS } from "./prompt.js";
 


### PR DESCRIPTION
I have an issue with the new outputparser refactors. you cant take in Final Tool name as a variable to getDefaultOutputParser (which is abstract so has to be there)