### PR TITLE
feat: add verbose and callbackManager to ChainTool

### DIFF
--- a/langchain/src/tools/chain.ts
+++ b/langchain/src/tools/chain.ts
@@ -17,7 +17,7 @@ export class ChainTool extends Tool {
     chain: BaseChain;
     returnDirect?: boolean;
     verbose?: boolean;
-    callbackManager?: CallbackManager
+    callbackManager?: CallbackManager;
   }) {
     super(fields.verbose, fields.callbackManager);
     this.name = fields.name;

--- a/langchain/src/tools/chain.ts
+++ b/langchain/src/tools/chain.ts
@@ -1,3 +1,4 @@
+import { CallbackManager } from "callbacks/base.js";
 import { Tool } from "./base.js";
 import { BaseChain } from "../chains/base.js";
 
@@ -15,8 +16,10 @@ export class ChainTool extends Tool {
     description: string;
     chain: BaseChain;
     returnDirect?: boolean;
+    verbose?: boolean;
+    callbackManager?: CallbackManager
   }) {
-    super();
+    super(fields.verbose, fields.callbackManager);
     this.name = fields.name;
     this.description = fields.description;
     this.chain = fields.chain;


### PR DESCRIPTION
This brings the ChainTool up to snuff with the base Tool, and allows users of the ChainTool to include a callbackManager.

I'm exploring making a standard callback manager for my project where we are able to log to a database every interaction consistently. So this will let us use this utility tool.