### PR TITLE
feat: agent make constructScratchPad async

### DIFF
--- a/langchain/src/agents/agent.ts
+++ b/langchain/src/agents/agent.ts
@@ -282,7 +282,7 @@ export abstract class Agent extends BaseSingleActionAgent {
     inputs: ChainValues,
     suffix?: string
   ): Promise<AgentAction | AgentFinish> {
-    const thoughts = this.constructScratchPad(steps);
+    const thoughts = await this.constructScratchPad(steps);
     const newInputs: ChainValues = {
       ...inputs,
       agent_scratchpad: suffix ? `${thoughts}${suffix}` : thoughts,

--- a/langchain/src/agents/agent.ts
+++ b/langchain/src/agents/agent.ts
@@ -262,7 +262,9 @@ export abstract class Agent extends BaseSingleActionAgent {
   /**
    * Construct a scratchpad to let the agent continue its thought process
    */
-  constructScratchPad(steps: AgentStep[]): string | BaseChatMessage[] {
+  async constructScratchPad(
+    steps: AgentStep[]
+  ): Promise<string | BaseChatMessage[]> {
     return steps.reduce(
       (thoughts, { action, observation }) =>
         thoughts +

--- a/langchain/src/agents/chat/index.ts
+++ b/langchain/src/agents/chat/index.ts
@@ -65,8 +65,8 @@ export class ChatAgent extends Agent {
     return new ChatAgentOutputParser();
   }
 
-  constructScratchPad(steps: AgentStep[]): string {
-    const agentScratchpad = super.constructScratchPad(steps);
+  async constructScratchPad(steps: AgentStep[]): Promise<string> {
+    const agentScratchpad = await super.constructScratchPad(steps);
     if (agentScratchpad) {
       return `This was your previous work (but I haven't seen any of it! I only see what you return as final answer):\n${agentScratchpad}`;
     }

--- a/langchain/src/agents/chat_convo/index.ts
+++ b/langchain/src/agents/chat_convo/index.ts
@@ -75,7 +75,7 @@ export class ChatConversationalAgent extends Agent {
     }
   }
 
-  constructScratchPad(steps: AgentStep[]): BaseChatMessage[] {
+  async constructScratchPad(steps: AgentStep[]): Promise<BaseChatMessage[]> {
     const thoughts: BaseChatMessage[] = [];
     for (const step of steps) {
       thoughts.push(new AIChatMessage(step.action.log));


### PR DESCRIPTION
Ive been carrying this patch for a bit, so it feels worth pushing

Ive done stuff where i reach back out to get something (dynamicContext) or i have an agent with a vectorstore built in where I add and get from the vector store

