### PR TITLE
Make __run special key non-enumerable, ie. you can only access it specifcally by name

### DIFF
--- a/langchain/src/chat_models/base.ts
+++ b/langchain/src/chat_models/base.ts
@@ -5,6 +5,7 @@ import {
   ChatGeneration,
   ChatResult,
   LLMResult,
+  RUN_KEY,
 } from "../schema/index.js";
 import {
   BaseLanguageModel,
@@ -80,7 +81,9 @@ export abstract class BaseChatModel extends BaseLanguageModel {
         : undefined,
     };
     await runManager?.handleLLMEnd(output);
-    output.__run = runManager ? { runId: runManager?.runId } : undefined;
+    Object.defineProperty(output, RUN_KEY, {
+      value: runManager ? { runId: runManager?.runId } : undefined,
+    });
     return output;
   }
 

--- a/langchain/src/llms/base.ts
+++ b/langchain/src/llms/base.ts
@@ -1,5 +1,11 @@
 import { InMemoryCache } from "../cache/index.js";
-import { BaseCache, BasePromptValue, LLMResult } from "../schema/index.js";
+import {
+  BaseCache,
+  BasePromptValue,
+  Generation,
+  LLMResult,
+  RUN_KEY,
+} from "../schema/index.js";
 import {
   BaseLanguageModel,
   BaseLanguageModelParams,
@@ -90,7 +96,12 @@ export abstract class BaseLLM extends BaseLanguageModel {
     }
 
     await runManager?.handleLLMEnd(output);
-    output.__run = runManager ? { runId: runManager?.runId } : undefined;
+    // This defines RUN_KEY as a non-enumerable property on the output object
+    // so that it is not serialized when the output is stringified, and so that
+    // it isnt included when listing the keys of the output object.
+    Object.defineProperty(output, RUN_KEY, {
+      value: runManager ? { runId: runManager?.runId } : undefined,
+    });
     return output;
   }
 
@@ -226,7 +237,7 @@ export abstract class LLM extends BaseLLM {
     stop?: string[],
     runManager?: CallbackManagerForLLMRun
   ): Promise<LLMResult> {
-    const generations = [];
+    const generations: Generation[][] = [];
     for (let i = 0; i < prompts.length; i += 1) {
       const text = await this._call(prompts[i], stop, runManager);
       generations.push([{ text }]);

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -1,5 +1,7 @@
 import { Document } from "../document.js";
 
+export const RUN_KEY = "__run";
+
 export type Example = Record<string, string>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -43,7 +45,7 @@ export type LLMResult = {
    * Dictionary of run metadata
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  __run?: Record<string, any>;
+  [RUN_KEY]?: Record<string, any>;
 };
 export type MessageType = "human" | "ai" | "generic" | "system";
 


### PR DESCRIPTION
- it does not show up when calling Object.keys
- it isn't included when calling JSON.stringify on the output object (eg. in the tracer)

This ensures that we don't break eg the logic that powers memory updates, and sequential application of chains