### PR TITLE
Improves pdf parsing

### DIFF
--- a/langchain/src/document_loaders/fs/pdf.ts
+++ b/langchain/src/document_loaders/fs/pdf.ts
@@ -40,8 +40,12 @@ export class PDFLoader extends BufferLoader {
       }
 
       const text = content.items
-        .map((item) => (item as TextItem).str)
-        .join("\n");
+      .map((i) => {
+        const item = i as TextItem;
+        if (item.hasEOL) {return `${item.str}\n`;}
+        return item.str;
+      })
+      .join("");
 
       documents.push(
         new Document({


### PR DESCRIPTION
The below changes improve upon `PDFLoader.parse` method. Instead of adding a newline character after every `TextItem`, we only add a newline if the `TextItem` has an EOL character. This significantly improves the output text. Attaching an example below - 

Before:
```
Contents

Foreword
 
iii
Preface
 
v

1.
 
Real Numbers
 
1

1.1
 
Introduction
 
1
1.2
 
Euclid's Division Lemma
 
2
1.3
 
The Fundamental Theorem of Arithmetic
 
7
1.4
 
Revisiting Irrational Numbers
 
11
1.5
 
Revisiting Rational Numbers and Their Decimal Expansions
 
15
1.6
 
Summary
``` 

After: 
```
Contents
Foreword iii
Preface v
1. Real Numbers 1
1.1 Introduction 1
1.2 Euclid's Division Lemma 2
1.3 The Fundamental Theorem of Arithmetic 7
1.4 Revisiting Irrational Numbers 11
1.5 Revisiting Rational Numbers and Their Decimal Expansions 15
1.6 Summary 18
```