### PR TITLE
feat: pass _runManager to func in the DynamicTool

### DIFF
--- a/langchain/src/tools/chain.ts
+++ b/langchain/src/tools/chain.ts
@@ -1,36 +1,19 @@
-import { CallbackManagerForToolRun } from "../callbacks/manager.js";
-import { DynamicToolInput } from "./dynamic.js";
+import { DynamicTool, DynamicToolInput } from "./dynamic.js";
 import { BaseChain } from "../chains/base.js";
-import { Tool } from "./base.js";
 
 export interface ChainToolInput extends Omit<DynamicToolInput, "func"> {
   chain: BaseChain;
 }
 
-export class ChainTool extends Tool {
-  name: string;
-
-  description: string;
-
+export class ChainTool extends DynamicTool {
   chain: BaseChain;
 
-  returnDirect: boolean;
-
-  constructor(fields: ChainToolInput) {
-    super(fields.verbose, fields.callbacks);
-    this.name = fields.name;
-    this.description = fields.description;
-    this.chain = fields.chain;
-    this.returnDirect = fields.returnDirect ?? this.returnDirect;
-    this.verbose = fields.verbose ?? this.verbose;
-    this.callbacks = fields.callbacks ?? this.callbacks;
-  }
-
-  /** @ignore */
-  async _call(
-    input: string,
-    runManager?: CallbackManagerForToolRun
-  ): Promise<string> {
-    return this.chain.run(input, runManager?.getChild());
+  constructor({ chain, ...rest }: ChainToolInput) {
+    super({
+      ...rest,
+      func: async (input, runManager) =>
+        chain.run(input, runManager?.getChild()),
+    });
+    this.chain = chain;
   }
 }

--- a/langchain/src/tools/dynamic.ts
+++ b/langchain/src/tools/dynamic.ts
@@ -4,7 +4,7 @@ import { Tool } from "./base.js";
 export interface DynamicToolInput {
   name: string;
   description: string;
-  func: (arg1: string) => Promise<string>;
+  func: (input: string, _runManager?: CallbackManagerForToolRun) => Promise<string>;
   returnDirect?: boolean;
   verbose?: boolean;
   callbacks?: Callbacks;
@@ -15,7 +15,7 @@ export class DynamicTool extends Tool {
 
   description: string;
 
-  func: (arg1: string) => Promise<string>;
+  func: DynamicToolInput['func'];
 
   constructor(fields: DynamicToolInput) {
     super(fields.verbose, fields.callbacks);
@@ -30,6 +30,6 @@ export class DynamicTool extends Tool {
     input: string,
     _runManager?: CallbackManagerForToolRun
   ): Promise<string> {
-    return this.func(input);
+    return this.func(input, _runManager);
   }
 }

--- a/langchain/src/tools/dynamic.ts
+++ b/langchain/src/tools/dynamic.ts
@@ -4,7 +4,10 @@ import { Tool } from "./base.js";
 export interface DynamicToolInput {
   name: string;
   description: string;
-  func: (input: string, _runManager?: CallbackManagerForToolRun) => Promise<string>;
+  func: (
+    input: string,
+    runManager?: CallbackManagerForToolRun
+  ) => Promise<string>;
   returnDirect?: boolean;
   verbose?: boolean;
   callbacks?: Callbacks;
@@ -15,7 +18,7 @@ export class DynamicTool extends Tool {
 
   description: string;
 
-  func: DynamicToolInput['func'];
+  func: DynamicToolInput["func"];
 
   constructor(fields: DynamicToolInput) {
     super(fields.verbose, fields.callbacks);
@@ -28,8 +31,8 @@ export class DynamicTool extends Tool {
   /** @ignore */
   async _call(
     input: string,
-    _runManager?: CallbackManagerForToolRun
+    runManager?: CallbackManagerForToolRun
   ): Promise<string> {
-    return this.func(input, _runManager);
+    return this.func(input, runManager);
   }
 }


### PR DESCRIPTION
It will be helpful to have the `_runManager` in the dynamic function.

We can use it as a context with the `runId`.