### PR TITLE
Update schema.prisma to inclue pgvector extension, simplify docs

### DIFF
--- a/docs/docs/modules/indexes/vector_stores/integrations/prisma.mdx
+++ b/docs/docs/modules/indexes/vector_stores/integrations/prisma.mdx
@@ -46,7 +46,7 @@ import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/sc
 Run the migration :
 
 ```bash npm2yarn
-npm run prisma migrate dev
+npx prisma migrate dev
 ```
 
 ## Usage

--- a/docs/docs/modules/indexes/vector_stores/integrations/prisma.mdx
+++ b/docs/docs/modules/indexes/vector_stores/integrations/prisma.mdx
@@ -37,29 +37,13 @@ volumes:
 
 ### Create a new schema
 
-Assuming you haven't created a schema yet, create a new model with a `vector` field of type `Unsupported("vector")`:
+Assuming you haven't created a schema yet, create a new schema and a model with a `vector` field of type `Unsupported("vector")`:
 
-```prisma
-model Document {
-  id      String                 @id @default(cuid())
-  content String
-  vector  Unsupported("vector")?
-}
-```
+import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/schema.prisma";
 
-Afterwards, create a new migration with `--create-only` to avoid running the migration directly.
+<CodeBlock language="prisma">{Schema}</CodeBlock>
 
-```bash npm2yarn
-npm run prisma migrate dev --create-only
-```
-
-Add the following line to the newly created migration to enable `pgvector` extension if it hasn't been enabled yet:
-
-```sql
-CREATE EXTENSION IF NOT EXISTS vector;
-```
-
-Run the migration afterwards:
+Run the migration :
 
 ```bash npm2yarn
 npm run prisma migrate dev
@@ -69,12 +53,7 @@ npm run prisma migrate dev
 
 import CodeBlock from "@theme/CodeBlock";
 import Example from "@examples/indexes/vector_stores/prisma_vectorstore/prisma.ts";
-import Schema from "@examples/indexes/vector_stores/prisma_vectorstore/prisma/schema.prisma";
 
 Use the `withModel` method to get proper type hints for `metadata` field:
 
 <CodeBlock language="typescript">{Example}</CodeBlock>
-
-The sample above uses the following schema:
-
-<CodeBlock language="prisma">{Schema}</CodeBlock>

--- a/examples/src/indexes/vector_stores/prisma_vectorstore/prisma/schema.prisma
+++ b/examples/src/indexes/vector_stores/prisma_vectorstore/prisma/schema.prisma
@@ -2,12 +2,14 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresqlExtensions"]
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [pgvector(map: "vector", schema: "extensions")] // Add the pgvector extension
 }
 
 model Document {


### PR DESCRIPTION
This PR updates the `schema.prisma` sample to create/add the [pgvector](https://github.com/pgvector/pgvector) postgresql extension and simplifies the steps listed in the [Prisma vector store integration doc](https://js.langchain.com/docs/modules/indexes/vector_stores/integrations/prisma).

With the updated `schema.prisma`, `prisma migration dev` should automatically generate and apply a `migration.sql` to the database with `CREATE EXTENSION IF NOT EXISTS "vector" WITH SCHEMA "extensions";` to add the pgvector extension. 
This avoids the manual migration SQL update step and reduces the commands the user needs to run.
Simplified the user/developer docs.
