### PR TITLE
Rename `initializeAgentExecutor` to `initializeAgentExecutorWithOptions` in comment

### DIFF
--- a/langchain/src/agents/initialize.ts
+++ b/langchain/src/agents/initialize.ts
@@ -13,7 +13,7 @@ type AgentType =
   | "chat-conversational-react-description";
 
 /**
- * @deprecated use initializeExecutorWithOptions instead
+ * @deprecated use initializeAgentExecutorWithOptions instead
  */
 export const initializeAgentExecutor = async (
   tools: Tool[],


### PR DESCRIPTION
There was a non-existent function name `initializeAgentExecutor` in the comments, so I changed it to the actual function name `initializeAgentExecutorWithOptions`.