### PR TITLE
Update Chroma class with new functionality for collection creation

### DIFF
--- a/docs/docs/modules/indexes/vector_stores/integrations/chroma.md
+++ b/docs/docs/modules/indexes/vector_stores/integrations/chroma.md
@@ -45,6 +45,13 @@ const vectorStore = await Chroma.fromDocuments(docs, new OpenAIEmbeddings(), {
   collectionName: "goldel-escher-bach",
 });
 
+// or alternatively from a existing collection
+const vectorStore = await Chroma.fromExistingCollection(new OpenAIEmbeddings(),
+  {
+    collectionName: "goldel-escher-bach",
+  }
+);
+
 const response = await vectorStore.similaritySearch("scared", 2);
 ```
 
@@ -54,12 +61,9 @@ const response = await vectorStore.similaritySearch("scared", 2);
 import { Chroma } from "langchain/vectorstores/chroma";
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 
-const vectorStore = await Chroma.fromExistingCollection(
-  new OpenAIEmbeddings(),
-  {
-    collectionName: "goldel-escher-bach",
-  }
-);
+const vectorStore = await Chroma.getVectorStore(new OpenAIEmbeddings(), {
+  collectionName: collection,
+});
 
 const response = await vectorStore.similaritySearch("scared", 2);
 ```

--- a/langchain/src/vectorstores/chroma.ts
+++ b/langchain/src/vectorstores/chroma.ts
@@ -38,14 +38,16 @@ export class Chroma extends VectorStore {
     );
   }
 
-  async ensureCollection() {
+  async ensureCollection(newCollection: boolean): Promise<void> {
     if (!this.index) {
       const { ChromaClient } = await Chroma.imports();
       this.index = new ChromaClient(this.url);
-      try {
-        await this.index.createCollection(this.collectionName);
-      } catch {
-        // ignore error
+      if (newCollection) {
+        try {
+          await this.index.createCollection(this.collectionName);
+        } catch {
+          // ignore error
+        }
       }
     }
   }
@@ -161,7 +163,19 @@ export class Chroma extends VectorStore {
     }
   ): Promise<Chroma> {
     const instance = new this(embeddings, dbConfig);
-    await instance.ensureCollection();
+    await instance.ensureCollection(true);
+    return instance;
+  }
+
+  static async getVectorStore(
+    embeddings: Embeddings,
+    dbConfig: {
+      collectionName: string;
+      url?: string;
+    }
+  ): Promise<Chroma> {
+    const instance = new this(embeddings, dbConfig);
+    await instance.ensureCollection(false);
     return instance;
   }
 


### PR DESCRIPTION
The Chroma class has been updated with new functionality for creating and retrieving collections. The ensureCollection method now takes a new optional parameter 'newCollection', which allows the caller to specify whether or not to create a new collection. If 'newCollection' is true, a new collection will be created if one with the same name does not already exist. If 'newCollection' is false (or not provided), the method will return without doing anything if the collection already exists.

Additionally, a new method 'getVectorStore' has been added to the Chroma class. This method retrieves the vector store without attempting to create a new collection if one with the same name already exists. This can be useful in cases where the user wants to retrieve an existing vector store, but does not want to create a new one if it does not exist.

The constructor has also been updated to use the new 'ensureCollection' method with the 'newCollection' parameter set to true by default, ensuring that a new collection is created if one does not already exist.

Before:
![image](https://user-images.githubusercontent.com/37886774/233834038-fc55dfc5-3b79-451d-8be7-884895a83ff8.png)

After:
![image](https://user-images.githubusercontent.com/37886774/233834050-c86b0804-23ca-4f8c-9fc3-ca6af5b5b354.png)

And it's a small change, but every millisecond counts.