### PR TITLE
unrolled error in supabase vectorstore and retrievers

### DIFF
--- a/langchain/src/retrievers/supabase.ts
+++ b/langchain/src/retrievers/supabase.ts
@@ -97,7 +97,9 @@ export class SupabaseHybridSearch extends BaseRetriever {
     );
 
     if (error) {
-      throw new Error(`Error searching for documents: ${error}`);
+      throw new Error(
+        `Error searching for documents: ${error.code} ${error.message} ${error.details}`
+      );
     }
 
     return (searches as SearchResponseRow[]).map((resp) => [
@@ -125,7 +127,9 @@ export class SupabaseHybridSearch extends BaseRetriever {
     );
 
     if (error) {
-      throw new Error(`Error searching for documents: ${error}`);
+      throw new Error(
+        `Error searching for documents: ${error.code} ${error.message} ${error.details}`
+      );
     }
 
     return (searches as SearchResponseRow[]).map((resp) => [

--- a/langchain/src/vectorstores/supabase.ts
+++ b/langchain/src/vectorstores/supabase.ts
@@ -81,7 +81,9 @@ export class SupabaseVectorStore extends VectorStore {
     );
 
     if (error) {
-      throw new Error(`Error searching for documents: ${error}`);
+      throw new Error(
+        `Error searching for documents: ${error.code} ${error.message} ${error.details}`
+      );
     }
 
     const result: [Document, number][] = (


### PR DESCRIPTION
So now if there's an error its clear what the error is, instead of printing out [object object].