### PR TITLE
test: update unstructured API url and enable test

### DIFF
--- a/docs/docs/ecosystem/unstructured.md
+++ b/docs/docs/ecosystem/unstructured.md
@@ -21,7 +21,9 @@ the service locally using the instructions found
 You can use Unstructured in`langchainjs` with the following code.
 Replace the filename with the file you would like to process.
 If you are running the container locally, switch the url to
-`https://api.unstructured.io/general/v0/general`.
+`https://api.unstructured.io/general/v0/general
+Check out the [API documentation page](https://api.unstructured.io/general/docs)
+for additional details.
 
 ```typescript
 import { UnstructuredLoader } from "langchain/document_loaders/fs/unstructured";

--- a/docs/docs/ecosystem/unstructured.md
+++ b/docs/docs/ecosystem/unstructured.md
@@ -21,7 +21,7 @@ the service locally using the instructions found
 You can use Unstructured in`langchainjs` with the following code.
 Replace the filename with the file you would like to process.
 If you are running the container locally, switch the url to
-`https://api.unstructured.io/general/v0/general
+`https://api.unstructured.io/general/v0/general.
 Check out the [API documentation page](https://api.unstructured.io/general/docs)
 for additional details.
 

--- a/langchain/src/document_loaders/tests/unstructured.test.ts
+++ b/langchain/src/document_loaders/tests/unstructured.test.ts
@@ -4,7 +4,6 @@ import { test, expect } from "@jest/globals";
 import { UnstructuredLoader } from "../fs/unstructured.js";
 
 test("Test Unstructured base loader", async () => {
-
   const filePath = path.resolve(
     path.dirname(url.fileURLToPath(import.meta.url)),
     "./example_data/example.txt"

--- a/langchain/src/document_loaders/tests/unstructured.test.ts
+++ b/langchain/src/document_loaders/tests/unstructured.test.ts
@@ -11,7 +11,7 @@ test("Test Unstructured base loader", async () => {
   );
 
   const loader = new UnstructuredLoader(
-    "https://api.unstructured.io/general/v0.0.12/general",
+    "https://api.unstructured.io/general/v0/general",
     filePath
   );
   const docs = await loader.load();

--- a/langchain/src/document_loaders/tests/unstructured.test.ts
+++ b/langchain/src/document_loaders/tests/unstructured.test.ts
@@ -1,10 +1,18 @@
+import * as url from "node:url";
+import * as path from "node:path";
 import { test, expect } from "@jest/globals";
 import { UnstructuredLoader } from "../fs/unstructured.js";
 
-test.skip("Test Unstructured base loader", async () => {
+test("Test Unstructured base loader", async () => {
+
+  const filePath = path.resolve(
+    path.dirname(url.fileURLToPath(import.meta.url)),
+    "./example_data/example.txt"
+  );
+
   const loader = new UnstructuredLoader(
-    "http://127.0.0.1:8000/general/v0.0.4/general",
-    "langchain/src/document_loaders/tests/example_data/example.txt"
+    "https://api.unstructured.io/general/v0.0.12/general",
+    filePath
   );
   const docs = await loader.load();
 


### PR DESCRIPTION
### Summary

Updates the URL in `unstructured.test.ts` to the URL for the live Unstructured API and enables the tests. Also adds a link to the Unstructured API Swagger docs to the Unstructured ecosystem docs page.

### Testing

`yarn test` should run successfully with the updated URL.