### PR TITLE
Fix the issue where the track function does not support the LANGCHAIN_SESSION environment variable

### DIFF
--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -464,7 +464,15 @@ export class CallbackManager
           (handler) => handler.name === "langchain_tracer"
         )
       ) {
-        callbackManager.addHandler(await getTracingCallbackHandler(), true);
+        const session =
+          typeof process !== "undefined"
+            ? // eslint-disable-next-line no-process-env
+              process.env?.LANGCHAIN_SESSION
+            : undefined;
+        callbackManager.addHandler(
+          await getTracingCallbackHandler(session),
+          true
+        );
       }
     }
     return callbackManager;


### PR DESCRIPTION
When using the langchain track, I found that the LANGCHAIN_SESSION environment variable does not take effect, and in python's documentation, it is supported.
ref: https://python.langchain.com/en/latest/tracing.html#changing-sessions
