### PR TITLE
Added additional check for empty object when upserting to Pinecone Index

### DIFF
--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -67,8 +67,11 @@ export class PineconeStore extends VectorStore {
       for (const key of Object.keys(metadata)) {
         if (metadata[key] == null) {
           delete metadata[key];
-        } else if(typeof metadata[key] == 'object' && Object.keys(metadata[key]).length === 0){
-            delete metadata[key];
+        } else if (
+          typeof metadata[key] === "object" &&
+          Object.keys(metadata[key] as unknown as object).length === 0
+        ) {
+          delete metadata[key];
         }
       }
       return {

--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -67,6 +67,8 @@ export class PineconeStore extends VectorStore {
       for (const key of Object.keys(metadata)) {
         if (metadata[key] == null) {
           delete metadata[key];
+        } else if(typeof metadata[key] == 'object' && Object.keys(metadata[key]).length === 0){
+            delete metadata[key];
         }
       }
       return {


### PR DESCRIPTION
Langchain checks for null properties and deletes these before upserting to the Index. I've added an additional check for empty objects in the metadata, as these are not handled when the array is flattened. 

I had issues when upserting to Pinecone, and I realised this was because of the fact that sometimes there were empty objects as properties in the PDF metadata. The proposed change fixed this issue.