### PR TITLE
CI: Speed up and less flaky

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,9 @@ jobs:
         run: yarn run test:unit --filter="!test-exports-cra"
         # test-exports-cra is still run in test-exports task, currently not
         # compatible with Node.js 20.x, so disabling here
+        # Note it is useful to run the others here in addition to test-exports
+        # because it would catch any issues that only manifest
+        # when optional peer deps are installed
 
   test-exports:
     name: Environment Tests
@@ -105,6 +108,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - name: Build
-        run: yarn run build --filter="!docs"
+        run: yarn workspace langchain build
       - name: Test Exports
         run: yarn run test:exports:docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - name: Build
-        run: yarn run build --filter="!docs"
+        run: yarn workspace langchain build
       - name: Test
         run: yarn run test:unit --filter="!test-exports-cra"
         # test-exports-cra is still run in test-exports task, currently not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - name: Build
-        run: yarn workspace langchain build
+        run: yarn run build
       - name: Test
         run: yarn run test:unit --filter="!test-exports-cra"
         # test-exports-cra is still run in test-exports task, currently not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
   build:
     name: Build and check types
     runs-on: ubuntu-latest
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: "true"
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "true"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x
@@ -58,10 +61,18 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         node-version: [18.x, 19.x, 20.x]
         # See Node.js release schedule at https://nodejs.org/en/about/releases/
+        include:
+          - os: windows-latest
+            node-version: 20.x
+          - os: macos-latest
+            node-version: 20.x
     runs-on: ${{ matrix.os }}
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: "true"
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "true"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -81,6 +92,9 @@ jobs:
   test-exports:
     name: Environment Tests
     runs-on: ubuntu-latest
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: "true"
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "true"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -324,7 +324,6 @@
     "mammoth": "^1.5.1",
     "mongodb": "^5.2.0",
     "pdf-parse": "1.1.1",
-    "pdfjs-dist": "^3.4.120",
     "playwright": "^1.32.1",
     "prettier": "^2.8.3",
     "puppeteer": "^19.7.2",

--- a/langchain/src/document_loaders/tests/pdf.test.ts
+++ b/langchain/src/document_loaders/tests/pdf.test.ts
@@ -26,22 +26,3 @@ test("Test PDF loader from file to single document", async () => {
   expect(docs.length).toBe(1);
   expect(docs[0].pageContent).toContain("Attention Is All You Need");
 });
-
-test("Test PDF loader from file using custom pdfjs", async () => {
-  if (process.version.startsWith("v20")) {
-    // `pdfjs-dist` doesn't support Node 20 (`canvas` doesn't support Node 20)
-    return;
-  }
-  const filePath = path.resolve(
-    path.dirname(url.fileURLToPath(import.meta.url)),
-    "./example_data/1706.03762.pdf"
-  );
-  const loader = new PDFLoader(filePath, {
-    pdfjs: () =>
-      import("pdfjs-dist/legacy/build/pdf.js").then((mod) => mod.default),
-  });
-  const docs = await loader.load();
-
-  expect(docs.length).toBe(15);
-  expect(docs[0].pageContent).toContain("Attention Is All You Need");
-});

--- a/test-exports-vercel/src/pages/index.tsx
+++ b/test-exports-vercel/src/pages/index.tsx
@@ -2,7 +2,6 @@
 import "../entrypoints.js";
 
 import Head from "next/head";
-import { Inter } from "next/font/google";
 import styles from "@/styles/Home.module.css";
 import { useCallback } from "react";
 import { ChatOpenAI } from "langchain/chat_models/openai";
@@ -12,8 +11,6 @@ import {
   ChatPromptTemplate,
   HumanMessagePromptTemplate,
 } from "langchain/prompts";
-
-const inter = Inter({ subsets: ["latin"] });
 
 // Don't do this in your app, it would leak your API key
 const OPENAI_API_KEY = process.env.NEXT_PUBLIC_OPENAI_API_KEY;
@@ -53,7 +50,7 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <main className={`${styles.main} ${inter.className}`}>
+      <main className={styles.main}>
         <button onClick={runChain}>Click to run a chain</button>
       </main>
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9661,18 +9661,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"canvas@npm:^2.11.0":
-  version: 2.11.2
-  resolution: "canvas@npm:2.11.2"
-  dependencies:
-    "@mapbox/node-pre-gyp": ^1.0.0
-    nan: ^2.17.0
-    node-gyp: latest
-    simple-get: ^3.0.3
-  checksum: 61e554aef80022841dc836964534082ec21435928498032562089dfb7736215f039c7d99ee546b0cf10780232d9bf310950f8b4d489dc394e0fb6f6adfc97994
-  languageName: node
-  linkType: hard
-
 "case-sensitive-paths-webpack-plugin@npm:^2.4.0":
   version: 2.4.0
   resolution: "case-sensitive-paths-webpack-plugin@npm:2.4.0"
@@ -11057,15 +11045,6 @@ __metadata:
   dependencies:
     mimic-response: ^1.0.0
   checksum: 952552ac3bd7de2fc18015086b09468645c9638d98a551305e485230ada278c039c91116e946d07894b39ee53c0f0d5b6473f25a224029344354513b412d7380
-  languageName: node
-  linkType: hard
-
-"decompress-response@npm:^4.2.0":
-  version: 4.2.1
-  resolution: "decompress-response@npm:4.2.1"
-  dependencies:
-    mimic-response: ^2.0.0
-  checksum: 4e783ca4dfe9417354d61349750fe05236f565a4415a6ca20983a311be2371debaedd9104c0b0e7b36e5f167aeaae04f84f1a0b3f8be4162f1d7d15598b8fdba
   languageName: node
   linkType: hard
 
@@ -17178,7 +17157,6 @@ __metadata:
     p-queue: ^6.6.2
     p-retry: 4
     pdf-parse: 1.1.1
-    pdfjs-dist: ^3.4.120
     playwright: ^1.32.1
     prettier: ^2.8.3
     puppeteer: ^19.7.2
@@ -18063,13 +18041,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-response@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "mimic-response@npm:2.1.0"
-  checksum: 014fad6ab936657e5f2f48bd87af62a8e928ebe84472aaf9e14fec4fcb31257a5edff77324d8ac13ddc6685ba5135cf16e381efac324e5f174fb4ddbf902bf07
-  languageName: node
-  linkType: hard
-
 "mimic-response@npm:^3.1.0":
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
@@ -18489,15 +18460,6 @@ __metadata:
     object-assign: ^4.0.1
     thenify-all: ^1.0.0
   checksum: 8427de0ece99a07e9faed3c0c6778820d7543e3776f9a84d22cf0ec0a8eb65f6e9aee9c9d353ff9a105ff62d33a9463c6ca638974cc652ee8140cd1e35951c87
-  languageName: node
-  linkType: hard
-
-"nan@npm:^2.17.0":
-  version: 2.17.0
-  resolution: "nan@npm:2.17.0"
-  dependencies:
-    node-gyp: latest
-  checksum: ec609aeaf7e68b76592a3ba96b372aa7f5df5b056c1e37410b0f1deefbab5a57a922061e2c5b369bae9c7c6b5e6eecf4ad2dac8833a1a7d3a751e0a7c7f849ed
   languageName: node
   linkType: hard
 
@@ -19654,13 +19616,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path2d-polyfill@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "path2d-polyfill@npm:2.0.1"
-  checksum: e38a4f920be3550e8334b899cc56f4fca0a976ca69404ee10d656a45d422996b7e27e294e2cf0aac2e410ce59d6977cde9f95586e62a24e6c904716695e059f8
-  languageName: node
-  linkType: hard
-
 "pathe@npm:^1.1.0":
   version: 1.1.0
   resolution: "pathe@npm:1.1.0"
@@ -19682,20 +19637,6 @@ __metadata:
     debug: ^3.1.0
     node-ensure: ^0.0.0
   checksum: 5d63a8be1b3b8915618b1b76350409513fdd7fe03c77056b2dd7a1c2da28a11e297645e33bb4e953e2c1cd0ae66980f30fd0bed2979877f894347962d9647241
-  languageName: node
-  linkType: hard
-
-"pdfjs-dist@npm:^3.4.120":
-  version: 3.5.141
-  resolution: "pdfjs-dist@npm:3.5.141"
-  dependencies:
-    canvas: ^2.11.0
-    path2d-polyfill: ^2.0.1
-    web-streams-polyfill: ^3.2.1
-  dependenciesMeta:
-    canvas:
-      optional: true
-  checksum: b58e801b92a0d7b58b3799c0cf48f35deb45e140ef488744251a3e3dd148acef7aef4edfb8c7622b342c7068e8b7c01b754546ed0e60897e48665fa45af9d845
   languageName: node
   linkType: hard
 
@@ -22824,24 +22765,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-concat@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "simple-concat@npm:1.0.1"
-  checksum: 4d211042cc3d73a718c21ac6c4e7d7a0363e184be6a5ad25c8a1502e49df6d0a0253979e3d50dbdd3f60ef6c6c58d756b5d66ac1e05cda9cacd2e9fc59e3876a
-  languageName: node
-  linkType: hard
-
-"simple-get@npm:^3.0.3":
-  version: 3.1.1
-  resolution: "simple-get@npm:3.1.1"
-  dependencies:
-    decompress-response: ^4.2.0
-    once: ^1.3.1
-    simple-concat: ^1.0.0
-  checksum: 80195e70bf171486e75c31e28e5485468195cc42f85940f8b45c4a68472160144d223eb4d07bc82ef80cb974b7c401db021a540deb2d34ac4b3b8883da2d6401
-  languageName: node
-  linkType: hard
-
 "sirv@npm:^1.0.7":
   version: 1.0.19
   resolution: "sirv@npm:1.0.19"
@@ -25512,7 +25435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-streams-polyfill@npm:^3.0.3, web-streams-polyfill@npm:^3.2.1":
+"web-streams-polyfill@npm:^3.0.3":
   version: 3.2.1
   resolution: "web-streams-polyfill@npm:3.2.1"
   checksum: b119c78574b6d65935e35098c2afdcd752b84268e18746606af149e3c424e15621b6f1ff0b42b2676dc012fc4f0d313f964b41a4b5031e525faa03997457da02


### PR DESCRIPTION
It currently builds/downloads some things that aren't needed, and this cuts down on that which both makes it faster and less likely to fail. Also rethink the matrix strategy, no need to test all 9 combinations, enough to test all node versions against one OS and all OSs against one node version