### PR TITLE
Add inputKey and outputKey fields to BufferWindowMemory

### DIFF
--- a/langchain/src/memory/buffer_window_memory.ts
+++ b/langchain/src/memory/buffer_window_memory.ts
@@ -25,6 +25,8 @@ export class BufferWindowMemory
     super({
       returnMessages: fields?.returnMessages ?? false,
       chatHistory: fields?.chatHistory,
+      inputKey: fields?.inputKey,
+      outputKey: fields?.outputKey,
     });
     this.humanPrefix = fields?.humanPrefix ?? this.humanPrefix;
     this.aiPrefix = fields?.aiPrefix ?? this.aiPrefix;


### PR DESCRIPTION
Useful when using `returnIntermediateSteps` - makes it ISO with `BufferMemory`.
