### PR TITLE
Properly handle OpenAI JSON error responses when expecting stream response

### DIFF
--- a/langchain/src/util/axios-fetch-adapter.js
+++ b/langchain/src/util/axios-fetch-adapter.js
@@ -250,6 +250,16 @@ async function getResponse(request, config) {
     if (config.responseType === "stream") {
       const contentType = stageOne.headers.get("content-type");
       if (!contentType?.startsWith(EventStreamContentType)) {
+        if (contentType?.startsWith('application/json')) {
+          // If the response is JSON, try to parse it and throw a more specific error
+          response.data = await stageOne.json();
+          if (response.data?.error instanceof Error) {
+            throw response.data.error;
+          }
+          throw new Error(
+              `Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}. Error: ${response.data?.error?.message}`
+          );
+        }
         throw new Error(
           `Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}`
         );

--- a/langchain/src/util/axios-fetch-adapter.js
+++ b/langchain/src/util/axios-fetch-adapter.js
@@ -19,6 +19,14 @@ import {
   getMessages,
 } from "./event-source-parse.js";
 
+function tryJsonStringify(data) {
+  try {
+    return JSON.stringify(data);
+  } catch (e) {
+    return data;
+  }
+}
+
 /**
  * In order to avoid import issues with axios 1.x, copying here the internal
  * utility functions that we used to import directly from axios.
@@ -32,7 +40,11 @@ function settle(resolve, reject, response) {
   } else {
     reject(
       createError(
-        `Request failed with status code ${response.status}`,
+        `Request failed with status code ${response.status} and body ${
+          typeof response.data === "string"
+            ? response.data
+            : tryJsonStringify(response.data)
+        }`,
         response.config,
         null,
         response.request,

--- a/langchain/src/util/tests/openai-stream.test.ts
+++ b/langchain/src/util/tests/openai-stream.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { AxiosResponse } from "axios";
+import fetchAdapter from "../axios-fetch-adapter.js";
+
+const mockFetchForOpenAIStream = async ({
+  chunks,
+  status,
+  contentType,
+}: {
+  chunks: Array<string>;
+  status: number;
+  contentType: string;
+}) => {
+  // Mock stream response chunks.
+  const stream = new ReadableStream({
+    async start(controller) {
+      chunks.forEach((chunk) => {
+        controller.enqueue(new TextEncoder().encode(chunk));
+      });
+      controller.close();
+    },
+  });
+
+  // Mock Fetch API call.
+  jest.spyOn(global, "fetch").mockImplementation(
+    async () =>
+      new Response(stream, {
+        status,
+        headers: {
+          "Content-Type": contentType,
+        },
+      })
+  );
+
+  let error: Error | null = null;
+  const receivedChunks: Array<string> = [];
+  const resp = await fetchAdapter({
+    url: "https://example.com",
+    method: "POST",
+    responseType: "stream",
+    onmessage: (strChunk: { data: string }) => {
+      receivedChunks.push(
+        JSON.parse(strChunk.data).choices[0].delta.content ?? ""
+      );
+    },
+  } as unknown as never).catch((err) => {
+    error = err;
+    return null;
+  });
+
+  return { resp, receivedChunks, error } as {
+    resp: AxiosResponse | null;
+    receivedChunks: Array<string>;
+    error: Error | null;
+  };
+};
+
+describe("OpenAI Stream Tests", () => {
+  it("should return a 200 response chunk by chunk", async () => {
+    // When stream mode enabled, OpenAI responds with a stream of `data: {...}\n\n` chunks.
+    const { resp, receivedChunks, error } = await mockFetchForOpenAIStream({
+      status: 200,
+      contentType: "text/event-stream",
+      chunks: [
+        'data: {"choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"Hello"},"index":0,"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"delta":{"content":" World"},"index":0,"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"!"},"index":0,"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}\n\n',
+      ],
+    });
+
+    expect(error).toEqual(null);
+    expect(resp?.status).toEqual(200);
+    expect(receivedChunks).toEqual(["", "Hello", " World", "!", ""]);
+  });
+
+  it("should handle OpenAI 400 json error", async () => {
+    // OpenAI returns errors with application/json content type.
+    // Even if stream mode is enabled, the error is returned as a normal JSON body.
+    // Error information is in the `error` field.
+    const { resp, receivedChunks, error } = await mockFetchForOpenAIStream({
+      status: 400,
+      contentType: "application/json",
+      chunks: [
+        JSON.stringify({
+          error: {},
+        }),
+      ],
+    });
+
+    expect(error).toEqual(null);
+    expect(resp?.status).toEqual(400);
+    expect(resp?.data).toEqual({ error: {} });
+    expect(receivedChunks).toEqual([]);
+  });
+
+  it("should handle 500 non-json error", async () => {
+    const { resp, receivedChunks, error } = await mockFetchForOpenAIStream({
+      status: 500,
+      contentType: "text/plain",
+      chunks: ["Some error message..."],
+    });
+    expect(error).toEqual(null);
+    expect(resp?.status).toEqual(500);
+    expect(resp?.data).toEqual("Some error message...");
+    expect(receivedChunks).toEqual([]);
+  });
+
+  it("should throw on 500 non-json body with json content type", async () => {
+    const { resp, receivedChunks, error } = await mockFetchForOpenAIStream({
+      status: 500,
+      contentType: "application/json",
+      chunks: ["a non-json error body"],
+    });
+    expect(resp).toEqual(null);
+    expect(error?.message).toContain("Unexpected token");
+    expect(receivedChunks).toEqual([]);
+  });
+
+  it("should throw the generic error if non-stream content is detected", async () => {
+    const { resp, receivedChunks, error } = await mockFetchForOpenAIStream({
+      status: 200,
+      contentType: "text/plain",
+      chunks: ["a non-stream body"],
+    });
+    expect(resp).toEqual(null);
+    expect(error?.message).toBe(
+      "Expected content-type to be text/event-stream, Actual: text/plain"
+    );
+    expect(receivedChunks).toEqual([]);
+  });
+});


### PR DESCRIPTION
OpenAI returns `application/json` content-type for errors even when expecting a stream in cases like token limit error or other openai related errors. Right now, `axios-fetch-adapter.js:getResponse` only throws a very generic error message, making it impossible to understand what the actual problem is.

```js
        // This is very generic and makes it impossible to understand the real error.
        throw new Error(
          `Expected content-type to be ${EventStreamContentType}, Actual: ${contentType}`
        );
```

My fix gets the json body and if there is a proper Error object found inside, throws the real error, making it possible to debug or notify users in such cases.

This issue also seems to be about the same problem: #670