### PR TITLE
Making sure that the SQL command is properly displayed in the logs

### DIFF
--- a/langchain/src/chains/sql_db/sql_db_chain.ts
+++ b/langchain/src/chains/sql_db/sql_db_chain.ts
@@ -96,7 +96,7 @@ export class SqlDatabaseChain extends BaseChain {
     if (this.returnDirect) {
       finalResult = { [this.outputKey]: queryResult };
     } else {
-      inputText += `${+sqlCommand}\nSQLResult: ${JSON.stringify(
+      inputText += `${sqlCommand}\nSQLResult: ${JSON.stringify(
         queryResult
       )}\nAnswer:`;
       llmInputs.input = inputText;


### PR DESCRIPTION
This change allows for the information related to `sqlCommand` to be displayed correctly in the logs.

At first, I thought this was a bug in my prompt/code because I was seeing the following output:
```
SQLQuery:NaN
SQLResult: [{"COUNT(*)":0}]
Answer:
```

With the new code this should now display the actual Command the LLM is suggesting. 