### PR TITLE
Add token count estimation to OpenAIChat LLM instance, to ensure parity w/ OpenAI LLM instance.

### DIFF
--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -1,3 +1,4 @@
+import { TiktokenModel } from "@dqbd/tiktoken";
 import {
   Configuration,
   OpenAIApi,
@@ -247,7 +248,7 @@ export class OpenAIChat extends LLM implements OpenAIChatInput {
       params.max_tokens = await calculateMaxTokens({
         prompt: promptAndPrefixes,
         // Cast here to allow for other models that may not fit the union
-        modelName: this.modelName,
+        modelName: this.modelName as TiktokenModel,
       });
   }
     const data = params.stream

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -238,7 +238,7 @@ export class OpenAIChat extends LLM implements OpenAIChatInput {
     params.stop = stop ?? params.stop;
 
     if (params.max_tokens === -1) {
-      // Include prefixes in the token count, as this will be enforced 
+      // Include prefixes in the token count, as this will be enforced
       // (if prefixes exist) by the OpenAI API token limits:
       // https://platform.openai.com/docs/api-reference/completions/create#max_tokens
       // Dump this all into one big blob of text with `.strigify` to
@@ -250,7 +250,7 @@ export class OpenAIChat extends LLM implements OpenAIChatInput {
         // Cast here to allow for other models that may not fit the union
         modelName: this.modelName as TiktokenModel,
       });
-  }
+    }
     const data = params.stream
       ? await new Promise<CreateChatCompletionResponse>((resolve, reject) => {
           let response: CreateChatCompletionResponse;


### PR DESCRIPTION
This issue was noticed during the process of working on https://github.com/ArtBlocks/artbot/pull/503, and has been verified by locally patching my local `/node_modules` with the fix.

Please see https://discord.com/channels/1038097195422978059/1076182741374214285/1101594063876149268 for additional context (in the Langchain Discord). 

---

I am @purphat on twitter if you want to give credit (I saw a note about this in the contributing guidelines) 💜 