### PR TITLE
Add new output parser CustomListOutputParser that allows for more specificity

### DIFF
--- a/docs/docs/modules/prompts/output_parsers/index.mdx
+++ b/docs/docs/modules/prompts/output_parsers/index.mdx
@@ -50,11 +50,19 @@ import Fix from "@examples/prompts/fix_parser.ts";
 
 ## Comma-separated List Parser
 
-This output parser can be used when you want to return a list of items.
+This output parser can be used when you want to return a list of comma-separated items.
 
 import Comma from "@examples/prompts/comma_list_parser.ts";
 
 <CodeBlock language="typescript">{Comma}</CodeBlock>
+
+## Custom List Parser
+
+This output parser can be used when you want to return a list of items, with a specific length and separator.
+
+import CustomList from "@examples/prompts/custom_list_parser.ts";
+
+<CodeBlock language="typescript">{CustomList}</CodeBlock>
 
 ## Combining Output Parsers
 

--- a/examples/src/prompts/custom_list_parser.ts
+++ b/examples/src/prompts/custom_list_parser.ts
@@ -1,0 +1,46 @@
+import { OpenAI } from "langchain/llms/openai";
+import { PromptTemplate } from "langchain/prompts";
+import { CustomListOutputParser } from "langchain/output_parsers";
+
+export const run = async () => {
+  // With a `CustomListOutputParser`, we can parse a list with a specific length and separator.
+  const parser = new CustomListOutputParser({ length: 3, separator: "\n" });
+
+  const formatInstructions = parser.getFormatInstructions();
+
+  const prompt = new PromptTemplate({
+    template: "Provide a list of {subject}.\n{format_instructions}",
+    inputVariables: ["subject"],
+    partialVariables: { format_instructions: formatInstructions },
+  });
+
+  const model = new OpenAI({ temperature: 0 });
+
+  const input = await prompt.format({
+    subject: "great fiction books (book, author)",
+  });
+
+  const response = await model.call(input);
+
+  console.log(input);
+  /*
+  Provide a list of great fiction books (book, author).
+  Your response should be a list of 3 items separated by "\n" (eg: `foo\n bar\n baz`)
+  */
+
+  console.log(response);
+  /*
+  The Catcher in the Rye, J.D. Salinger
+  To Kill a Mockingbird, Harper Lee
+  The Great Gatsby, F. Scott Fitzgerald
+  */
+
+  console.log(await parser.parse(response));
+  /*
+  [
+    'The Catcher in the Rye, J.D. Salinger',
+    'To Kill a Mockingbird, Harper Lee',
+    'The Great Gatsby, F. Scott Fitzgerald'
+  ]
+  */
+};

--- a/langchain/src/output_parsers/index.ts
+++ b/langchain/src/output_parsers/index.ts
@@ -3,3 +3,4 @@ export { RegexParser } from "./regex.js";
 export { StructuredOutputParser } from "./structured.js";
 export { OutputFixingParser } from "./fix.js";
 export { CombiningOutputParser } from "./combining.js";
+export { CustomListOutputParser } from "./list.js";

--- a/langchain/src/output_parsers/list.ts
+++ b/langchain/src/output_parsers/list.ts
@@ -29,3 +29,43 @@ export class CommaSeparatedListOutputParser extends ListOutputParser {
     return `Your response should be a list of comma separated values, eg: \`foo, bar, baz\``;
   }
 }
+
+/**
+ * Class to parse the output of an LLM call to a list with a specific length and separator.
+ * @augments ListOutputParser
+ */
+export class CustomListOutputParser extends ListOutputParser {
+  private length: number | undefined;
+
+  private separator: string;
+
+  constructor({ length, separator }: { length?: number; separator?: string }) {
+    super();
+    this.length = length;
+    this.separator = separator || ",";
+  }
+
+  async parse(text: string): Promise<string[]> {
+    try {
+      const items = text
+        .trim()
+        .split(this.separator)
+        .map((s) => s.trim());
+      if (this.length !== undefined && items.length !== this.length) {
+        throw new OutputParserException(
+          `Incorrect number of items. Expected ${this.length}, got ${items.length}.`
+        );
+      }
+      return items;
+    } catch (e) {
+      if (Object.getPrototypeOf(e) === OutputParserException.prototype) {
+        throw e;
+      }
+      throw new OutputParserException(`Could not parse output: ${text}`);
+    }
+  }
+
+  getFormatInstructions(): string {
+    return `Your response should be a list of ${this.length} items separated by "${this.separator}" (eg: \`foo${this.separator} bar${this.separator} baz\`)`;
+  }
+}

--- a/langchain/src/output_parsers/tests/list.test.ts
+++ b/langchain/src/output_parsers/tests/list.test.ts
@@ -1,6 +1,11 @@
 import { test, expect } from "@jest/globals";
 
-import { CommaSeparatedListOutputParser } from "../list.js";
+import {
+  CommaSeparatedListOutputParser,
+  CustomListOutputParser,
+} from "../list.js";
+
+import { OutputParserException } from "../../schema/output_parser.js";
 
 test("CommaSeparatedListOutputParser", async () => {
   const parser = new CommaSeparatedListOutputParser();
@@ -10,4 +15,34 @@ test("CommaSeparatedListOutputParser", async () => {
   expect(await parser.parse("hello,bye")).toEqual(["hello", "bye"]);
 
   expect(await parser.parse("hello")).toEqual(["hello"]);
+});
+
+test("CustomListOutputParser", async () => {
+  const parser1 = new CustomListOutputParser({ length: 3, separator: ";" });
+
+  expect(await parser1.parse("a; b;c")).toEqual(["a", "b", "c"]);
+
+  // without try/catch, the test will fail
+  try {
+    expect(await parser1.parse("a; b c")).toThrow(OutputParserException);
+  } catch (e) {
+    expect(e).toBeInstanceOf(OutputParserException);
+  }
+
+  const parser2 = new CustomListOutputParser({ separator: "\n" });
+
+  expect(await parser2.parse("a\nb\nc\nd")).toEqual(["a", "b", "c", "d"]);
+
+  const parser3 = new CustomListOutputParser({ length: 8 });
+
+  expect(await parser3.parse("a,b,c,d,e,f,g,h")).toEqual([
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+  ]);
 });


### PR DESCRIPTION
Unlike `CommaSeparatedListOutputParser`, this class allows you to chose your own separator, and also you to ensure a certain length to your list.

Making this PR cause I was having trouble with the comma-separated list, as my list items had commas in them.