### PR TITLE
Fixed import for TextLoader in example

### DIFF
--- a/docs/docs/modules/indexes/document_loaders/examples/file_loaders/text.md
+++ b/docs/docs/modules/indexes/document_loaders/examples/file_loaders/text.md
@@ -7,7 +7,7 @@ hide_table_of_contents: true
 This example goes over how to load data from text files.
 
 ```typescript
-import { TextLoader } from "langchain/document_loaders/fs/text";
+import { TextLoader } from "langchain/document_loaders";
 
 const loader = new TextLoader("src/document_loaders/example_data/example.txt");
 


### PR DESCRIPTION
import { TextLoader } from "langchain/document_loaders" was sufficient