### PR TITLE
Update broken docs links

### DIFF
--- a/docs/docs/modules/prompts/example_selectors/index.mdx
+++ b/docs/docs/modules/prompts/example_selectors/index.mdx
@@ -8,7 +8,7 @@ import CodeBlock from "@theme/CodeBlock";
 # Example Selectors
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/example-selectors)
+[Conceptual Guide](https://docs.langchain.com/docs/components/prompts/example-selectors)
 :::
 
 If you have a large number of examples, you may need to programmatically select which ones to include in the prompt. The ExampleSelector is the class responsible for doing so. The base interface is defined as below.

--- a/docs/docs/modules/prompts/output_parsers/index.mdx
+++ b/docs/docs/modules/prompts/output_parsers/index.mdx
@@ -8,7 +8,7 @@ import CodeBlock from "@theme/CodeBlock";
 # Output Parsers
 
 :::info
-[Conceptual Guide](https://docs.langchain.com/docs/components/output-parser)
+[Conceptual Guide](https://docs.langchain.com/docs/components/prompts/output-parser)
 :::
 
 Language models output text. But many times you may want to get more structured information than just text back. This is where output parsers come in.


### PR DESCRIPTION
While looking into writing docs for #1049, I noticed a few broken links in the `Prompts` section of the docs. I've fixed them here.