### PR TITLE
feat: Implement HyDE style document retriever

### DIFF
--- a/docs/docs/modules/indexes/retrievers/hyde.mdx
+++ b/docs/docs/modules/indexes/retrievers/hyde.mdx
@@ -1,0 +1,18 @@
+---
+hide_table_of_contents: true
+---
+
+# HyDE Retriever
+
+This example shows how to use the HyDE Retriever, which implements Hypothetical Document Embeddings (HyDE) as described in [this paper](https://arxiv.org/abs/2212.10496).
+
+At a high level, HyDE is an embedding technique that takes queries, generates a hypothetical answer, and then embeds that generated document and uses that as the final example.
+
+In order to use HyDE, we therefore need to provide a base embedding model, as well as an LLM that can be used to generate those documents. By default, the HyDE class comes with some default prompts to use (see the paper for more details on them), but we can also create our own, which should have a single input variable `{question}`.
+
+## Usage
+
+import CodeBlock from "@theme/CodeBlock";
+import Example from "@examples/retrievers/hyde.ts";
+
+<CodeBlock language="typescript">{Example}</CodeBlock>

--- a/examples/src/retrievers/hyde.ts
+++ b/examples/src/retrievers/hyde.ts
@@ -1,0 +1,34 @@
+import { OpenAI } from "langchain/llms/openai";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { MemoryVectorStore } from "langchain/vectorstores/memory";
+import { HydeRetriever } from "langchain/retrievers/hyde";
+import { Document } from "langchain/document";
+
+const embeddings = new OpenAIEmbeddings();
+const vectorStore = new MemoryVectorStore(embeddings);
+const llm = new OpenAI();
+const retriever = new HydeRetriever({
+  vectorStore,
+  llm,
+  k: 1,
+});
+
+await vectorStore.addDocuments(
+  [
+    "My name is John.",
+    "My name is Bob.",
+    "My favourite food is pizza.",
+    "My favourite food is pasta.",
+  ].map((pageContent) => new Document({ pageContent }))
+);
+
+const results = await retriever.getRelevantDocuments(
+  "What is my favourite food?"
+);
+
+console.log(results);
+/*
+[
+  Document { pageContent: 'My favourite food is pasta.', metadata: {} }
+]
+*/

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -229,6 +229,9 @@ retrievers/contextual_compression.d.ts
 retrievers/document_compressors.cjs
 retrievers/document_compressors.js
 retrievers/document_compressors.d.ts
+retrievers/hyde.cjs
+retrievers/hyde.js
+retrievers/hyde.d.ts
 cache.cjs
 cache.js
 cache.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -241,6 +241,9 @@
     "retrievers/document_compressors.cjs",
     "retrievers/document_compressors.js",
     "retrievers/document_compressors.d.ts",
+    "retrievers/hyde.cjs",
+    "retrievers/hyde.js",
+    "retrievers/hyde.d.ts",
     "cache.cjs",
     "cache.js",
     "cache.d.ts",
@@ -902,6 +905,11 @@
       "types": "./retrievers/document_compressors.d.ts",
       "import": "./retrievers/document_compressors.js",
       "require": "./retrievers/document_compressors.cjs"
+    },
+    "./retrievers/hyde": {
+      "types": "./retrievers/hyde.d.ts",
+      "import": "./retrievers/hyde.js",
+      "require": "./retrievers/hyde.cjs"
     },
     "./cache": {
       "types": "./cache.d.ts",

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -104,6 +104,7 @@ const entrypoints = {
   "retrievers/databerry": "retrievers/databerry",
   "retrievers/contextual_compression": "retrievers/contextual_compression",
   "retrievers/document_compressors": "retrievers/document_compressors/index",
+  "retrievers/hyde": "retrievers/hyde",
   // cache
   cache: "cache/index",
   "cache/redis": "cache/redis",

--- a/langchain/src/prompts/base.ts
+++ b/langchain/src/prompts/base.ts
@@ -8,10 +8,11 @@ import {
 import { BaseOutputParser } from "../schema/output_parser.js";
 import { SerializedBasePromptTemplate } from "./serde.js";
 
-export class StringPromptValue {
+export class StringPromptValue extends BasePromptValue {
   value: string;
 
   constructor(value: string) {
+    super();
     this.value = value;
   }
 

--- a/langchain/src/retrievers/hyde.ts
+++ b/langchain/src/retrievers/hyde.ts
@@ -1,0 +1,46 @@
+import { Document } from "document.js";
+import { PromptTemplate } from "index.js";
+import { LLM } from "llms/base.js";
+import { VectorStore, VectorStoreRetriever } from "vectorstores/base.js";
+
+interface HydeRetrieverOptions {
+  llm: LLM;
+  promptTemplate?: PromptTemplate;
+  vectorStore: VectorStore;
+  k?: number;
+  filter?: VectorStore["FilterType"];
+}
+
+export class HydeRetriever extends VectorStoreRetriever {
+  llm: LLM;
+  promptTemplate?: PromptTemplate;
+
+  constructor(fields: HydeRetrieverOptions) {
+    super({
+      vectorStore: fields.vectorStore,
+      k: fields.k,
+      filter: fields.filter,
+    });
+    this.llm = fields.llm;
+    this.promptTemplate = fields.promptTemplate;
+  }
+
+  async getRelevantDocuments(query: string): Promise<Document[]> {
+    // Use a custom template if provided
+    if (this.promptTemplate) {
+      query = await this.promptTemplate.format({ question: query });
+    }
+
+    // Get a hypothetical answer from the LLM
+    const res = await this.llm.call(query);
+
+    // Retrieve relevant documents based on the hypothetical answer
+    const results = await this.vectorStore.similaritySearch(
+      res,
+      this.k,
+      this.filter
+    );
+
+    return results;
+  }
+}

--- a/langchain/src/retrievers/hyde.ts
+++ b/langchain/src/retrievers/hyde.ts
@@ -1,5 +1,6 @@
 import { Document } from "../document.js";
 import { BasePromptTemplate, StringPromptValue } from "../prompts/base.js";
+import { PromptTemplate } from "../prompts/prompt.js";
 import {
   VectorStore,
   VectorStoreRetriever,
@@ -8,10 +9,20 @@ import {
 import { BaseLanguageModel } from "../base_language/index.js";
 import { BasePromptValue } from "../schema/index.js";
 
-interface HydeRetrieverOptions<V extends VectorStore>
+export type PromptKey =
+  | "websearch"
+  | "scifact"
+  | "arguana"
+  | "trec-covid"
+  | "fiqa"
+  | "dbpedia-entity"
+  | "trec-news"
+  | "mr-tydi";
+
+export interface HydeRetrieverOptions<V extends VectorStore>
   extends VectorStoreRetrieverInput<V> {
   llm: BaseLanguageModel;
-  promptTemplate?: BasePromptTemplate;
+  promptTemplate?: BasePromptTemplate | PromptKey;
 }
 
 export class HydeRetriever<
@@ -24,7 +35,18 @@ export class HydeRetriever<
   constructor(fields: HydeRetrieverOptions<V>) {
     super(fields);
     this.llm = fields.llm;
-    this.promptTemplate = fields.promptTemplate;
+    this.promptTemplate =
+      typeof fields.promptTemplate === "string"
+        ? getPromptTemplateFromKey(fields.promptTemplate)
+        : fields.promptTemplate;
+    if (this.promptTemplate) {
+      const { inputVariables } = this.promptTemplate;
+      if (inputVariables.length !== 1 && inputVariables[0] !== "question") {
+        throw new Error(
+          `Prompt template must accept a single input variable 'question'. Invalid input variables for prompt template: ${inputVariables}`
+        );
+      }
+    }
   }
 
   async getRelevantDocuments(query: string): Promise<Document[]> {
@@ -48,4 +70,55 @@ export class HydeRetriever<
 
     return results;
   }
+}
+
+export function getPromptTemplateFromKey(key: PromptKey): BasePromptTemplate {
+  let template: string;
+
+  switch (key) {
+    case "websearch":
+      template = `Please write a passage to answer the question 
+Question: {question}
+Passage:`;
+      break;
+    case "scifact":
+      template = `Please write a scientific paper passage to support/refute the claim 
+Claim: {question}
+Passage:`;
+      break;
+    case "arguana":
+      template = `Please write a counter argument for the passage 
+Passage: {question}
+Counter Argument:`;
+      break;
+    case "trec-covid":
+      template = `Please write a scientific paper passage to answer the question
+Question: {question}
+Passage:`;
+      break;
+    case "fiqa":
+      template = `Please write a financial article passage to answer the question
+Question: {question}
+Passage:`;
+      break;
+    case "dbpedia-entity":
+      template = `Please write a passage to answer the question.
+Question: {question}
+Passage:`;
+      break;
+    case "trec-news":
+      template = `Please write a news passage about the topic.
+Topic: {question}
+Passage:`;
+      break;
+    case "mr-tydi":
+      template = `Please write a passage in Swahili/Korean/Japanese/Bengali to answer the question in detail.
+Question: {question}
+Passage:`;
+      break;
+    default:
+      throw new Error(`Invalid prompt key: ${key}`);
+  }
+
+  return PromptTemplate.fromTemplate(template);
 }

--- a/langchain/src/retrievers/tests/hyde.int.test.ts
+++ b/langchain/src/retrievers/tests/hyde.int.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@jest/globals";
+import { HydeRetriever } from "../hyde.js";
+import { OpenAIEmbeddings } from "../../embeddings/openai.js";
+import { OpenAI } from "../../llms/openai.js";
+import { MemoryVectorStore } from "../../vectorstores/memory.js";
+import { Document } from "../../document.js";
+
+test("Hyde retriever", async () => {
+  const embeddings = new OpenAIEmbeddings();
+  const vectorStore = new MemoryVectorStore(embeddings);
+  const llm = new OpenAI();
+  const retriever = new HydeRetriever({
+    vectorStore,
+    llm,
+    k: 1,
+  });
+
+  await vectorStore.addDocuments(
+    [
+      "My name is John.",
+      "My name is Bob.",
+      "My favourite food is pizza.",
+      "My favourite food is pasta.",
+    ].map((pageContent) => new Document({ pageContent }))
+  );
+
+  const results = await retriever.getRelevantDocuments(
+    "What is my favourite food?"
+  );
+
+  expect(results.length).toBe(1);
+  console.log(results);
+});

--- a/langchain/src/retrievers/tests/hyde.int.test.ts
+++ b/langchain/src/retrievers/tests/hyde.int.test.ts
@@ -31,3 +31,31 @@ test("Hyde retriever", async () => {
   expect(results.length).toBe(1);
   console.log(results);
 });
+
+test("Hyde retriever with default prompt template", async () => {
+  const embeddings = new OpenAIEmbeddings();
+  const vectorStore = new MemoryVectorStore(embeddings);
+  const llm = new OpenAI();
+  const retriever = new HydeRetriever({
+    vectorStore,
+    llm,
+    k: 1,
+    promptTemplate: "websearch",
+  });
+
+  await vectorStore.addDocuments(
+    [
+      "My name is John.",
+      "My name is Bob.",
+      "My favourite food is pizza.",
+      "My favourite food is pasta.",
+    ].map((pageContent) => new Document({ pageContent }))
+  );
+
+  const results = await retriever.getRelevantDocuments(
+    "What is my favourite food?"
+  );
+
+  expect(results.length).toBe(1);
+  console.log(results);
+});

--- a/langchain/src/vectorstores/base.ts
+++ b/langchain/src/vectorstores/base.ts
@@ -2,6 +2,12 @@ import { Embeddings } from "../embeddings/base.js";
 import { Document } from "../document.js";
 import { BaseRetriever } from "../schema/index.js";
 
+export interface VectorStoreRetrieverInput<V extends VectorStore> {
+  vectorStore: V;
+  k?: number;
+  filter?: V["FilterType"];
+}
+
 export class VectorStoreRetriever<
   V extends VectorStore = VectorStore
 > extends BaseRetriever {
@@ -11,11 +17,7 @@ export class VectorStoreRetriever<
 
   filter?: V["FilterType"];
 
-  constructor(fields: {
-    vectorStore: V;
-    k?: number;
-    filter?: V["FilterType"];
-  }) {
+  constructor(fields: VectorStoreRetrieverInput<V>) {
     super();
     this.vectorStore = fields.vectorStore;
     this.k = fields.k ?? this.k;

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -105,6 +105,7 @@
       "src/retrievers/databerry.ts",
       "src/retrievers/contextual_compression.ts",
       "src/retrievers/document_compressors/index.ts",
+      "src/retrievers/hyde.ts",
       "src/cache/index.ts",
       "src/cache/redis.ts",
       "src/stores/file/in_memory.ts",

--- a/test-exports-cf/src/entrypoints.js
+++ b/test-exports-cf/src/entrypoints.js
@@ -26,6 +26,7 @@ export * from "langchain/retrievers/remote";
 export * from "langchain/retrievers/databerry";
 export * from "langchain/retrievers/contextual_compression";
 export * from "langchain/retrievers/document_compressors";
+export * from "langchain/retrievers/hyde";
 export * from "langchain/cache";
 export * from "langchain/stores/file/in_memory";
 export * from "langchain/experimental/autogpt";

--- a/test-exports-cjs/src/entrypoints.js
+++ b/test-exports-cjs/src/entrypoints.js
@@ -26,6 +26,7 @@ const retrievers_remote = require("langchain/retrievers/remote");
 const retrievers_databerry = require("langchain/retrievers/databerry");
 const retrievers_contextual_compression = require("langchain/retrievers/contextual_compression");
 const retrievers_document_compressors = require("langchain/retrievers/document_compressors");
+const retrievers_hyde = require("langchain/retrievers/hyde");
 const cache = require("langchain/cache");
 const stores_file_in_memory = require("langchain/stores/file/in_memory");
 const experimental_autogpt = require("langchain/experimental/autogpt");

--- a/test-exports-cra/src/entrypoints.js
+++ b/test-exports-cra/src/entrypoints.js
@@ -26,6 +26,7 @@ export * from "langchain/retrievers/remote";
 export * from "langchain/retrievers/databerry";
 export * from "langchain/retrievers/contextual_compression";
 export * from "langchain/retrievers/document_compressors";
+export * from "langchain/retrievers/hyde";
 export * from "langchain/cache";
 export * from "langchain/stores/file/in_memory";
 export * from "langchain/experimental/autogpt";

--- a/test-exports-esm/src/entrypoints.js
+++ b/test-exports-esm/src/entrypoints.js
@@ -26,6 +26,7 @@ import * as retrievers_remote from "langchain/retrievers/remote";
 import * as retrievers_databerry from "langchain/retrievers/databerry";
 import * as retrievers_contextual_compression from "langchain/retrievers/contextual_compression";
 import * as retrievers_document_compressors from "langchain/retrievers/document_compressors";
+import * as retrievers_hyde from "langchain/retrievers/hyde";
 import * as cache from "langchain/cache";
 import * as stores_file_in_memory from "langchain/stores/file/in_memory";
 import * as experimental_autogpt from "langchain/experimental/autogpt";

--- a/test-exports-vercel/src/entrypoints.js
+++ b/test-exports-vercel/src/entrypoints.js
@@ -26,6 +26,7 @@ export * from "langchain/retrievers/remote";
 export * from "langchain/retrievers/databerry";
 export * from "langchain/retrievers/contextual_compression";
 export * from "langchain/retrievers/document_compressors";
+export * from "langchain/retrievers/hyde";
 export * from "langchain/cache";
 export * from "langchain/stores/file/in_memory";
 export * from "langchain/experimental/autogpt";

--- a/test-exports-vite/src/entrypoints.js
+++ b/test-exports-vite/src/entrypoints.js
@@ -26,6 +26,7 @@ export * from "langchain/retrievers/remote";
 export * from "langchain/retrievers/databerry";
 export * from "langchain/retrievers/contextual_compression";
 export * from "langchain/retrievers/document_compressors";
+export * from "langchain/retrievers/hyde";
 export * from "langchain/cache";
 export * from "langchain/stores/file/in_memory";
 export * from "langchain/experimental/autogpt";


### PR DESCRIPTION
This adds the ability to retrieve documents from a vector store using the HyDE method as described [here](https://wfhbrian.com/revolutionizing-search-how-hypothetical-document-embeddings-hyde-can-save-time-and-increase-productivity/) 

"The HyDE method is a way to find information in a large set of documents using artificial intelligence. It starts by having a Large Language Model (LLM), like ChatGPT, create a document based on a specific question or topic. This document may contain some false information, but it also has relevant patterns that can be used to find similar documents in a trusted knowledge base.

Next, another AI model is used to turn the created document into an embedding vector, which is then used to find other documents similar to the one the AI model created."