### PR TITLE
Add `refine` type for summarization chain

### DIFF
--- a/docs/docs/modules/chains/other_chains/summarization.mdx
+++ b/docs/docs/modules/chains/other_chains/summarization.mdx
@@ -3,6 +3,6 @@ import SummarizeExample from "@examples/chains/summarization_map_reduce.ts";
 
 # Summarization
 
-A summarization chain can be used to summarize multiple documents. One way is to input multiple smaller documents, after they have been divided into chunks, and operate over them with a `MapReduceDocumentsChain`.
+A summarization chain can be used to summarize multiple documents. One way is to input multiple smaller documents, after they have been divided into chunks, and operate over them with a `MapReduceDocumentsChain`. You can also choose instead for the chain that does summarization to be a StuffDocumentsChain, or a RefineDocumentsChain. See more about the differences between them [here](../index_related_chains/document_qa)
 
 <CodeBlock language="typescript">{SummarizeExample}</CodeBlock>

--- a/langchain/src/chains/index.ts
+++ b/langchain/src/chains/index.ts
@@ -30,7 +30,10 @@ export {
   loadQAMapReduceChain,
   loadQARefineChain,
 } from "./question_answering/load.js";
-export { loadSummarizationChain } from "./summarization/load.js";
+export {
+  loadSummarizationChain,
+  SummarizationChainParams,
+} from "./summarization/load.js";
 export {
   SqlDatabaseChain,
   SqlDatabaseChainInput,

--- a/langchain/src/chains/summarization/load.ts
+++ b/langchain/src/chains/summarization/load.ts
@@ -4,14 +4,18 @@ import { BasePromptTemplate } from "../../prompts/base.js";
 import {
   StuffDocumentsChain,
   MapReduceDocumentsChain,
+  RefineDocumentsChain,
 } from "../combine_docs_chain.js";
 import { DEFAULT_PROMPT } from "./stuff_prompts.js";
+import { REFINE_PROMPT } from "./refine_prompts.js";
 
 interface summarizationChainParams {
   prompt?: BasePromptTemplate;
   combineMapPrompt?: BasePromptTemplate;
   combinePrompt?: BasePromptTemplate;
-  type?: "map_reduce" | "stuff";
+  refinePrompt?: BasePromptTemplate;
+  questionPrompt?: BasePromptTemplate;
+  type?: "map_reduce" | "stuff" | "refine";
 }
 export const loadSummarizationChain = (
   llm: BaseLanguageModel,
@@ -21,6 +25,8 @@ export const loadSummarizationChain = (
     prompt = DEFAULT_PROMPT,
     combineMapPrompt = DEFAULT_PROMPT,
     combinePrompt = DEFAULT_PROMPT,
+    refinePrompt = REFINE_PROMPT,
+    questionPrompt = DEFAULT_PROMPT,
     type = "map_reduce",
   } = params;
   if (type === "stuff") {
@@ -41,6 +47,16 @@ export const loadSummarizationChain = (
     const chain = new MapReduceDocumentsChain({
       llmChain,
       combineDocumentChain,
+      documentVariableName: "text",
+    });
+    return chain;
+  }
+  if (type === "refine") {
+    const llmChain = new LLMChain({ prompt: questionPrompt, llm });
+    const refineLLMChain = new LLMChain({ prompt: refinePrompt, llm });
+    const chain = new RefineDocumentsChain({
+      llmChain,
+      refineLLMChain,
       documentVariableName: "text",
     });
     return chain;

--- a/langchain/src/chains/summarization/refine_prompts.ts
+++ b/langchain/src/chains/summarization/refine_prompts.ts
@@ -1,0 +1,19 @@
+import { PromptTemplate } from "../../prompts/prompt.js";
+
+const refinePromptTemplate = `Your job is to produce a final summary
+We have provided an existing summary up to a certain point: "{existing_answer}"
+We have the opportunity to refine the existing summary
+(only if needed) with some more context below.
+------------
+"{text}"
+------------
+
+Given the new context, refine the original summary
+If the context isn't useful, return the original summary.
+
+REFINED SUMMARY:`;
+
+export const REFINE_PROMPT = /* #__PURE__ */ new PromptTemplate({
+  template: refinePromptTemplate,
+  inputVariables: ["existing_answer", "text"],
+});

--- a/langchain/src/chains/summarization/tests/load.int.test.ts
+++ b/langchain/src/chains/summarization/tests/load.int.test.ts
@@ -3,9 +3,9 @@ import { OpenAI } from "../../../llms/openai.js";
 import { loadSummarizationChain } from "../load.js";
 import { Document } from "../../../document.js";
 
-test("Test loadSummzationChain", async () => {
+test("Test loadSummzationChain stuff", async () => {
   const model = new OpenAI({ modelName: "text-ada-001" });
-  const chain = loadSummarizationChain(model);
+  const chain = loadSummarizationChain(model, { type: "stuff" });
   const docs = [
     new Document({ pageContent: "foo" }),
     new Document({ pageContent: "bar" }),
@@ -18,6 +18,18 @@ test("Test loadSummzationChain", async () => {
 test("Test loadSummarizationChain map_reduce", async () => {
   const model = new OpenAI({ modelName: "text-ada-001" });
   const chain = loadSummarizationChain(model, { type: "map_reduce" });
+  const docs = [
+    new Document({ pageContent: "foo" }),
+    new Document({ pageContent: "bar" }),
+    new Document({ pageContent: "baz" }),
+  ];
+  const res = await chain.call({ input_documents: docs, question: "Whats up" });
+  console.log({ res });
+});
+
+test("Test loadSummarizationChain refine", async () => {
+  const model = new OpenAI({ modelName: "text-ada-001" });
+  const chain = loadSummarizationChain(model, { type: "refine" });
   const docs = [
     new Document({ pageContent: "foo" }),
     new Document({ pageContent: "bar" }),


### PR DESCRIPTION
Adds refine type for summarization chain based on https://github.com/hwchase17/langchain/blob/d7e17fc8fefb347affd9d1ae6db4764b9685537a/langchain/chains/summarize/__init__.py#L88