### PR TITLE
feat: OutputParserException store offending text

### DIFF
--- a/langchain/src/output_parsers/list.ts
+++ b/langchain/src/output_parsers/list.ts
@@ -21,7 +21,7 @@ export class CommaSeparatedListOutputParser extends ListOutputParser {
         .split(",")
         .map((s) => s.trim());
     } catch (e) {
-      throw new OutputParserException(`Could not parse output: ${text}`);
+      throw new OutputParserException(`Could not parse output: ${text}`, text);
     }
   }
 

--- a/langchain/src/output_parsers/regex.ts
+++ b/langchain/src/output_parsers/regex.ts
@@ -39,7 +39,7 @@ export class RegexParser extends BaseOutputParser<Record<string, string>> {
     }
 
     if (this.defaultOutputKey === undefined) {
-      throw new OutputParserException(`Could not parse output: ${text}`);
+      throw new OutputParserException(`Could not parse output: ${text}`, text);
     }
 
     return this.outputKeys.reduce((acc, key) => {

--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -52,7 +52,8 @@ ${JSON.stringify(zodToJsonSchema(this.schema))}
       return this.schema.parseAsync(JSON.parse(json));
     } catch (e) {
       throw new OutputParserException(
-        `Failed to parse. Text: "${text}". Error: ${e}`
+        `Failed to parse. Text: "${text}". Error: ${e}`,
+        text
       );
     }
   }

--- a/langchain/src/schema/output_parser.ts
+++ b/langchain/src/schema/output_parser.ts
@@ -41,7 +41,10 @@ export abstract class BaseOutputParser<T = unknown> {
 }
 
 export class OutputParserException extends Error {
-  constructor(message: string) {
+  output?: string;
+
+  constructor(message: string, output?: string) {
     super(message);
+    this.output = output;
   }
 }


### PR DESCRIPTION
I think it would be nice to recover the offending text in a catch block outside a chain. For instance sometimes if text can't parse it very well might still be usable and worth showing to the user.