### PR TITLE
add support of parsing multi-line text

### DIFF
--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -22,7 +22,9 @@ export class ZeroShotAgentOutputParser extends AgentActionOutputParser {
       };
     }
 
-    const match = /Action: ([\s\S]*?)(?:\nAction Input: ([\s\S]*?))?$/.exec(text);
+    const match = /Action: ([\s\S]*?)(?:\nAction Input: ([\s\S]*?))?$/.exec(
+      text
+    );
     if (!match) {
       throw new Error(`Could not parse LLM output: ${text}`);
     }

--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -22,7 +22,7 @@ export class ZeroShotAgentOutputParser extends AgentActionOutputParser {
       };
     }
 
-    const match = /Action: (.*)\nAction Input: (.*)/s.exec(text);
+    const match = /Action: (.*?)\nAction Input:\s*({[\s\S]*?})/.exec(text);
     if (!match) {
       throw new Error(`Could not parse LLM output: ${text}`);
     }

--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -22,7 +22,7 @@ export class ZeroShotAgentOutputParser extends AgentActionOutputParser {
       };
     }
 
-    const match = /Action: (.*?)\nAction Input:\s*({[\s\S]*?})/.exec(text);
+    const match = /Action: (.*?)\nAction Input:\s*(?:`)?\s*({[\s\S]*?})(?:`)?\s*/.exec(text);
     if (!match) {
       throw new Error(`Could not parse LLM output: ${text}`);
     }

--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -22,7 +22,7 @@ export class ZeroShotAgentOutputParser extends AgentActionOutputParser {
       };
     }
 
-    const match = /Action: (.*?)\nAction Input:\s*(?:`)?\s*({[\s\S]*?})(?:`)?\s*/.exec(text);
+    const match = /Action: ([\s\S]*?)(?:\nAction Input: ([\s\S]*?))?$/.exec(text);
     if (!match) {
       throw new Error(`Could not parse LLM output: ${text}`);
     }


### PR DESCRIPTION
for example, an image generator may need the following input. the current regex can not match multi line text.

<pre>I need to generate an image of the Mona Lisa in the style of traditional Chinese painting.
Action: image-generator
Action Input: 
{
  "Subject": "Mona Lisa",
  "Style": "Chinese traditional painting",
  "Color": "Mainly wash tones of ink, with small color blocks in some parts",
  "Details": "Mona Lisa should have long hair, a silk dress, holding a fan. The background should have mountains and trees.",
  "Emotion": "Serene and elegant"
}<pre>