### PR TITLE
Allow filter value in ".call" invocation for VectorDBQAChain

### DIFF
--- a/langchain/src/chains/tests/vector_db_qa_chain.int.test.ts
+++ b/langchain/src/chains/tests/vector_db_qa_chain.int.test.ts
@@ -7,6 +7,7 @@ import { StuffDocumentsChain } from "../combine_docs_chain.js";
 import { VectorDBQAChain } from "../vector_db_qa.js";
 import { HNSWLib } from "../../vectorstores/hnswlib.js";
 import { OpenAIEmbeddings } from "../../embeddings/openai.js";
+import { Document } from "../../document.js";
 
 test("Test VectorDBQAChain", async () => {
   const model = new OpenAI({ modelName: "text-ada-001" });
@@ -42,6 +43,23 @@ test("Test VectorDBQAChain from LLM", async () => {
   const chain = VectorDBQAChain.fromLLM(model, vectorStore);
   const res = await chain.call({ query: "What up" });
   console.log({ res });
+});
+
+test("Test VectorDBQAChain from LLM with a filter function", async () => {
+  const model = new OpenAI({ modelName: "text-ada-001" });
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new OpenAIEmbeddings()
+  );
+  const chain = VectorDBQAChain.fromLLM(model, vectorStore, {
+    returnSourceDocuments: true,
+  });
+  const res = await chain.call({
+    query: "What up",
+    filter: (document: Document) => document.metadata.id === 3,
+  });
+  console.log({ res, sourceDocuments: res.sourceDocuments });
 });
 
 test("Load chain from hub", async () => {

--- a/langchain/src/chains/vector_db_qa.ts
+++ b/langchain/src/chains/vector_db_qa.ts
@@ -57,8 +57,11 @@ export class VectorDBQAChain extends BaseChain implements VectorDBQAChainInput {
       throw new Error(`Question key ${this.inputKey} not found.`);
     }
     const question: string = values[this.inputKey];
-    const filter = values["filter"]
-    const docs = await this.vectorstore.similaritySearch(question, this.k, filter);
+    const docs = await this.vectorstore.similaritySearch(
+      question,
+      this.k,
+      values.filter
+    );
     const inputs = { question, input_documents: docs };
     const result = await this.combineDocumentsChain.call(
       inputs,


### PR DESCRIPTION
- extract "filter" key from ChainValues passed to ".call"
- pass filter value to "similaritySearch" call
- if user does not supply "filter" value it remains "undefined" as before
- if the shape of filter does not conform to value expected by VectorStore, error returns as expected