### PR TITLE
Added type to LLMChain to be used on predict

### DIFF
--- a/langchain/src/chains/llm_chain.ts
+++ b/langchain/src/chains/llm_chain.ts
@@ -7,13 +7,13 @@ import { SerializedLLMChain } from "./serde.js";
 import { CallbackManager } from "../callbacks/index.js";
 import { CallbackManagerForChainRun } from "../callbacks/manager.js";
 
-export interface LLMChainInput extends ChainInputs {
+export interface LLMChainInput<T> extends ChainInputs {
   /** Prompt object to use */
   prompt: BasePromptTemplate;
   /** LLM Wrapper to use */
   llm: BaseLanguageModel;
   /** OutputParser to use */
-  outputParser?: BaseOutputParser;
+  outputParser?: BaseOutputParser<T>;
   /** Key to use for output, defaults to `text` */
   outputKey?: string;
 }
@@ -33,7 +33,7 @@ export interface LLMChainInput extends ChainInputs {
  */
 export class LLMChain<T extends string | object = string>
   extends BaseChain
-  implements LLMChainInput
+  implements LLMChainInput<T>
 {
   prompt: BasePromptTemplate;
 
@@ -41,7 +41,7 @@ export class LLMChain<T extends string | object = string>
 
   outputKey = "text";
 
-  outputParser?: BaseOutputParser;
+  outputParser?: BaseOutputParser<T>;
 
   get inputKeys() {
     return this.prompt.inputVariables;
@@ -51,7 +51,7 @@ export class LLMChain<T extends string | object = string>
     return [this.outputKey];
   }
 
-  constructor(fields: LLMChainInput) {
+  constructor(fields: LLMChainInput<T>) {
     super(fields);
     this.prompt = fields.prompt;
     this.llm = fields.llm;
@@ -61,7 +61,7 @@ export class LLMChain<T extends string | object = string>
       if (this.outputParser) {
         throw new Error("Cannot set both outputParser and prompt.outputParser");
       }
-      this.outputParser = this.prompt.outputParser;
+      this.outputParser = this.prompt.outputParser as BaseOutputParser<T>;
     }
   }
 

--- a/langchain/src/chains/llm_chain.ts
+++ b/langchain/src/chains/llm_chain.ts
@@ -31,7 +31,10 @@ export interface LLMChainInput extends ChainInputs {
  * const llm = new LLMChain({ llm: new OpenAI(), prompt });
  * ```
  */
-export class LLMChain extends BaseChain implements LLMChainInput {
+export class LLMChain<T extends string | object = string>
+  extends BaseChain
+  implements LLMChainInput
+{
   prompt: BasePromptTemplate;
 
   llm: BaseLanguageModel;
@@ -121,7 +124,7 @@ export class LLMChain extends BaseChain implements LLMChainInput {
   async predict(
     values: ChainValues,
     callbackManager?: CallbackManager
-  ): Promise<string> {
+  ): Promise<T> {
     const output = await this.call(values, callbackManager);
     return output[this.outputKey];
   }

--- a/langchain/src/chains/llm_chain.ts
+++ b/langchain/src/chains/llm_chain.ts
@@ -7,7 +7,8 @@ import { SerializedLLMChain } from "./serde.js";
 import { CallbackManager } from "../callbacks/index.js";
 import { CallbackManagerForChainRun } from "../callbacks/manager.js";
 
-export interface LLMChainInput<T> extends ChainInputs {
+export interface LLMChainInput<T extends string | object = string>
+  extends ChainInputs {
   /** Prompt object to use */
   prompt: BasePromptTemplate;
   /** LLM Wrapper to use */


### PR DESCRIPTION
LLMChain predict can return string and object since we have structured output parser now.

- Extend LLMChain class with generic type T, defaulting to string
- Modify predict method to return Promise<T>
- Accommodate StructuredOutputParser to enable object return type