### PR TITLE
[ConversationalRetrievalQAChain] Fix wrong return type in Doc

### DIFF
--- a/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
+++ b/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
@@ -28,7 +28,7 @@ static fromLLM(
     qaTemplate?: string;
     returnSourceDocuments?: boolean;
   }
-): ChatVectorDBQAChain
+): ConversationalRetrievalQAChain
 ```
 
 Here's an explanation of each of the attributes of the options object:

--- a/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
+++ b/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
@@ -13,6 +13,7 @@ The `ConversationalRetrievalQA` chain builds on `RetrievalQAChain` to provide a 
 It requires two inputs: a question and the chat history. It first combines the chat history and the question into a standalone question, then looks up relevant documents from the retriever, and then passes those documents and the question to a question answering chain to return a response.
 
 To create one, you will need a retriever. In the below example, we will create one from a vectorstore, which can be created from embeddings.
+
 import Example from "@examples/chains/conversational_qa.ts";
 
 <CodeBlock language="typescript">{ConvoRetrievalQAExample}</CodeBlock>


### PR DESCRIPTION

In [ConversationalRetrievalQAChain](https://js.langchain.com/docs/modules/chains/index_related_chains/conversational_retrieval) doc, a return type in the example is still old.