### PR TITLE
Move tiktoken to devdeps

### DIFF
--- a/langchain/package.json
+++ b/langchain/package.json
@@ -316,6 +316,7 @@
     "@aws-sdk/client-lambda": "^3.310.0",
     "@aws-sdk/client-s3": "^3.310.0",
     "@clickhouse/client": "^0.0.14",
+    "@dqbd/tiktoken": "^1.0.7",
     "@faker-js/faker": "^7.6.0",
     "@getmetal/metal-sdk": "^2.0.1",
     "@huggingface/inference": "^1.5.1",
@@ -501,7 +502,6 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.4.3",
-    "@dqbd/tiktoken": "^1.0.7",
     "ansi-styles": "^5.0.0",
     "binary-extensions": "^2.2.0",
     "browser-or-node": "^2.1.1",

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -1,4 +1,4 @@
-import { TiktokenModel } from "@dqbd/tiktoken";
+import type { TiktokenModel } from "@dqbd/tiktoken";
 import { isNode } from "browser-or-node";
 import {
   Configuration,


### PR DESCRIPTION
It seemed unnecessary as a core dependency instead of a devdeps as most of the imports were converted to dynamic.

This should allow users to use their own version of tiktoken or dismiss it completely (Which reduces bundle sizes - but may be redundant with #847 which also does).