### PR TITLE
Fix typo in additional_functionality.mdx

### DIFF
--- a/docs/docs/modules/models/embeddings/additional_functionality.mdx
+++ b/docs/docs/modules/models/embeddings/additional_functionality.mdx
@@ -7,7 +7,7 @@ import TimeoutExample from "@examples/models/embeddings/openai_timeout.ts";
 
 # Additional Functionality: Embeddings
 
-We offer a number of additional features for chat models. In the examples below, we'll be using the `ChatOpenAI` model.
+We offer a number of additional features for chat models. In the examples below, we'll be using the `OpenAIEmbeddings` model.
 
 ## Adding a timeout
 


### PR DESCRIPTION
Typo where "ChatOpenAI" should be "OpenAIEmbeddings"