### PR TITLE
[Doc][QuickStart] Move steps forget to move

### DIFF
--- a/docs/docs/getting-started/guide-chat.mdx
+++ b/docs/docs/getting-started/guide-chat.mdx
@@ -297,6 +297,37 @@ const chain = new ConversationChain({
 });
 ```
 
+The chain will internally accumulate the messages sent to the model, and the ones received as output. Then it will inject the messages into the prompt on the next call. So you can call the chain a few times, and it remembers previous messages:
+
+```typescript
+const responseH = await chain.call({
+  input: "hi from London, how are you doing today",
+});
+
+console.log(responseH)
+```
+
+```
+{
+  response: "Hello! As an AI language model, I don't have feelings, but I'm functioning properly and ready to assist you with any questions or tasks you may have. How can I help you today?"
+}
+```
+
+```typescript
+const responseI = await chain.call({
+  input: "Do you know where I am?",
+});
+
+console.log(responseI);
+```
+
+```
+{
+  response: "Yes, you mentioned that you are from London. However, as an AI language model, I don't have access to your current location unless you provide me with that information."
+}
+```
+
+
 ## Streaming
 
 You can also use the streaming API to get words streamed back to you as they are generated. This is useful for eg. chatbots, where you want to show the user what is being generated as it is being generated. Note: OpenAI as of this writing does not support `tokenUsage` reporting while streaming is enabled.

--- a/docs/docs/getting-started/guide-chat.mdx
+++ b/docs/docs/getting-started/guide-chat.mdx
@@ -304,7 +304,7 @@ const responseH = await chain.call({
   input: "hi from London, how are you doing today",
 });
 
-console.log(responseH)
+console.log(responseH);
 ```
 
 ```

--- a/docs/docs/getting-started/guide-chat.mdx
+++ b/docs/docs/getting-started/guide-chat.mdx
@@ -196,34 +196,6 @@ console.log(responseB);
 { text: "J'aime programmer." }
 ```
 
-The chain will internally accumulate the messages sent to the model, and the ones received as output. Then it will inject the messages into the prompt on the next call. So you can call the chain a few times, and it remembers previous messages:
-
-```typescript
-const responseD = await chain.call({
-  input: "hi from London, how are you doing today",
-});
-```
-
-```
-{
-  response: "Hello! As an AI language model, I don't have feelings, but I'm functioning properly and ready to assist you with any questions or tasks you may have. How can I help you today?"
-}
-```
-
-```typescript
-const responseE = await chain.call({
-  input: "Do you know where I am?",
-});
-
-console.log(responseE);
-```
-
-```
-{
-  response: "Yes, you mentioned that you are from London. However, as an AI language model, I don't have access to your current location unless you provide me with that information."
-}
-```
-
 ### Agents: Dynamically Run Chains Based on User Input
 
 Finally, we introduce Tools and Agents, which extend the model with other abilities, such as search, or a calculator.

--- a/docs/docs/getting-started/guide-chat.mdx
+++ b/docs/docs/getting-started/guide-chat.mdx
@@ -327,7 +327,6 @@ console.log(responseI);
 }
 ```
 
-
 ## Streaming
 
 You can also use the streaming API to get words streamed back to you as they are generated. This is useful for eg. chatbots, where you want to show the user what is being generated as it is being generated. Note: OpenAI as of this writing does not support `tokenUsage` reporting while streaming is enabled.


### PR DESCRIPTION
## Background

In the past, [the quickstart tutorial](https://js.langchain.com/docs/getting-started/guide-chat#model--prompt--llmchain) has a step to explain `ConversationChain` https://github.com/hwchase17/langchainjs/commit/2b54606c0ff2f46704a3aef8f0ebb05f6e67d216

However, the PR above looks to have forgotten to move some explanations, so it causes confusion.
https://github.com/hwchase17/langchainjs/issues/1161

![スクリーンショット 2023-05-09 0 28 06](https://user-images.githubusercontent.com/3285355/236865466-3ae30d3c-f900-45c7-a398-37213a4d4829.png)



