### PR TITLE
Moved handleChainEnd to After Context Update

### DIFF
--- a/langchain/src/chains/base.ts
+++ b/langchain/src/chains/base.ts
@@ -125,10 +125,10 @@ export abstract class BaseChain extends BaseLangChain implements ChainInputs {
       await runManager?.handleChainError(e);
       throw e;
     }
-    await runManager?.handleChainEnd(outputValues);
     if (!(this.memory == null)) {
       await this.memory.saveContext(values, outputValues);
     }
+    await runManager?.handleChainEnd(outputValues);
     // add the runManager's currentRunId to the outputValues
     Object.defineProperty(outputValues, RUN_KEY, {
       value: runManager ? { runId: runManager?.runId } : undefined,


### PR DESCRIPTION
This change ensures that handleChainEnd is called after the context is updated, as @nfcampos mentioned it should be part of the chain run and should come after the context update in this [issue](https://github.com/hwchase17/langchainjs/issues/1158)