### PR TITLE
Add ability to pass in signal to the call via ChainValues

### DIFF
--- a/langchain/src/chains/llm_chain.ts
+++ b/langchain/src/chains/llm_chain.ts
@@ -98,7 +98,7 @@ export class LLMChain<T extends string | object = string>
     const promptValue = await this.prompt.formatPromptValue(values);
     const { generations } = await this.llm.generatePrompt(
       [promptValue],
-      stop,
+      stop || values["options"],
       runManager?.getChild()
     );
     return {


### PR DESCRIPTION
Should be able to call with `chain.call({ input: "Hi", options: { signal: abortController.signal }})`

@nfcampos not sure if this is how you want it implemented but this should pass through to the openai llm #1159 