### PR TITLE
Add LCP Client with CRD methods for datasets and examples

### DIFF
--- a/langchain/src/callbacks/handlers/tracers.ts
+++ b/langchain/src/callbacks/handlers/tracers.ts
@@ -99,6 +99,11 @@ export interface AgentRun extends Run {
   actions: AgentAction[];
 }
 
+export interface RunResult extends BaseRun {
+  name: string;
+  parent_run_id?: string; // uuid
+}
+
 export abstract class BaseTracer extends BaseCallbackHandler {
   protected session?: TracerSessionV1 | TracerSession;
 

--- a/langchain/src/client/langchainplus.ts
+++ b/langchain/src/client/langchainplus.ts
@@ -49,16 +49,10 @@ const getSeededTenantId = async (
   let response;
 
   try {
-    let requestInit: { [param: string]: string | object } = {
+    response = await fetch(url, {
       method: "GET",
-    };
-    if (apiKey) {
-      requestInit = {
-        ...requestInit,
-        headers: { authorization: `Bearer ${apiKey}` },
-      };
-    }
-    response = await fetch(url, requestInit);
+      headers: apiKey ? { authorization: `Bearer ${apiKey}` } : undefined,
+    });
   } catch (err) {
     throw new Error("Unable to get seeded tenant ID. Please manually provide.");
   }
@@ -87,7 +81,7 @@ export class LangChainPlusClient {
 
   private tenantId: string;
 
-  constructor(apiUrl: string, apiKey: string | undefined, tenantId: string) {
+  constructor(apiUrl: string, tenantId: string, apiKey?: string) {
     this.apiUrl = apiUrl;
     this.apiKey = apiKey;
     this.tenantId = tenantId;
@@ -103,17 +97,15 @@ export class LangChainPlusClient {
     if (!tenantId_) {
       tenantId_ = await getSeededTenantId(apiUrl, apiKey);
     }
-    return new LangChainPlusClient(apiUrl, apiKey, tenantId_);
+    return new LangChainPlusClient(apiUrl, tenantId_, apiKey);
   }
 
   private validateApiKeyIfHosted(): void {
     const isLocal = isLocalhost(this.apiUrl);
-    if (!isLocal) {
-      if (!this.apiKey) {
-        throw new Error(
-          "API key must be provided when using hosted LangChain+ API"
-        );
-      }
+    if (!isLocal && !this.apiKey) {
+      throw new Error(
+        "API key must be provided when using hosted LangChain+ API"
+      );
     }
   }
 

--- a/langchain/src/client/langchainplus.ts
+++ b/langchain/src/client/langchainplus.ts
@@ -1,0 +1,350 @@
+import { URL } from "url";
+import { RunResult } from "../callbacks/handlers/tracers.js";
+import { RunInputs, RunOutputs } from "../schema/index.js";
+
+export interface BaseDataset {
+  name: string;
+  description: string;
+  tenant_id: string;
+}
+
+export interface Dataset extends BaseDataset {
+  id: string;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface BaseExample {
+  dataset_id: string;
+  inputs: RunInputs;
+  outputs: RunOutputs;
+}
+
+export interface ExampleCreate extends BaseExample {
+  id?: string;
+  created_at: string;
+}
+
+export interface Example extends BaseExample {
+  id: string;
+  created_at: string;
+  modified_at: string;
+  runs: RunResult[];
+}
+
+// utility functions
+const isLocalhost = (url: string): boolean => {
+  const { hostname } = new URL(url);
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+  );
+};
+
+const getSeededTenantId = async (
+  apiUrl: string,
+  apiKey: string | undefined
+): Promise<string> => {
+  // Get the tenant ID from the seeded tenant
+  const url = `${apiUrl}/tenants`;
+  let response;
+
+  try {
+    let requestInit: { [param: string]: string | object } = {
+      method: "GET",
+    };
+    if (apiKey) {
+      requestInit = {
+        ...requestInit,
+        headers: { authorization: `Bearer ${apiKey}` },
+      };
+    }
+    response = await fetch(url, requestInit);
+  } catch (err) {
+    throw new Error("Unable to get seeded tenant ID. Please manually provide.");
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch seeded tenant ID: ${response.status} ${response.statusText}`
+    );
+  }
+  const tenants = await response.json();
+  if (!Array.isArray(tenants)) {
+    throw new Error(
+      `Expected tenants GET request to return an array, but got ${tenants}`
+    );
+  }
+  if (tenants.length === 0) {
+    throw new Error("No seeded tenant found");
+  }
+
+  return tenants[0].id;
+};
+
+export class LangChainPlusClient {
+  private apiKey?: string;
+
+  private apiUrl: string;
+
+  private tenantId: string;
+
+  constructor(apiUrl: string, apiKey: string | undefined, tenantId: string) {
+    this.apiUrl = apiUrl;
+    this.apiKey = apiKey;
+    this.tenantId = tenantId;
+    this.validateApiKeyIfHosted();
+  }
+
+  public static async create(
+    apiUrl: string,
+    apiKey: string | undefined = undefined,
+    tenantId: string | undefined = undefined
+  ): Promise<LangChainPlusClient> {
+    let tenantId_ = tenantId;
+    if (!tenantId_) {
+      tenantId_ = await getSeededTenantId(apiUrl, apiKey);
+    }
+    return new LangChainPlusClient(apiUrl, apiKey, tenantId_);
+  }
+
+  private validateApiKeyIfHosted(): void {
+    const isLocal = isLocalhost(this.apiUrl);
+    if (!isLocal) {
+      if (!this.apiKey) {
+        throw new Error(
+          "API key must be provided when using hosted LangChain+ API"
+        );
+      }
+    }
+  }
+
+  private get headers(): { [header: string]: string } {
+    const headers: { [header: string]: string } = {};
+    if (this.apiKey) {
+      headers.authorization = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+
+  private get queryParams(): { [param: string]: string } {
+    return { tenant_id: this.tenantId };
+  }
+
+  private async _get<T>(
+    path: string,
+    queryParams: { [param: string]: string } = {}
+  ): Promise<T> {
+    const params = { ...this.queryParams, ...queryParams };
+    const url = new URL(path, this.apiUrl);
+    url.search = new URLSearchParams(params).toString();
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      headers: this.headers,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch ${path}: ${response.status} ${response.statusText}`
+      );
+    }
+    return response.json() as T;
+  }
+
+  public async uploadCsv(
+    csvFile: Blob,
+    fileName: string,
+    description: string,
+    inputKeys: string[],
+    outputKeys: string[]
+  ): Promise<Dataset> {
+    const url = new URL("/datasets/upload", this.apiUrl);
+    const formData = new FormData();
+    formData.append("file", csvFile, fileName);
+    formData.append("input_keys", inputKeys.join(","));
+    formData.append("output_keys", outputKeys.join(","));
+    formData.append("description", description);
+    formData.append("tenant_id", this.tenantId);
+
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: this.headers,
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const result = await response.json();
+      if (result.detail && result.detail.includes("already exists")) {
+        throw new Error(`Dataset ${fileName} already exists`);
+      }
+      throw new Error(
+        `Failed to upload CSV: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const result = await response.json();
+    return result as Dataset;
+  }
+
+  public async readDataset(
+    datasetId: string | undefined,
+    datasetName: string | undefined
+  ): Promise<Dataset> {
+    let path = "/datasets";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params: { [param: string]: any } = { limit: 1 };
+    if (datasetId !== undefined && datasetName !== undefined) {
+      throw new Error("Must provide either datasetName or datasetId, not both");
+    } else if (datasetId !== undefined) {
+      path += `/${datasetId}`;
+    } else if (datasetName !== undefined) {
+      params.name = datasetName;
+    } else {
+      throw new Error("Must provide datasetName or datasetId");
+    }
+
+    const response = await this._get<Dataset | Dataset[]>(path, params);
+    let result: Dataset;
+    if (Array.isArray(response)) {
+      if (response.length === 0) {
+        throw new Error(
+          `Dataset[id=${datasetId}, name=${datasetName}] not found`
+        );
+      }
+      result = response[0] as Dataset;
+    } else {
+      result = response as Dataset;
+    }
+    return result;
+  }
+
+  public async listDatasets(limit = 100): Promise<Dataset[]> {
+    const path = "/datasets";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const params: { [param: string]: any } = { limit };
+    const response = await this._get<Dataset[]>(path, params);
+    if (!Array.isArray(response)) {
+      throw new Error(
+        `Expected ${path} to return an array, but got ${response}`
+      );
+    }
+    return response as Dataset[];
+  }
+
+  public async deleteDataset(
+    datasetId: string | undefined,
+    datasetName: string | undefined
+  ): Promise<Dataset> {
+    let path = "/datasets";
+    let datasetId_ = datasetId;
+    if (datasetId !== undefined && datasetName !== undefined) {
+      throw new Error("Must provide either datasetName or datasetId, not both");
+    } else if (datasetName !== undefined) {
+      const dataset = await this.readDataset(undefined, datasetName);
+      datasetId_ = dataset.id;
+    }
+    if (datasetId_ !== undefined) {
+      path += `/${datasetId_}`;
+    } else {
+      throw new Error("Must provide datasetName or datasetId");
+    }
+    const url = new URL(path, this.apiUrl);
+    const response = await fetch(url.toString(), {
+      method: "DELETE",
+      headers: this.headers,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to delete ${path}: ${response.status} ${response.statusText}`
+      );
+    }
+    const results = await response.json();
+    return results as Dataset;
+  }
+
+  public async createExample(
+    inputs: RunInputs,
+    outputs: RunOutputs = {},
+    datasetId: string | undefined = undefined,
+    datasetName: string | undefined = undefined,
+    createdAt: Date | undefined = undefined
+  ): Promise<Example> {
+    let datasetId_ = datasetId;
+    if (datasetId_ === undefined && datasetName === undefined) {
+      throw new Error("Must provide either datasetName or datasetId");
+    } else if (datasetId_ !== undefined && datasetName !== undefined) {
+      throw new Error("Must provide either datasetName or datasetId, not both");
+    } else if (datasetId_ === undefined) {
+      const dataset = await this.readDataset(undefined, datasetName);
+      datasetId_ = dataset.id;
+    }
+
+    const createdAt_ = createdAt || new Date();
+    const data: ExampleCreate = {
+      dataset_id: datasetId_,
+      inputs,
+      outputs,
+      created_at: createdAt_.toISOString(),
+    };
+
+    const url = new URL("/examples", this.apiUrl);
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: { ...this.headers, "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to create example: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const result = await response.json();
+    return result as Example;
+  }
+
+  public async readExample(exampleId: string): Promise<Example> {
+    const path = `/examples/${exampleId}`;
+    return await this._get<Example>(path);
+  }
+
+  public async listExamples(
+    datasetId: string | undefined = undefined,
+    datasetName: string | undefined = undefined
+  ): Promise<Example[]> {
+    let datasetId_;
+    if (datasetId !== undefined && datasetName !== undefined) {
+      throw new Error("Must provide either datasetName or datasetId, not both");
+    } else if (datasetId !== undefined) {
+      datasetId_ = datasetId;
+    } else if (datasetName !== undefined) {
+      const dataset = await this.readDataset(undefined, datasetName);
+      datasetId_ = dataset.id;
+    } else {
+      throw new Error("Must provide a datasetName or datasetId");
+    }
+    const response = await this._get<Example[]>("/examples", {
+      dataset: datasetId_,
+    });
+    if (!Array.isArray(response)) {
+      throw new Error(
+        `Expected /examples to return an array, but got ${response}`
+      );
+    }
+    return response as Example[];
+  }
+
+  public async deleteExample(exampleId: string): Promise<Example> {
+    const path = `/examples/${exampleId}`;
+    const url = new URL(path, this.apiUrl);
+    const response = await fetch(url.toString(), {
+      method: "DELETE",
+      headers: this.headers,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to delete ${path}: ${response.status} ${response.statusText}`
+      );
+    }
+    const result = await response.json();
+    return result as Example;
+  }
+}

--- a/langchain/src/client/tests/langchainplus.int.test.ts
+++ b/langchain/src/client/tests/langchainplus.int.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-process-env */
+import { test } from "@jest/globals";
+import { LangChainPlusClient } from "../langchainplus.js";
+
+test("Test LangChainPlus Client Dataset CRD", async () => {
+  const client: LangChainPlusClient = await LangChainPlusClient.create(
+    "http://localhost:8000"
+  );
+
+  const csvContent = `col1,col2\nval1,val2`;
+  const blobData = new Blob([Buffer.from(csvContent)]);
+
+  const description = "Test Dataset";
+  const inputKeys = ["col1"];
+  const outputKeys = ["col2"];
+
+  const newDataset = await client.uploadCsv(
+    blobData,
+    "some_file.csv",
+    description,
+    inputKeys,
+    outputKeys
+  );
+  expect(newDataset).toHaveProperty("id");
+  expect(newDataset.description).toBe(description);
+
+  const dataset = await client.readDataset(newDataset.id, undefined);
+  const datasetId = dataset.id;
+  const dataset2 = await client.readDataset(datasetId, undefined);
+  expect(dataset.id).toBe(dataset2.id);
+
+  const datasets = await client.listDatasets();
+  expect(datasets.length).toBeGreaterThan(0);
+  expect(datasets.map((d) => d.id)).toContain(datasetId);
+
+  // Test Example CRD
+  const example = await client.createExample(
+    { col1: "addedExampleCol1" },
+    { col2: "addedExampleCol2" },
+    newDataset.id
+  );
+  const exampleValue = await client.readExample(example.id);
+  expect(exampleValue.inputs.col1).toBe("addedExampleCol1");
+  expect(exampleValue.outputs.col2).toBe("addedExampleCol2");
+
+  const examples = await client.listExamples(newDataset.id);
+  expect(examples.length).toBe(2);
+  expect(examples.map((e) => e.id)).toContain(example.id);
+
+  const deletedExample = await client.deleteExample(example.id);
+  expect(deletedExample.id).toBe(example.id);
+  const examples2 = await client.listExamples(newDataset.id);
+  expect(examples2.length).toBe(1);
+
+  const deleted = await client.deleteDataset(datasetId, undefined);
+  expect(deleted.id).toBe(datasetId);
+});


### PR DESCRIPTION
Create a LangChainPlus client that contains methods to
- upload csv dataset (blob)
- read dataset
- list datasets
- delete dataset
- create/read/list/delete example

Tested with an int test
 
Next PR will be to add the 'runOnDataset' functionality