### PR TITLE
Scrape all pages, not only level 1 navigation

### DIFF
--- a/langchain/src/document_loaders/tests/gitbook.int.test.ts
+++ b/langchain/src/document_loaders/tests/gitbook.int.test.ts
@@ -7,13 +7,13 @@ test("Test GitbookLoader", async () => {
   );
 
   const docs = await loader.load();
-  console.log(docs);
+  console.log('Loaded', docs.length, 'Gitbook documents');
 });
 
 test.only("Test GitbookLoader with shouldLoadAllPaths", async () => {
-  const loader = new GitbookLoader("https://docs.gitbook.com", {
+  const loader = new GitbookLoader("https://docs.maildrop.cc", {
     shouldLoadAllPaths: true,
   });
   const docs = await loader.load();
-  console.log(docs);
+  console.log('Loaded', docs.length, 'Gitbook documents');
 });

--- a/langchain/src/document_loaders/tests/gitbook.int.test.ts
+++ b/langchain/src/document_loaders/tests/gitbook.int.test.ts
@@ -1,0 +1,19 @@
+import { test } from "@jest/globals";
+import { GitbookLoader } from "../web/gitbook.js";
+
+test("Test GitbookLoader", async () => {
+  const loader = new GitbookLoader(
+    "https://docs.gitbook.com/product-tour/navigation"
+  );
+
+  const docs = await loader.load();
+  console.log(docs);
+});
+
+test.only("Test GitbookLoader with shouldLoadAllPaths", async () => {
+  const loader = new GitbookLoader("https://docs.gitbook.com", {
+    shouldLoadAllPaths: true,
+  });
+  const docs = await loader.load();
+  console.log(docs);
+});

--- a/langchain/src/document_loaders/tests/gitbook.int.test.ts
+++ b/langchain/src/document_loaders/tests/gitbook.int.test.ts
@@ -7,7 +7,7 @@ test("Test GitbookLoader", async () => {
   );
 
   const docs = await loader.load();
-  console.log('Loaded', docs.length, 'Gitbook documents');
+  console.log("Loaded", docs.length, "Gitbook documents");
 });
 
 test.only("Test GitbookLoader with shouldLoadAllPaths", async () => {
@@ -15,5 +15,5 @@ test.only("Test GitbookLoader with shouldLoadAllPaths", async () => {
     shouldLoadAllPaths: true,
   });
   const docs = await loader.load();
-  console.log('Loaded', docs.length, 'Gitbook documents');
+  console.log("Loaded", docs.length, "Gitbook documents");
 });

--- a/langchain/src/document_loaders/web/gitbook.ts
+++ b/langchain/src/document_loaders/web/gitbook.ts
@@ -11,7 +11,7 @@ export class GitbookLoader extends CheerioWebBaseLoader {
 
   constructor(public webPath: string, params: GitbookLoaderParams = {}) {
     const path =
-      params.shouldLoadAllPaths === true ? webPath : `${webPath}/sitemap.xml`;
+      params.shouldLoadAllPaths === true ? `${webPath}/sitemap.xml` : webPath;
     super(path);
 
     this.shouldLoadAllPaths =

--- a/langchain/src/document_loaders/web/gitbook.ts
+++ b/langchain/src/document_loaders/web/gitbook.ts
@@ -10,6 +10,9 @@ export class GitbookLoader extends CheerioWebBaseLoader {
   shouldLoadAllPaths = false;
 
   constructor(public webPath: string, params: GitbookLoaderParams = {}) {
+    if (params.shouldLoadAllPaths === true)
+      webPath += '/sitemap.xml'
+
     super(webPath);
     this.shouldLoadAllPaths =
       params.shouldLoadAllPaths ?? this.shouldLoadAllPaths;
@@ -45,14 +48,12 @@ export class GitbookLoader extends CheerioWebBaseLoader {
   }
 
   private async loadAllPaths($: CheerioAPI): Promise<Document[]> {
-    const relative_paths = $("nav a")
+    const urls = $("loc")
       .toArray()
-      .map((element) => $(element).attr("href"))
-      .filter((text) => text && text[0] === "/");
+      .map((element) => $(element).text())
 
     const documents: Document[] = [];
-    for (const path of relative_paths) {
-      const url = this.webPath + path;
+    for (const url of urls) {
       console.log(`Fetching text from ${url}`);
       const html = await GitbookLoader._scrape(url, this.caller, this.timeout);
       documents.push(...this.loadPath(html, url));

--- a/langchain/src/document_loaders/web/gitbook.ts
+++ b/langchain/src/document_loaders/web/gitbook.ts
@@ -10,10 +10,10 @@ export class GitbookLoader extends CheerioWebBaseLoader {
   shouldLoadAllPaths = false;
 
   constructor(public webPath: string, params: GitbookLoaderParams = {}) {
-    if (params.shouldLoadAllPaths === true)
-      webPath += '/sitemap.xml'
+    const path =
+      params.shouldLoadAllPaths === true ? webPath : `${webPath}/sitemap.xml`;
+    super(path);
 
-    super(webPath);
     this.shouldLoadAllPaths =
       params.shouldLoadAllPaths ?? this.shouldLoadAllPaths;
   }
@@ -50,7 +50,7 @@ export class GitbookLoader extends CheerioWebBaseLoader {
   private async loadAllPaths($: CheerioAPI): Promise<Document[]> {
     const urls = $("loc")
       .toArray()
-      .map((element) => $(element).text())
+      .map((element) => $(element).text());
 
     const documents: Document[] = [];
     for (const url of urls) {

--- a/langchain/src/document_loaders/web/gitbook.ts
+++ b/langchain/src/document_loaders/web/gitbook.ts
@@ -14,6 +14,8 @@ export class GitbookLoader extends CheerioWebBaseLoader {
       params.shouldLoadAllPaths === true ? `${webPath}/sitemap.xml` : webPath;
     super(path);
 
+    this.webPath = path;
+
     this.shouldLoadAllPaths =
       params.shouldLoadAllPaths ?? this.shouldLoadAllPaths;
   }


### PR DESCRIPTION
Gitbook's server-side rendering means that when we fetch the contents of the index page
the sub-menu items are not rendered and thus are invisible to $('nav a').
This patch makes the loader use sitemap.xml which has an index of all pages.

Inspired by the Python version.