### PR TITLE
Unifying the output standard

### DIFF
--- a/langchain/src/chains/combine_docs_chain.ts
+++ b/langchain/src/chains/combine_docs_chain.ts
@@ -276,7 +276,7 @@ export class RefineDocumentsChain
 
   inputKey = "input_documents";
 
-  outputKey = "output_text";
+  outputKey = "text";
 
   documentVariableName = "context";
 


### PR DESCRIPTION
## Abstract

Unifying the output standard like other chain(ex: QAStuffChain, QAMapReduceChain

## Examples
```ts
const qAStuffChainResponse = await loadQAStuffChain(llm).call({ question: 'xxx', input_documents: docs });
console.log(qAStuffChainResponse) // { text: '...' }

const qAMapReduceChainResponse = await loadQAMapReduceChain(llm).call({ question: 'xxx', input_documents: docs });
console.log(qAMapReduceChainResponse) // { text: '...' }


// here~
const qARefineChainResponse = await loadQARefineChain(llm).call({ question: 'xxx', input_documents: docs });
console.log(qARefineChainResponse) // { output_text: '...' }  // here is the problem 

```
