### PR TITLE
Run the Client over a Dataset

### DIFF
--- a/examples/src/client/tracing_datasets.ts
+++ b/examples/src/client/tracing_datasets.ts
@@ -20,7 +20,7 @@ import { initializeAgentExecutorWithOptions } from "langchain/agents";
 
 export const run = async () => {
   // Capture traces by setting the LANGCHAIN_TRACING_V2 environment variable
-  process.env.LANGCHAIN_TRACING_V2 = "langchain";
+  process.env.LANGCHAIN_TRACING_V2 = "true";
   const model = new ChatOpenAI({ temperature: 0 });
   const tools = [
     new SerpAPI(process.env.SERPAPI_API_KEY, {

--- a/examples/src/client/tracing_datasets.ts
+++ b/examples/src/client/tracing_datasets.ts
@@ -5,11 +5,16 @@ import { SerpAPI } from "langchain/tools";
 import { Calculator } from "langchain/tools/calculator";
 import { initializeAgentExecutorWithOptions } from "langchain/agents";
 
-// Developing applications with language models can be uniquely challenging. To manage this complexity and ensure reliable performance, LangChain provides tracing and evaluation functionality. This notebook demonstrates how to run Chains, which are language model functions, as well as Chat models, and LLMs on previously captured datasets or traces. Some common use cases for this approach include:
-
-// - Running an evaluation chain to grade previous runs.
-// - Comparing different chains, LLMs, and agents on traced datasets.
-// - Executing a stochastic chain multiple times over a dataset to generate metrics before deployment.
+// LangChain wants to make developing and deploying safe, high-quality
+// language model applications as easy as possible.
+// To manage the complexity and challenges of working with LLMs,
+// LangChain provides tracing and evaluation functionality.
+// This notebook demonstrates how to run Chains,
+// which are language model functions on traced datasets.
+// Some common use cases for this approach include:
+//    - Running an evaluation chain to grade previous runs.
+//    - Comparing different chains, LLMs, and agents on traced datasets.
+//    - Executing a stochastic chain multiple times over a dataset to generate metrics before deployment.
 // Please note that this example assumes you have LangChain+ tracing running in the background.
 // It is configured to work only with the V2 endpoints.
 

--- a/examples/src/client/tracing_datasets.ts
+++ b/examples/src/client/tracing_datasets.ts
@@ -1,0 +1,91 @@
+/* eslint-disable no-process-env */
+import { ChatOpenAI } from "langchain/chat_models/openai";
+import { LangChainPlusClient, Dataset } from "langchain/client/langchainplus";
+import { SerpAPI } from "langchain/tools";
+import { Calculator } from "langchain/tools/calculator";
+import { initializeAgentExecutorWithOptions } from "langchain/agents";
+
+// Developing applications with language models can be uniquely challenging. To manage this complexity and ensure reliable performance, LangChain provides tracing and evaluation functionality. This notebook demonstrates how to run Chains, which are language model functions, as well as Chat models, and LLMs on previously captured datasets or traces. Some common use cases for this approach include:
+
+// - Running an evaluation chain to grade previous runs.
+// - Comparing different chains, LLMs, and agents on traced datasets.
+// - Executing a stochastic chain multiple times over a dataset to generate metrics before deployment.
+// Please note that this example assumes you have LangChain+ tracing running in the background.
+// It is configured to work only with the V2 endpoints.
+
+export const run = async () => {
+  // Capture traces by setting the LANGCHAIN_TRACING_V2 environment variable
+  process.env.LANGCHAIN_TRACING_V2 = "langchain";
+  const model = new ChatOpenAI({ temperature: 0 });
+  const tools = [
+    new SerpAPI(process.env.SERPAPI_API_KEY, {
+      location: "Austin,Texas,United States",
+      hl: "en",
+      gl: "us",
+    }),
+    new Calculator(),
+  ];
+
+  const executor = await initializeAgentExecutorWithOptions(tools, model, {
+    agentType: "chat-conversational-react-description",
+    verbose: true,
+  });
+  console.log("Loaded agent.");
+
+  const inputs: string[] = [
+    "How many people live in canada as of 2023?",
+    "who is dua lipa's boyfriend? what is his age raised to the .43 power?",
+    "what is dua lipa's boyfriend age raised to the .43 power?",
+    "how far is it from paris to boston in miles",
+    "what was the total number of points scored in the 2023 super bowl? what is that number raised to the .23 power?",
+  ];
+  for (const input of inputs) {
+    const result = await executor.call({ input });
+    console.log(`Got output ${result.output}`);
+  }
+  // Now you can navigate to the UI at http://localhost/sessions then:
+  // 1. Select the default session from the list.
+  // 2. Next to the fist example, click "+ to Dataset".
+  // 3. Click "Create Dataset" and select a title like "calculator-example-dataset".
+  // 4. Add the other examples to the dataset as well
+
+  // So that you don't have to create the dataset manually, we will create it for you
+  const client: LangChainPlusClient = await LangChainPlusClient.create(
+    "http://localhost:8000"
+  );
+  const csvContent = `
+input,output
+How many people live in canada as of 2023?,"approximately 38,625,801"
+who is dua lipa's boyfriend? what is his age raised to the .43 power?,her boyfriend is Romain Gravas. his age raised to the .43 power is approximately 4.9373857399466665
+what is dua lipa's boyfriend age raised to the .43 power?,her boyfriend is Romain Gravas. his age raised to the .43 power is approximately 4.9373857399466665
+how far is it from paris to boston in miles,"approximately 3,435 mi"
+what was the total number of points scored in the 2023 super bowl? what is that number raised to the .23 power?,approximately 2.682651500990882
+what was the total number of points scored in the 2023 super bowl raised to the .23 power?,approximately 2.682651500990882
+how many more points were scored in the 2023 super bowl than in the 2022 super bowl?,30
+what is 153 raised to .1312 power?,approximately 1.9347796717823205
+who is kendall jenner's boyfriend? what is his height (in inches) raised to .13 power?,approximately 1.7589107138176394
+what is 1213 divided by 4345?,approximately 0.2791714614499425
+`;
+  const blobData = new Blob([Buffer.from(csvContent)]);
+
+  const datasetName = "mathy.csv";
+  const description = "Silly Math Dataset";
+  const inputKeys = ["input"];
+  const outputKeys = ["output"];
+  // Check if dataset name exists in listDatasets
+  const datasets = await client.listDatasets();
+  if (!datasets.map((d: Dataset) => d.name).includes(datasetName)) {
+    await client.uploadCsv(
+      blobData,
+      datasetName,
+      description,
+      inputKeys,
+      outputKeys
+    );
+  }
+
+  // If using the traced dataset, you can update the datasetName to be
+  // "calculator-example-dataset" or the custom name you chose.
+  const results = await client.runOnDataset(datasetName, executor);
+  console.log(results);
+};

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -274,6 +274,12 @@ experimental/babyagi.d.ts
 experimental/plan_and_execute.cjs
 experimental/plan_and_execute.js
 experimental/plan_and_execute.d.ts
+client.cjs
+client.js
+client.d.ts
+client/langchainplus.cjs
+client/langchainplus.js
+client/langchainplus.d.ts
 index.cjs
 index.js
 index.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -286,6 +286,12 @@
     "experimental/plan_and_execute.cjs",
     "experimental/plan_and_execute.js",
     "experimental/plan_and_execute.d.ts",
+    "client.cjs",
+    "client.js",
+    "client.d.ts",
+    "client/langchainplus.cjs",
+    "client/langchainplus.js",
+    "client/langchainplus.d.ts",
     "index.cjs",
     "index.js",
     "index.d.ts"
@@ -1015,6 +1021,16 @@
       "types": "./experimental/plan_and_execute.d.ts",
       "import": "./experimental/plan_and_execute.js",
       "require": "./experimental/plan_and_execute.cjs"
+    },
+    "./client": {
+      "types": "./client.d.ts",
+      "import": "./client.js",
+      "require": "./client.cjs"
+    },
+    "./client/langchainplus": {
+      "types": "./client/langchainplus.d.ts",
+      "import": "./client/langchainplus.js",
+      "require": "./client/langchainplus.cjs"
     },
     "./package.json": "./package.json"
   }

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -123,6 +123,8 @@ const entrypoints = {
   "experimental/autogpt": "experimental/autogpt/index",
   "experimental/babyagi": "experimental/babyagi/index",
   "experimental/plan_and_execute": "experimental/plan_and_execute/index",
+  client: "client/index",
+  "client/langchainplus": "client/langchainplus",
 };
 
 // Entrypoints in this list will

--- a/langchain/src/callbacks/handlers/tracers.ts
+++ b/langchain/src/callbacks/handlers/tracers.ts
@@ -95,6 +95,10 @@ export interface Run extends RunCreate {
   parent_run_id?: string; // uuid
 }
 
+export interface RunResult extends BaseRun {
+  name: string;
+  parent_run_id?: string; // uuid
+}
 export interface AgentRun extends Run {
   actions: AgentAction[];
 }

--- a/langchain/src/callbacks/handlers/tracers.ts
+++ b/langchain/src/callbacks/handlers/tracers.ts
@@ -95,10 +95,6 @@ export interface Run extends RunCreate {
   parent_run_id?: string; // uuid
 }
 
-export interface RunResult extends BaseRun {
-  name: string;
-  parent_run_id?: string; // uuid
-}
 export interface AgentRun extends Run {
   actions: AgentAction[];
 }

--- a/langchain/src/client/index.ts
+++ b/langchain/src/client/index.ts
@@ -1,0 +1,6 @@
+export {
+  LangChainPlusClient,
+  Dataset,
+  Example,
+  DatasetRunResults,
+} from "./langchainplus.js";

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -117,7 +117,9 @@
       "src/stores/message/dynamodb.ts",
       "src/experimental/autogpt/index.ts",
       "src/experimental/babyagi/index.ts",
-      "src/experimental/plan_and_execute/index.ts"
+      "src/experimental/plan_and_execute/index.ts",
+      "src/client/index.ts",
+      "src/client/langchainplus.ts"
     ],
     "sort": [
       "kind",

--- a/test-exports-cf/src/entrypoints.js
+++ b/test-exports-cf/src/entrypoints.js
@@ -35,3 +35,5 @@ export * from "langchain/stores/file/in_memory";
 export * from "langchain/experimental/autogpt";
 export * from "langchain/experimental/babyagi";
 export * from "langchain/experimental/plan_and_execute";
+export * from "langchain/client";
+export * from "langchain/client/langchainplus";

--- a/test-exports-cjs/src/entrypoints.js
+++ b/test-exports-cjs/src/entrypoints.js
@@ -35,3 +35,5 @@ const stores_file_in_memory = require("langchain/stores/file/in_memory");
 const experimental_autogpt = require("langchain/experimental/autogpt");
 const experimental_babyagi = require("langchain/experimental/babyagi");
 const experimental_plan_and_execute = require("langchain/experimental/plan_and_execute");
+const client = require("langchain/client");
+const client_langchainplus = require("langchain/client/langchainplus");

--- a/test-exports-cra/src/entrypoints.js
+++ b/test-exports-cra/src/entrypoints.js
@@ -35,3 +35,5 @@ export * from "langchain/stores/file/in_memory";
 export * from "langchain/experimental/autogpt";
 export * from "langchain/experimental/babyagi";
 export * from "langchain/experimental/plan_and_execute";
+export * from "langchain/client";
+export * from "langchain/client/langchainplus";

--- a/test-exports-esm/src/entrypoints.js
+++ b/test-exports-esm/src/entrypoints.js
@@ -35,3 +35,5 @@ import * as stores_file_in_memory from "langchain/stores/file/in_memory";
 import * as experimental_autogpt from "langchain/experimental/autogpt";
 import * as experimental_babyagi from "langchain/experimental/babyagi";
 import * as experimental_plan_and_execute from "langchain/experimental/plan_and_execute";
+import * as client from "langchain/client";
+import * as client_langchainplus from "langchain/client/langchainplus";

--- a/test-exports-vercel/src/entrypoints.js
+++ b/test-exports-vercel/src/entrypoints.js
@@ -35,3 +35,5 @@ export * from "langchain/stores/file/in_memory";
 export * from "langchain/experimental/autogpt";
 export * from "langchain/experimental/babyagi";
 export * from "langchain/experimental/plan_and_execute";
+export * from "langchain/client";
+export * from "langchain/client/langchainplus";

--- a/test-exports-vite/src/entrypoints.js
+++ b/test-exports-vite/src/entrypoints.js
@@ -35,3 +35,5 @@ export * from "langchain/stores/file/in_memory";
 export * from "langchain/experimental/autogpt";
 export * from "langchain/experimental/babyagi";
 export * from "langchain/experimental/plan_and_execute";
+export * from "langchain/client";
+export * from "langchain/client/langchainplus";


### PR DESCRIPTION
Part 3 of the client PRs.
- Part 1 https://github.com/hwchase17/langchainjs/pull/1174 creates the V2 tracer and breaks the type signatures of the BaseTracer 
- Part 2 https://github.com/hwchase17/langchainjs/pull/1190 adds the client along with creation / read / deletion methods for datasets and examples. 


This PR adds a method to run a chain or LLM over a dataset.

It doesn't yet introduce concurrency or properly support chat models. I'll try to add that in a fourth PR (this is too big already).