### PR TITLE
Add V2 Env Var for Callbacks

### DIFF
--- a/langchain/src/callbacks/handlers/initialize.ts
+++ b/langchain/src/callbacks/handlers/initialize.ts
@@ -1,9 +1,21 @@
-import { LangChainTracer } from "./tracers.js";
+import { LangChainTracer, LangChainTracerV2 } from "./tracers.js";
 
 export async function getTracingCallbackHandler(
   session?: string
 ): Promise<LangChainTracer> {
   const tracer = new LangChainTracer();
+  if (session) {
+    await tracer.loadSession(session);
+  } else {
+    await tracer.loadDefaultSession();
+  }
+  return tracer;
+}
+
+export async function getTracingV2CallbackHandler(
+  session?: string
+): Promise<LangChainTracerV2> {
+  const tracer = new LangChainTracerV2();
   if (session) {
     await tracer.loadSession(session);
   } else {


### PR DESCRIPTION
- Add a LANGCHAIN_TRACING_V2 environment variables to enable v2 tracing
- Initialize a v2 tracer if this is set (has precedence over the regular tracing env var)