### PR TITLE
Fix: Tool `action_input` containing markdown with JSON

### DIFF
--- a/langchain/src/agents/chat_convo/outputParser.ts
+++ b/langchain/src/agents/chat_convo/outputParser.ts
@@ -3,7 +3,55 @@ import { FORMAT_INSTRUCTIONS } from "./prompt.js";
 
 export class ChatConversationalAgentOutputParser extends AgentActionOutputParser {
   async parse(text: string) {
-    let jsonOutput = text.trim();
+    const trimmedText = text.trim();
+    let action: string | undefined;
+    let action_input: string | undefined;
+
+    try {
+      ({ action, action_input } = JSON.parse(trimmedText));
+    } catch (_error) {
+      ({ action, action_input } = this.findActionAndInput(trimmedText));
+    }
+
+    if (!action) {
+      throw new Error(`\`action\` could not be found in: "${trimmedText}"`);
+    }
+
+    if (!action_input) {
+      throw new Error(
+        `\`action_input\` could not be found in: "${trimmedText}"`
+      );
+    }
+
+    if (action === "Final Answer") {
+      return { returnValues: { output: action_input }, log: text };
+    }
+
+    return { tool: action, toolInput: action_input, log: text };
+  }
+
+  getFormatInstructions(): string {
+    return FORMAT_INSTRUCTIONS;
+  }
+
+  private findActionAndInput(text: string): {
+    action: string | undefined;
+    action_input: string | undefined;
+  } {
+    const jsonOutput = this.findJson(text);
+
+    try {
+      const response = JSON.parse(jsonOutput);
+
+      return response;
+    } catch (error) {
+      return { action: undefined, action_input: undefined };
+    }
+  }
+
+  private findJson(text: string) {
+    let jsonOutput = text;
+
     if (jsonOutput.includes("```json")) {
       jsonOutput = jsonOutput.split("```json")[1].trimStart();
     } else if (jsonOutput.includes("```")) {
@@ -11,21 +59,11 @@ export class ChatConversationalAgentOutputParser extends AgentActionOutputParser
       jsonOutput = jsonOutput.slice(firstIndex + 3).trimStart();
     }
     const lastIndex = jsonOutput.lastIndexOf("```");
+
     if (lastIndex !== -1) {
       jsonOutput = jsonOutput.slice(0, lastIndex).trimEnd();
     }
 
-    const response = JSON.parse(jsonOutput);
-
-    const { action, action_input } = response;
-
-    if (action === "Final Answer") {
-      return { returnValues: { output: action_input }, log: text };
-    }
-    return { tool: action, toolInput: action_input, log: text };
-  }
-
-  getFormatInstructions(): string {
-    return FORMAT_INSTRUCTIONS;
+    return jsonOutput;
   }
 }


### PR DESCRIPTION
This PR fixes a bug where if a `Tool` returns JSON markdown in the `action_input` string then `ChatConversationalAgentOutputParser.parse` fails to parse the `action_input` properly.

An example `text`/message that fails to parse:
```json
{"action":"ToolWithJson","action_input":"The tool input ```json\\n{\\"yes\\":true}\\n```"}
```

This PR optimistically tries to parse the `text`/message as JSON and if that fails then it attempts to find the JSON in the string.

Before this PR the above example fails with:
```
SyntaxError: Unexpected token '\', "\n{\"yes\":true}\n" is not valid JSON
```

This PR also adds further error handling to return that either `action` or `action_input` could not be found.