### PR TITLE
Update Chat Model Serialization

### DIFF
--- a/langchain/src/callbacks/handlers/tracer.ts
+++ b/langchain/src/callbacks/handlers/tracer.ts
@@ -6,6 +6,7 @@ import {
   RunInputs,
   RunOutputs,
 } from "../../schema/index.js";
+import { mapChatMessagesToStoredMessages } from "../../stores/message/utils.js";
 import { BaseCallbackHandler } from "../base.js";
 
 export type RunType = "llm" | "chain" | "tool";
@@ -132,10 +133,7 @@ export abstract class BaseTracer extends BaseCallbackHandler {
   ): Promise<void> {
     const execution_order = this._getExecutionOrder(parentRunId);
     const convertedMessages = messages.map((batch) =>
-      batch.map((message) => ({
-        _type: message._getType(),
-        content: message.text, // TODO: Unify serialization btwn languages
-      }))
+      mapChatMessagesToStoredMessages(batch)
     );
     const run: Run = {
       id: runId,

--- a/langchain/src/callbacks/tests/tracer.test.ts
+++ b/langchain/src/callbacks/tests/tracer.test.ts
@@ -94,7 +94,11 @@ test("Test Chat Message Run", async () => {
     execution_order: 1,
     child_execution_order: 1,
     serialized: { name: "test" },
-    inputs: { messages: [[{ type: "human", data: {content: "Avast", role: undefined}}]] },
+    inputs: {
+      messages: [
+        [{ type: "human", data: { content: "Avast", role: undefined } }],
+      ],
+    },
     run_type: "llm",
     outputs: { generations: [] },
     child_runs: [],

--- a/langchain/src/callbacks/tests/tracer.test.ts
+++ b/langchain/src/callbacks/tests/tracer.test.ts
@@ -94,7 +94,7 @@ test("Test Chat Message Run", async () => {
     execution_order: 1,
     child_execution_order: 1,
     serialized: { name: "test" },
-    inputs: { messages: [[{ _type: "human", content: "Avast" }]] },
+    inputs: { messages: [[{ type: "human", data: {content: "Avast", role: undefined}}]] },
     run_type: "llm",
     outputs: { generations: [] },
     child_runs: [],

--- a/langchain/src/stores/message/dynamodb.ts
+++ b/langchain/src/stores/message/dynamodb.ts
@@ -95,11 +95,14 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
     const messages = items
       .map((item) => ({
         type: item.M?.type.S,
-        role: item.M?.role?.S,
-        text: item.M?.text.S,
+        data: {
+          role: item.M?.role?.S,
+          content: item.M?.text.S,
+        },
       }))
       .filter(
-        (x): x is StoredMessage => x.type !== undefined && x.text !== undefined
+        (x): x is StoredMessage =>
+          x.type !== undefined && x.data.content !== undefined
       );
     return mapStoredMessagesToChatMessages(messages);
   }
@@ -133,12 +136,12 @@ export class DynamoDBChatMessageHistory extends BaseListChatMessageHistory {
                   S: message.type,
                 },
                 text: {
-                  S: message.text,
+                  S: message.data.content,
                 },
               },
             };
-            if (message.role) {
-              dynamoSerializedMessage.M.role = { S: message.role };
+            if (message.data.role) {
+              dynamoSerializedMessage.M.role = { S: message.data.role };
             }
             return dynamoSerializedMessage;
           }),

--- a/langchain/src/stores/message/redis.ts
+++ b/langchain/src/stores/message/redis.ts
@@ -60,11 +60,14 @@ export class RedisChatMessageHistory extends BaseListChatMessageHistory {
     const previousMessages = orderedMessages
       .map((item) => ({
         type: item.type,
-        role: item.role,
-        text: item.text,
+        data: {
+          role: item.role,
+          content: item.text,
+        },
       }))
       .filter(
-        (x): x is StoredMessage => x.type !== undefined && x.text !== undefined
+        (x): x is StoredMessage =>
+          x.type !== undefined && x.data.content !== undefined
       );
     return mapStoredMessagesToChatMessages(previousMessages);
   }

--- a/langchain/src/stores/message/utils.ts
+++ b/langchain/src/stores/message/utils.ts
@@ -28,7 +28,8 @@ interface StoredMessageV1 {
 export function mapV1MessageToStoredMessage(
   message: StoredMessage | StoredMessageV1
 ): StoredMessage {
-  if ("data" in message) {
+  // TODO: Remove this mapper when we deprecate the old message format.
+  if ((message as StoredMessage).data !== undefined) {
     return message as StoredMessage;
   } else {
     const v1Message = message as StoredMessageV1;
@@ -46,24 +47,24 @@ export function mapStoredMessagesToChatMessages(
   messages: StoredMessage[]
 ): BaseChatMessage[] {
   return messages.map((message) => {
-    const stored_msg = mapV1MessageToStoredMessage(message);
-    switch (stored_msg.type) {
+    const storedMessage = mapV1MessageToStoredMessage(message);
+    switch (storedMessage.type) {
       case "human":
-        return new HumanChatMessage(stored_msg.data.content);
+        return new HumanChatMessage(storedMessage.data.content);
       case "ai":
-        return new AIChatMessage(stored_msg.data.content);
+        return new AIChatMessage(storedMessage.data.content);
       case "system":
-        return new SystemChatMessage(stored_msg.data.content);
+        return new SystemChatMessage(storedMessage.data.content);
       case "chat":
-        if (stored_msg.data?.additional_kwargs?.role === undefined) {
+        if (storedMessage.data?.additional_kwargs?.role === undefined) {
           throw new Error("Role must be defined for chat messages");
         }
         return new ChatMessage(
-          stored_msg.data.content,
-          stored_msg.data.additional_kwargs.role
+          storedMessage.data.content,
+          storedMessage.data.additional_kwargs.role
         );
       default:
-        throw new Error(`Got unexpected type: ${stored_msg.type}`);
+        throw new Error(`Got unexpected type: ${storedMessage.type}`);
     }
   });
 }

--- a/langchain/src/stores/tests/utils.test.ts
+++ b/langchain/src/stores/tests/utils.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@jest/globals";
+import { mapV1MessageToStoredMessage } from "../message/utils.js";
+
+test("mapV1MessageToStoredMessage", () => {
+  // Test that a V1 message is upgraded.
+  // Test that a v2 message is not changed.
+  const v1Message = {
+    type: "human",
+    role: "user",
+    text: "Hello, world!",
+  };
+  const v2Message = {
+    type: "human",
+    data: {
+      content: "Hello, world!",
+      role: "user",
+    },
+  };
+  expect(mapV1MessageToStoredMessage(v1Message)).toEqual(v2Message);
+
+  const v2Message2 = {
+    type: "human",
+    data: {
+      content: "Hello, world!",
+      role: "user",
+      additional_kwargs: {
+        foo: "bar",
+      },
+    },
+  };
+  expect(mapV1MessageToStoredMessage(v2Message2)).toEqual(v2Message2);
+});


### PR DESCRIPTION
Unify format with the python lib, which was [defined of yore as](https://github.com/hwchase17/langchain/blob/4ee47926cafba0eb00851972783c1d66236f6f00/langchain/schema.py#L121)

```
def _message_to_dict(message: BaseMessage) -> dict:
    return {"type": message.type, "data": message.dict()}


def messages_to_dict(messages: List[BaseMessage]) -> List[dict]:
    return [_message_to_dict(m) for m in messages]


def _message_from_dict(message: dict) -> BaseMessage:
    _type = message["type"]
    if _type == "human":
        return HumanMessage(**message["data"])
    elif _type == "ai":
        return AIMessage(**message["data"])
    elif _type == "system":
        return SystemMessage(**message["data"])
    elif _type == "chat":
        return ChatMessage(**message["data"])
    else:
        raise ValueError(f"Got unexpected type: {_type}")


def messages_from_dict(messages: List[dict]) -> List[BaseMessage]:
    return [_message_from_dict(m) for m in messages]
```