### PR TITLE
[test-exports-esbuild] Add missing entrypoints

### DIFF
--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -203,6 +203,10 @@ const testExports = [
     (p) => `import * as ${p.replace(/\//g, "_")} from "langchain/${p}";`,
   ],
   [
+    "test-exports-esbuild",
+    (p) => `import * as ${p.replace(/\//g, "_")} from "langchain/${p}";`,
+  ],
+  [
     "test-exports-cjs",
     (p) => `const ${p.replace(/\//g, "_")} = require("langchain/${p}");`,
   ],

--- a/test-exports-esbuild/src/entrypoints.js
+++ b/test-exports-esbuild/src/entrypoints.js
@@ -34,3 +34,5 @@ import * as cache from "langchain/cache";
 import * as stores_file_in_memory from "langchain/stores/file/in_memory";
 import * as experimental_autogpt from "langchain/experimental/autogpt";
 import * as experimental_babyagi from "langchain/experimental/babyagi";
+import * as experimental_plan_and_execute from "langchain/experimental/plan_and_execute";
+import * as client from "langchain/client";


### PR DESCRIPTION
Syncing entrypoints with `esm` modules since esbuild/esm should have the same imports. This should give us the expected CI test coverage in `esbuild`.

It seems like these were missed because in the time `esbuild` was added, `esm` already had two more commits that added entrypoints.

Compare to `esm`:
https://github.com/hwchase17/langchainjs/blob/main/test-exports-esm/src/entrypoints.js

Test plan:
 - CI tests