### PR TITLE
(example): a small implementation of document loader from foler + splitter

### DIFF
--- a/examples/src/document_loaders/pdf_directory.ts
+++ b/examples/src/document_loaders/pdf_directory.ts
@@ -1,0 +1,26 @@
+import { DirectoryLoader } from "langchain/document_loaders/fs/directory";
+import { PDFLoader } from "langchain/document_loaders/fs/pdf";
+import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
+
+export const run = async () => {
+  /* load raw docs from the all files in the directory */
+  const directoryLoader = new DirectoryLoader(
+    "src/document_loaders/example_data/",
+    {
+      ".pdf": (path: string) => new PDFLoader(path),
+    }
+  );
+
+  const documents = await directoryLoader.load();
+
+  console.log({ documents });
+
+  /* Additionnal steps : Split text into chunks */
+  const textSplitter = new RecursiveCharacterTextSplitter({
+    chunkSize: 1000,
+    chunkOverlap: 200,
+  });
+
+  const splittedDocuments = await textSplitter.splitDocuments(documents);
+  console.log({ splittedDocuments });
+};


### PR DESCRIPTION
This example show how to retrieve all pdfs from a folder, then load it and chunk it.

This is another example for issue https://github.com/hwchase17/langchainjs/issues/1209

A follow up of https://github.com/hwchase17/langchainjs/pull/1229