### PR TITLE
[DOC] Fixing typos related in the sequential chain documentation

### DIFF
--- a/examples/src/chains/sequential_chain.ts
+++ b/examples/src/chains/sequential_chain.ts
@@ -26,13 +26,13 @@ const reviewTemplate = `You are a play critic from the New York Times. Given the
    Play Synopsis:
    {synopsis}
    Review from a New York Times play critic of the above play:`;
-const reviewPromptTempalte = new PromptTemplate({
+const reviewPromptTemplate = new PromptTemplate({
   template: reviewTemplate,
   inputVariables: ["synopsis"],
 });
 const reviewChain = new LLMChain({
   llm: reviewLLM,
-  prompt: reviewPromptTempalte,
+  prompt: reviewPromptTemplate,
   outputKey: "review",
 });
 

--- a/langchain/src/chains/sequential_chain.ts
+++ b/langchain/src/chains/sequential_chain.ts
@@ -210,8 +210,8 @@ export interface SimpleSequentialChainInput extends ChainInputs {
  * Play Synopsis:
  * {synopsis}
  * Review from a New York Times play critic of the above play:`
- * const reviewPromptTempalte = new PromptTemplate({ template: reviewTemplate, inputVariables: ["synopsis"] });
- * const reviewChain = new LLMChain({ llm: reviewLLM, prompt: reviewPromptTempalte });
+ * const reviewPromptTemplate = new PromptTemplate({ template: reviewTemplate, inputVariables: ["synopsis"] });
+ * const reviewChain = new LLMChain({ llm: reviewLLM, prompt: reviewPromptTemplate });
  *
  * const overallChain = new SimpleSequentialChain({chains: [synopsisChain, reviewChain], verbose:true})
  * const review = await overallChain.run("Tragedy at sunset on the beach")

--- a/langchain/src/chains/tests/sequential_chain.int.test.ts
+++ b/langchain/src/chains/tests/sequential_chain.int.test.ts
@@ -30,13 +30,13 @@ test("Test SequentialChain example usage", async () => {
      Play Synopsis:
      {synopsis}
      Review from a New York Times play critic of the above play:`;
-  const reviewPromptTempalte = new PromptTemplate({
+  const reviewPromptTemplate = new PromptTemplate({
     template: reviewTemplate,
     inputVariables: ["synopsis"],
   });
   const reviewChain = new LLMChain({
     llm: reviewLLM,
-    prompt: reviewPromptTempalte,
+    prompt: reviewPromptTemplate,
     outputKey: "review",
   });
 

--- a/langchain/src/chains/tests/simple_sequential_chain.int.test.ts
+++ b/langchain/src/chains/tests/simple_sequential_chain.int.test.ts
@@ -25,13 +25,13 @@ test("Test SimpleSequentialChain example usage", async () => {
      Play Synopsis:
      {synopsis}
      Review from a New York Times play critic of the above play:`;
-  const reviewPromptTempalte = new PromptTemplate({
+  const reviewPromptTemplate = new PromptTemplate({
     template: reviewTemplate,
     inputVariables: ["synopsis"],
   });
   const reviewChain = new LLMChain({
     llm: reviewLLM,
-    prompt: reviewPromptTempalte,
+    prompt: reviewPromptTemplate,
   });
 
   const overallChain = new SimpleSequentialChain({


### PR DESCRIPTION
## Overview

Replacing wrong references to "Tempalte" in the documentation and examples related to sequential chains.