### PR TITLE
fix: maintain human and ai prefix in buffer window memory

### DIFF
--- a/langchain/src/memory/buffer_window_memory.ts
+++ b/langchain/src/memory/buffer_window_memory.ts
@@ -47,7 +47,7 @@ export class BufferWindowMemory
       return result;
     }
     const result = {
-      [this.memoryKey]: getBufferString(messages.slice(-this.k * 2)),
+      [this.memoryKey]: getBufferString(messages.slice(-this.k * 2), this.humanPrefix, this.aiPrefix),
     };
     return result;
   }


### PR DESCRIPTION
Same as in python repository

https://github.com/hwchase17/langchain/blob/master/langchain/memory/buffer_window.py#L33-L37