### PR TITLE
feat: add datetime tool

### DIFF
--- a/docs/docs/modules/agents/tools/datetime.mdx
+++ b/docs/docs/modules/agents/tools/datetime.mdx
@@ -1,0 +1,15 @@
+---
+hide_table_of_contents: true
+---
+
+import CodeBlock from "@theme/CodeBlock";
+
+# Date Time Tool
+
+This tool empowers agents with the ability to determine the present date and time. Its usefulness lies in liberating models from the constraints of being stuck in a snapshot of the past, where they were originally trained.
+
+## Usage, standalone
+
+import ToolExample from "@examples/tools/datetime.ts";
+
+<CodeBlock language="typescript">{ToolExample}</CodeBlock>

--- a/examples/src/tools/datetime.ts
+++ b/examples/src/tools/datetime.ts
@@ -1,0 +1,12 @@
+import { DateTimeTool } from "langchain/tools/datetime";
+
+export async function run() {
+  const dateTimeTool = new DateTimeTool();
+
+  const result = await dateTimeTool.call({});
+
+  console.log(result);
+  /*
+  Current date time is Sun, 14 May 2023 09:54:18 GMT
+  */
+}

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -16,6 +16,9 @@ tools/aws_lambda.d.ts
 tools/calculator.cjs
 tools/calculator.js
 tools/calculator.d.ts
+tools/datetime.cjs
+tools/datetime.js
+tools/datetime.d.ts
 tools/webbrowser.cjs
 tools/webbrowser.js
 tools/webbrowser.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -28,6 +28,9 @@
     "tools/calculator.cjs",
     "tools/calculator.js",
     "tools/calculator.d.ts",
+    "tools/datetime.cjs",
+    "tools/datetime.js",
+    "tools/datetime.d.ts",
     "tools/webbrowser.cjs",
     "tools/webbrowser.js",
     "tools/webbrowser.d.ts",
@@ -579,6 +582,11 @@
       "types": "./tools/calculator.d.ts",
       "import": "./tools/calculator.js",
       "require": "./tools/calculator.cjs"
+    },
+    "./tools/datetime": {
+      "types": "./tools/datetime.d.ts",
+      "import": "./tools/datetime.js",
+      "require": "./tools/datetime.cjs"
     },
     "./tools/webbrowser": {
       "types": "./tools/webbrowser.d.ts",

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -16,6 +16,7 @@ const entrypoints = {
   tools: "tools/index",
   "tools/aws_lambda": "tools/aws_lambda",
   "tools/calculator": "tools/calculator",
+  "tools/datetime": "tools/datetime",
   "tools/webbrowser": "tools/webbrowser",
   // chains
   chains: "chains/index",

--- a/langchain/src/tools/datetime.ts
+++ b/langchain/src/tools/datetime.ts
@@ -1,0 +1,13 @@
+import { Tool } from "./base.js";
+
+export class DateTimeTool extends Tool {
+  name = "date-time";
+
+  description =
+    "Useful for getting the current date and time. No input is required.";
+
+  /** @ignore */
+  async _call(): Promise<string> {
+    return `Current date time is ${new Date().toUTCString()}`;
+  }
+}

--- a/langchain/src/tools/tests/datetime.test.ts
+++ b/langchain/src/tools/tests/datetime.test.ts
@@ -1,0 +1,23 @@
+import { it, expect, jest } from "@jest/globals";
+
+import { DateTimeTool } from "../datetime.js";
+
+describe("DateTimeTool", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2023-05-14"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should return the current date time", async () => {
+    const tool = new DateTimeTool();
+
+    const result = await tool.call({});
+
+    expect(result).toEqual(
+      "Current date time is Sun, 14 May 2023 00:00:00 GMT"
+    );
+  });
+});

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -38,6 +38,7 @@
       "src/tools/index.ts",
       "src/tools/aws_lambda.ts",
       "src/tools/calculator.ts",
+      "src/tools/datetime.ts",
       "src/tools/webbrowser.ts",
       "src/chains/index.ts",
       "src/chains/load.ts",

--- a/test-exports-cf/src/entrypoints.js
+++ b/test-exports-cf/src/entrypoints.js
@@ -1,6 +1,7 @@
 export * from "langchain/agents";
 export * from "langchain/base_language";
 export * from "langchain/tools";
+export * from "langchain/tools/datetime";
 export * from "langchain/chains";
 export * from "langchain/embeddings/base";
 export * from "langchain/embeddings/fake";

--- a/test-exports-cjs/src/entrypoints.js
+++ b/test-exports-cjs/src/entrypoints.js
@@ -1,6 +1,7 @@
 const agents = require("langchain/agents");
 const base_language = require("langchain/base_language");
 const tools = require("langchain/tools");
+const tools_datetime = require("langchain/tools/datetime");
 const chains = require("langchain/chains");
 const embeddings_base = require("langchain/embeddings/base");
 const embeddings_fake = require("langchain/embeddings/fake");

--- a/test-exports-cra/src/entrypoints.js
+++ b/test-exports-cra/src/entrypoints.js
@@ -1,6 +1,7 @@
 export * from "langchain/agents";
 export * from "langchain/base_language";
 export * from "langchain/tools";
+export * from "langchain/tools/datetime";
 export * from "langchain/chains";
 export * from "langchain/embeddings/base";
 export * from "langchain/embeddings/fake";

--- a/test-exports-esm/src/entrypoints.js
+++ b/test-exports-esm/src/entrypoints.js
@@ -1,6 +1,7 @@
 import * as agents from "langchain/agents";
 import * as base_language from "langchain/base_language";
 import * as tools from "langchain/tools";
+import * as tools_datetime from "langchain/tools/datetime";
 import * as chains from "langchain/chains";
 import * as embeddings_base from "langchain/embeddings/base";
 import * as embeddings_fake from "langchain/embeddings/fake";

--- a/test-exports-vercel/src/entrypoints.js
+++ b/test-exports-vercel/src/entrypoints.js
@@ -1,6 +1,7 @@
 export * from "langchain/agents";
 export * from "langchain/base_language";
 export * from "langchain/tools";
+export * from "langchain/tools/datetime";
 export * from "langchain/chains";
 export * from "langchain/embeddings/base";
 export * from "langchain/embeddings/fake";

--- a/test-exports-vite/src/entrypoints.js
+++ b/test-exports-vite/src/entrypoints.js
@@ -1,6 +1,7 @@
 export * from "langchain/agents";
 export * from "langchain/base_language";
 export * from "langchain/tools";
+export * from "langchain/tools/datetime";
 export * from "langchain/chains";
 export * from "langchain/embeddings/base";
 export * from "langchain/embeddings/fake";


### PR DESCRIPTION
This tool empowers agents with the ability to determine the present date and time.
Its usefulness lies in liberating models from the constraints of being stuck in a snapshot of the past, where they were originally trained.
