### PR TITLE
Fixed typo with example

### DIFF
--- a/docs/docs/modules/chains/other_chains/sql.mdx
+++ b/docs/docs/modules/chains/other_chains/sql.mdx
@@ -32,6 +32,6 @@ It can also reduce the number of tokens used in the chain.
 ```typescript
 const db = await SqlDatabase.fromDataSourceParams({
   appDataSource: datasource,
-  includeTables: ["Track"],
+  includesTables: ["Track"],
 });
 ```


### PR DESCRIPTION
I was checking out the `langchainjs` and found out that there was a typo in the example.