### PR TITLE
Fix env detection for Deno in Supabase Edge Functions

### DIFF
--- a/langchain/package.json
+++ b/langchain/package.json
@@ -524,7 +524,6 @@
     "@dqbd/tiktoken": "^1.0.7",
     "ansi-styles": "^5.0.0",
     "binary-extensions": "^2.2.0",
-    "browser-or-node": "^2.1.1",
     "expr-eval": "^2.0.2",
     "flat": "^5.0.2",
     "jsonpointer": "^5.0.1",

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -485,7 +485,7 @@ export class ChatOpenAI
       this.client = new OpenAIApi(clientConfig);
     }
     const axiosOptions = {
-      adapter: isNode ? undefined : fetchAdapter,
+      adapter: isNode() ? undefined : fetchAdapter,
       ...this.clientConfig.baseOptions,
       ...options,
     } as StreamingAxiosConfiguration;

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -1,4 +1,3 @@
-import { isNode } from "browser-or-node";
 import {
   Configuration,
   OpenAIApi,
@@ -8,6 +7,7 @@ import {
   ChatCompletionResponseMessageRoleEnum,
   ChatCompletionRequestMessage,
 } from "openai";
+import { isNode } from "../util/env.js";
 import {
   AzureOpenAIInput,
   OpenAICallOptions,

--- a/langchain/src/embeddings/openai.ts
+++ b/langchain/src/embeddings/openai.ts
@@ -176,7 +176,7 @@ export class OpenAIEmbeddings
         basePath: endpoint,
         baseOptions: {
           timeout: this.timeout,
-          adapter: isNode ? undefined : fetchAdapter,
+          adapter: isNode() ? undefined : fetchAdapter,
           ...this.clientConfig.baseOptions,
         },
       });

--- a/langchain/src/embeddings/openai.ts
+++ b/langchain/src/embeddings/openai.ts
@@ -4,8 +4,8 @@ import {
   CreateEmbeddingRequest,
   ConfigurationParameters,
 } from "openai";
-import { isNode } from "browser-or-node";
 import type { AxiosRequestConfig } from "axios";
+import { isNode } from "../util/env.js";
 import { AzureOpenAIInput } from "../types/openai-types.js";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
 import { chunkArray } from "../util/chunk.js";

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -1,4 +1,3 @@
-import { isNode } from "browser-or-node";
 import {
   Configuration,
   OpenAIApi,
@@ -8,6 +7,7 @@ import {
   ChatCompletionResponseMessageRoleEnum,
   CreateChatCompletionResponse,
 } from "openai";
+import { isNode } from "../util/env.js";
 import {
   AzureOpenAIInput,
   OpenAICallOptions,

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -368,7 +368,7 @@ export class OpenAIChat
       this.client = new OpenAIApi(clientConfig);
     }
     const axiosOptions = {
-      adapter: isNode ? undefined : fetchAdapter,
+      adapter: isNode() ? undefined : fetchAdapter,
       ...this.clientConfig.baseOptions,
       ...options,
     } as StreamingAxiosConfiguration;

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -430,7 +430,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput, AzureOpenAIInput {
       this.client = new OpenAIApi(clientConfig);
     }
     const axiosOptions: StreamingAxiosConfiguration = {
-      adapter: isNode ? undefined : fetchAdapter,
+      adapter: isNode() ? undefined : fetchAdapter,
       ...this.clientConfig.baseOptions,
       ...options,
     };

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -1,5 +1,4 @@
 import { TiktokenModel } from "@dqbd/tiktoken";
-import { isNode } from "browser-or-node";
 import {
   Configuration,
   ConfigurationParameters,
@@ -8,6 +7,7 @@ import {
   CreateCompletionResponseChoicesInner,
   OpenAIApi,
 } from "openai";
+import { isNode } from "../util/env.js";
 import {
   AzureOpenAIInput,
   OpenAICallOptions,

--- a/langchain/src/tools/webbrowser.ts
+++ b/langchain/src/tools/webbrowser.ts
@@ -1,6 +1,6 @@
 import axiosMod, { AxiosRequestConfig, AxiosStatic } from "axios";
-import { isNode } from "browser-or-node";
 import * as cheerio from "cheerio";
+import { isNode } from "../util/env.js";
 import { BaseLanguageModel } from "../base_language/index.js";
 import { RecursiveCharacterTextSplitter } from "../text_splitter.js";
 import { MemoryVectorStore } from "../vectorstores/memory.js";

--- a/langchain/src/tools/webbrowser.ts
+++ b/langchain/src/tools/webbrowser.ts
@@ -179,7 +179,7 @@ export class WebBrowser extends Tool {
     this.headers = headers || DEFAULT_HEADERS;
     this.axiosConfig = {
       withCredentials: true,
-      adapter: isNode ? undefined : fetchAdapter,
+      adapter: isNode() ? undefined : fetchAdapter,
       ...axiosConfig,
     };
   }

--- a/langchain/src/util/env.ts
+++ b/langchain/src/util/env.ts
@@ -9,15 +9,15 @@ declare global {
     | undefined;
 }
 
-export const isBrowser =
+export const isBrowser = () =>
   typeof window !== "undefined" && typeof window.document !== "undefined";
 
-export const isWebWorker =
+export const isWebWorker = () =>
   typeof globalThis === "object" &&
   globalThis.constructor &&
   globalThis.constructor.name === "DedicatedWorkerGlobalScope";
 
-export const isJsDom =
+export const isJsDom = () =>
   (typeof window !== "undefined" && window.name === "nodejs") ||
   (typeof navigator !== "undefined" &&
     (navigator.userAgent.includes("Node.js") ||
@@ -25,10 +25,10 @@ export const isJsDom =
 
 // Supabase Edge Function provides a `Deno` global object
 // without `version` property
-export const isDeno = typeof Deno !== "undefined";
+export const isDeno = () => typeof Deno !== "undefined";
 
 // Mark not-as-node if in Supabase Edge Function
-export const isNode =
+export const isNode = () =>
   typeof process !== "undefined" &&
   process.versions != null &&
   process.versions.node != null &&
@@ -36,15 +36,15 @@ export const isNode =
 
 export const getEnv = () => {
   let env: string;
-  if (isBrowser) {
+  if (isBrowser()) {
     env = "browser";
-  } else if (isNode) {
+  } else if (isNode()) {
     env = "node";
-  } else if (isWebWorker) {
+  } else if (isWebWorker()) {
     env = "webworker";
-  } else if (isJsDom) {
+  } else if (isJsDom()) {
     env = "jsdom";
-  } else if (isDeno) {
+  } else if (isDeno()) {
     env = "deno";
   } else {
     env = "other";

--- a/langchain/src/util/env.ts
+++ b/langchain/src/util/env.ts
@@ -1,10 +1,38 @@
-import {
-  isBrowser,
-  isNode,
-  isWebWorker,
-  isJsDom,
-  isDeno,
-} from "browser-or-node";
+// Inlined from https://github.com/flexdinesh/browser-or-node
+declare global {
+  const Deno:
+    | {
+        version: {
+          deno: string;
+        };
+      }
+    | undefined;
+}
+
+export const isBrowser =
+  typeof window !== "undefined" && typeof window.document !== "undefined";
+
+export const isWebWorker =
+  typeof globalThis === "object" &&
+  globalThis.constructor &&
+  globalThis.constructor.name === "DedicatedWorkerGlobalScope";
+
+export const isJsDom =
+  (typeof window !== "undefined" && window.name === "nodejs") ||
+  (typeof navigator !== "undefined" &&
+    (navigator.userAgent.includes("Node.js") ||
+      navigator.userAgent.includes("jsdom")));
+
+// Supabase Edge Function provides a `Deno` global object
+// without `version` property
+export const isDeno = typeof Deno !== "undefined";
+
+// Mark not-as-node if in Supabase Edge Function
+export const isNode =
+  typeof process !== "undefined" &&
+  process.versions != null &&
+  process.versions.node != null &&
+  !isDeno;
 
 export const getEnv = () => {
   let env: string;

--- a/langchain/src/util/env.ts
+++ b/langchain/src/util/env.ts
@@ -32,7 +32,7 @@ export const isNode = () =>
   typeof process !== "undefined" &&
   process.versions != null &&
   process.versions.node != null &&
-  !isDeno;
+  !isDeno();
 
 export const getEnv = () => {
   let env: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10196,13 +10196,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browser-or-node@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "browser-or-node@npm:2.1.1"
-  checksum: b1650b579345574d2c1905c73d385915a032523066ef9589036cf129b23b27b85096b6713476dffb88feb83cda798ed0774363e699117aa2724a0409adea25aa
-  languageName: node
-  linkType: hard
-
 "browser-process-hrtime@npm:^1.0.0":
   version: 1.0.0
   resolution: "browser-process-hrtime@npm:1.0.0"
@@ -18073,7 +18066,6 @@ __metadata:
     apify-client: ^2.7.1
     axios: ^0.26.0
     binary-extensions: ^2.2.0
-    browser-or-node: ^2.1.1
     cheerio: ^1.0.0-rc.12
     chromadb: ^1.4.0
     cohere-ai: ^5.0.2


### PR DESCRIPTION
Closes #1268

It does seem like Supabase Deno Functions only provides a global Deno functions _without_ `versions` property, which will mark `isDeno` as `false` and because of NodeJS compat, will mark `isNode` as `true`.

This PR aims to correct both of the properties, which is required to force the `axios-fetch-adapter` in these environments. 