### PR TITLE
Fix escaping of special characters in JsonListKeyTool

### DIFF
--- a/langchain/src/agents/tests/json.test.ts
+++ b/langchain/src/agents/tests/json.test.ts
@@ -29,6 +29,22 @@ test("JsonListKeysTool", async () => {
   expect(await jsonListKeysTool.call("/bar")).toContain("not a dictionary");
 });
 
+test("JsonListKeysTool, paths containing escaped characters", async () => {
+  const jsonSpec = new JsonSpec({
+    paths: {
+      "a~b": 1,
+      "a/b": 2,
+      "a~/b": 3,
+      "a//~b": 4,
+    },
+  });
+
+  const jsonListKeyTool = new JsonListKeysTool(jsonSpec);
+  expect(await jsonListKeyTool.call("/paths")).toBe(
+    "a~0b, a~1b, a~0~1b, a~1~1~0b"
+  );
+});
+
 test("JsonGetValueTool", async () => {
   const jsonSpec = new JsonSpec({
     foo: "bar",
@@ -72,4 +88,32 @@ test("JsonGetValueTool, large values", async () => {
   );
   expect(await jsonGetValueTool.call("/baz/test/foo")).toBe("[1,2,...");
   expect(await jsonGetValueTool.call("/baz/test/foo/0")).toBe("1");
+});
+
+test("JsonGetValueTool, paths containing escaped characters", async () => {
+  const jsonSpec = new JsonSpec({
+    paths: {
+      "~IDSGenericFXCrossRate": 1,
+      "/IDSGenericFXCrossRate": 2,
+      "~/IDSGenericFXCrossRate": 3,
+      "/~IDSGenericFXCrossRate": 4,
+    },
+  });
+
+  const jsonGetValueTool = new JsonGetValueTool(jsonSpec);
+  expect(await jsonGetValueTool.call("/paths/~0IDSGenericFXCrossRate")).toBe(
+    "1"
+  );
+
+  expect(await jsonGetValueTool.call("/paths/~1IDSGenericFXCrossRate")).toBe(
+    "2"
+  );
+
+  expect(await jsonGetValueTool.call("/paths/~0~1IDSGenericFXCrossRate")).toBe(
+    "3"
+  );
+
+  expect(await jsonGetValueTool.call("/paths/~1~0IDSGenericFXCrossRate")).toBe(
+    "4"
+  );
 });

--- a/langchain/src/tools/json.ts
+++ b/langchain/src/tools/json.ts
@@ -25,7 +25,9 @@ export class JsonSpec {
     const pointer = jsonpointer.compile(input);
     const res = pointer.get(this.obj) as Json;
     if (typeof res === "object" && !Array.isArray(res) && res !== null) {
-      return Object.keys(res).join(", ");
+      return Object.keys(res)
+        .map((i) => i.replaceAll("~", "~0").replaceAll("/", "~1"))
+        .join(", ");
     }
 
     throw new Error(


### PR DESCRIPTION
This PR addresses escaping special characters (`/` and `~`) when listing keys in JsonListKeyTool.

The following agent will now work properly:

```typescript
import { OpenAI } from "langchain/llms/openai";
import { JsonSpec, JsonObject } from "langchain/tools";
import { JsonToolkit, createJsonAgent } from "langchain/agents";

export const run = async () => {
  const data: JsonObject = {
    paths: {
      "/IDSGenericFXCrossRate": "32",
    },
  };

  const toolkit = new JsonToolkit(new JsonSpec(data));
  const model = new OpenAI({ temperature: 0 });
  const executor = createJsonAgent(model, toolkit);

  const input = `What is the value found in IDSGenericFXCrossRate?`;

  console.log(`Executing with input "${input}"...`);

  const result = await executor.call({ input });

  console.log(`Got output ${result.output}`);

  console.log(
    `Got intermediate steps ${JSON.stringify(
      result.intermediateSteps,
      null,
      2
    )}`
  );
};
```

Closes #1300