### PR TITLE
Handle incompatibility of `ChatOpenAI` with Azure OpenAI

### DIFF
--- a/langchain/src/util/event-source-parse.ts
+++ b/langchain/src/util/event-source-parse.ts
@@ -30,12 +30,22 @@ export interface EventSourceMessage {
  */
 export async function getBytes(
   stream: ReadableStream<Uint8Array>,
-  onChunk: (arr: Uint8Array) => void
+  onChunk: (arr: Uint8Array, flush?: boolean) => void
 ) {
   const reader = stream.getReader();
-  let result: ReadableStreamReadResult<Uint8Array>;
-  // eslint-disable-next-line no-cond-assign
-  while (!(result = await reader.read()).done) {
+
+  // CHANGED: Introduced a "flush" mechanism to process potential pending messages when the stream ends.
+  //          This change is essential to ensure that we capture every last piece of information from streams,
+  //          such as those from Azure OpenAI, which may not terminate with a blank line. Without this
+  //          mechanism, we risk ignoring a possibly significant last message.
+  //          See https://github.com/hwchase17/langchainjs/issues/1299 for details.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const result = await reader.read();
+    if (result.done) {
+      onChunk(new Uint8Array(), true);
+      break;
+    }
     onChunk(result.value);
   }
 }
@@ -54,7 +64,7 @@ const enum ControlChars {
  * @returns A function that should be called for each incoming byte chunk.
  */
 export function getLines(
-  onLine: (line: Uint8Array, fieldLength: number) => void
+  onLine: (line: Uint8Array, fieldLength: number, flush?: boolean) => void
 ) {
   let buffer: Uint8Array | undefined;
   let position: number; // current read position
@@ -62,7 +72,12 @@ export function getLines(
   let discardTrailingNewline = false;
 
   // return a function that can process each incoming byte chunk:
-  return function onChunk(arr: Uint8Array) {
+  return function onChunk(arr: Uint8Array, flush?: boolean) {
+    if (flush) {
+      onLine(arr, 0, true);
+      return;
+    }
+
     if (buffer === undefined) {
       buffer = arr;
       position = 0;
@@ -143,7 +158,19 @@ export function getMessages(
   const decoder = new TextDecoder();
 
   // return a function that can process each incoming line buffer:
-  return function onLine(line: Uint8Array, fieldLength: number) {
+  return function onLine(
+    line: Uint8Array,
+    fieldLength: number,
+    flush?: boolean
+  ) {
+    if (flush) {
+      if (!isEmpty(message)) {
+        onMessage?.(message);
+        message = newMessage();
+      }
+      return;
+    }
+
     if (line.length === 0) {
       // empty line denotes end of message. Trigger the callback and start a new message:
       onMessage?.(message);
@@ -200,4 +227,13 @@ function newMessage(): EventSourceMessage {
     id: "",
     retry: undefined,
   };
+}
+
+function isEmpty(message: EventSourceMessage): boolean {
+  return (
+    message.data === "" &&
+    message.event === "" &&
+    message.id === "" &&
+    message.retry === undefined
+  );
 }

--- a/langchain/src/util/tests/openai-stream.test.ts
+++ b/langchain/src/util/tests/openai-stream.test.ts
@@ -33,46 +33,56 @@ const mockFetchForOpenAIStream = async ({
   );
 
   let error: Error | null = null;
+  let done = false;
   const receivedChunks: Array<string> = [];
   const resp = await fetchAdapter({
     url: "https://example.com",
     method: "POST",
     responseType: "stream",
-    onmessage: (strChunk: { data: string }) => {
-      receivedChunks.push(
-        JSON.parse(strChunk.data).choices[0].delta.content ?? ""
-      );
+    onmessage: (event: { data: string }) => {
+      if (event.data?.trim?.() === "[DONE]") {
+        done = true;
+      } else {
+        receivedChunks.push(
+          JSON.parse(event.data).choices[0].delta.content ?? ""
+        );
+      }
     },
   } as unknown as never).catch((err) => {
     error = err;
     return null;
   });
 
-  return { resp, receivedChunks, error } as {
+  return { resp, receivedChunks, error, done } as {
     resp: AxiosResponse | null;
     receivedChunks: Array<string>;
     error: Error | null;
+    done: boolean;
   };
 };
 
 describe("OpenAI Stream Tests", () => {
   it("should return a 200 response chunk by chunk", async () => {
-    // When stream mode enabled, OpenAI responds with a stream of `data: {...}\n\n` chunks.
-    const { resp, receivedChunks, error } = await mockFetchForOpenAIStream({
-      status: 200,
-      contentType: "text/event-stream",
-      chunks: [
-        'data: {"choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}]}\n\n',
-        'data: {"choices":[{"delta":{"content":"Hello"},"index":0,"finish_reason":null}]}\n\n',
-        'data: {"choices":[{"delta":{"content":" World"},"index":0,"finish_reason":null}]}\n\n',
-        'data: {"choices":[{"delta":{"content":"!"},"index":0,"finish_reason":null}]}\n\n',
-        'data: {"choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}\n\n',
-      ],
-    });
+    // When stream mode enabled, OpenAI responds with a stream of `data: {...}\n\n` chunks
+    // followed by `data: [DONE]\n\n`.
+    const { resp, receivedChunks, error, done } =
+      await mockFetchForOpenAIStream({
+        status: 200,
+        contentType: "text/event-stream",
+        chunks: [
+          'data: {"choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}]}\n\n',
+          'data: {"choices":[{"delta":{"content":"Hello"},"index":0,"finish_reason":null}]}\n\n',
+          'data: {"choices":[{"delta":{"content":" World"},"index":0,"finish_reason":null}]}\n\n',
+          'data: {"choices":[{"delta":{"content":"!"},"index":0,"finish_reason":null}]}\n\n',
+          'data: {"choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}\n\n',
+          "data: [DONE]\n\n",
+        ],
+      });
 
     expect(error).toEqual(null);
     expect(resp?.status).toEqual(200);
     expect(receivedChunks).toEqual(["", "Hello", " World", "!", ""]);
+    expect(done).toBe(true);
   });
 
   it("should handle OpenAI 400 json error", async () => {


### PR DESCRIPTION
This pull request introduces several enhancements to the handling of event stream parsing. This pull request closes #1299.

In summary, the changes made include:

1. Fixing existing test cases to handle an additional 'done' flag, which ensures that all message chunks have been successfully processed from the stream.
2. Introducing a new test case designed to simulate the behaviour of Azure OpenAI's event streams. This case was initially expected to fail as it illustrated the problem of the last message being ignored due to the absence of a trailing blank line.
3. Implementing a 'flush' mechanism in the stream processing functions within `event-source-parse.ts`. This mechanism ensures that any pending messages are correctly processed when the stream ends, addressing the issue identified in the newly introduced test case.

These modifications are essential to ensuring complete and accurate processing of all messages, particularly from streams such as Azure OpenAI, which may not always terminate with a blank line.

By implementing these changes, we enhance the library's robustness in handling varying event stream behaviours across different platforms, making 'langchainjs' a more flexible and reliable tool for developers.