### PR TITLE
chore: remove useless code

### DIFF
--- a/langchain/src/chains/sql_db/sql_db_chain.ts
+++ b/langchain/src/chains/sql_db/sql_db_chain.ts
@@ -88,16 +88,13 @@ export class SqlDatabaseChain extends BaseChain {
     };
     await this.verifyNumberOfTokens(inputText, tableInfo);
 
-    const intermediateStep: string[] = [];
     const sqlCommand = await llmChain.predict(
       llmInputs,
       runManager?.getChild()
     );
-    intermediateStep.push(sqlCommand);
     let queryResult = "";
     try {
       queryResult = await this.database.appDataSource.query(sqlCommand);
-      intermediateStep.push(queryResult);
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
I found that after adding the sqlOutputKey, the intermediateStep had no effect, so I removed it