### PR TITLE
fix input keys in refine and stuff chains

### DIFF
--- a/langchain/src/chains/combine_docs_chain.ts
+++ b/langchain/src/chains/combine_docs_chain.ts
@@ -38,7 +38,7 @@ export class StuffDocumentsChain
 
   get inputKeys() {
     return [this.inputKey, ...this.llmChain.inputKeys].filter(
-      (key) => key != this.documentVariableName
+      (key) => key !== this.documentVariableName
     );
   }
 
@@ -304,7 +304,7 @@ export class RefineDocumentsChain
       ]),
     ].filter(
       (key) =>
-        key != this.documentVariableName && key != this.initialResponseName
+        key !== this.documentVariableName && key !== this.initialResponseName
     );
   }
 

--- a/langchain/src/chains/combine_docs_chain.ts
+++ b/langchain/src/chains/combine_docs_chain.ts
@@ -37,7 +37,9 @@ export class StuffDocumentsChain
   documentVariableName = "context";
 
   get inputKeys() {
-    return [this.inputKey, ...this.llmChain.inputKeys];
+    return [this.inputKey, ...this.llmChain.inputKeys].filter(
+      (key) => key != this.documentVariableName
+    );
   }
 
   get outputKeys() {
@@ -294,7 +296,16 @@ export class RefineDocumentsChain
   documentPrompt = this.defaultDocumentPrompt;
 
   get inputKeys() {
-    return [this.inputKey, ...this.refineLLMChain.inputKeys];
+    return [
+      ...new Set([
+        this.inputKey,
+        ...this.llmChain.inputKeys,
+        ...this.refineLLMChain.inputKeys,
+      ]),
+    ].filter(
+      (key) =>
+        key != this.documentVariableName && key != this.initialResponseName
+    );
   }
 
   get outputKeys() {

--- a/langchain/src/chains/tests/combine_docs_chain.test.ts
+++ b/langchain/src/chains/tests/combine_docs_chain.test.ts
@@ -3,6 +3,7 @@ import { Document } from "../../document.js";
 import { BaseLLM } from "../../llms/base.js";
 import { loadQAMapReduceChain } from "../question_answering/load.js";
 import { LLMResult } from "../../schema/index.js";
+import { loadSummarizationChain } from "../index.js";
 
 class FakeLLM extends BaseLLM {
   nrMapCalls = 0;
@@ -103,4 +104,18 @@ test("Test MapReduceDocumentsChain with content above maxTokens and intermediate
   });
   expect(model.nrMapCalls).toBe(2); // above maxTokens
   expect(model.nrReduceCalls).toBe(1);
+});
+
+test("Test RefineDocumentsChain", async () => {
+  const model = new FakeLLM({});
+  const chain = loadSummarizationChain(model, { type: "refine" });
+  const docs = [
+    new Document({ pageContent: "harrison went to harvard" }),
+    new Document({ pageContent: "ankush went to princeton" }),
+  ];
+
+  expect(chain.inputKeys).toEqual(["input_documents"]);
+
+  const res = await chain.run(docs);
+  console.log({ res });
 });


### PR DESCRIPTION
In the refine and stuff chain the input keys are the input keys of the llm chains used and the input key of the chain. This causes issues because in these chains some of the inputs to the llm chain are given by the chain: 

```typescript
const model = new OpenAI({ temperature: 0 });
const chain = loadSummarizationChain(model, { type: "refine" });
const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
const docs = await textSplitter.createDocuments(["test"]);

console.log(chain.inputKeys)
// ['input_documents', 'existing_answer', 'text']. Should be ['input_documents']

console.log(await chain.call({"input_documents":docs}))
// output_text: Test is a process used to evaluate a syst…termine its performance and functionality.'

console.log(await chain.run(docs))
// Uncaught Error Error: Chain refine_documents_chain expects multiple inputs, cannot use 'run' 
```

This fixes the bug by filtering out the input keys of the llm chains added by the refine and stuff chains and adds a test for the refine chain.