### PR TITLE
Update tracer to use new simpler api

### DIFF
--- a/langchain/src/callbacks/handlers/tracer_langchain.ts
+++ b/langchain/src/callbacks/handlers/tracer_langchain.ts
@@ -97,8 +97,10 @@ export class LangChainTracer
       body: JSON.stringify(persistedRun),
       signal: AbortSignal.timeout(this.timeout),
     });
+    // consume the response body to release the connection
+    // https://undici.nodejs.org/#/?id=garbage-collection
+    const body = await response.text();
     if (!response.ok) {
-      const body = await response.text();
       throw new Error(
         `Failed to persist run: ${response.status} ${response.statusText} ${body}`
       );

--- a/langchain/src/callbacks/handlers/tracer_langchain.ts
+++ b/langchain/src/callbacks/handlers/tracer_langchain.ts
@@ -7,32 +7,14 @@ import { BaseTracer, Run, BaseRun } from "./tracer.js";
 
 export interface RunCreate extends BaseRun {
   child_runs: this[];
-  session_id: string; // uuid
-}
-
-export interface BaseTracerSession {
-  start_time: number;
-  name?: string;
-}
-
-export interface BaseTracerSessionV2 extends BaseTracerSession {
-  tenant_id: string; // uuid
-}
-
-export interface TracerSessionCreateV2 extends BaseTracerSessionV2 {
-  id?: string; // uuid. Auto-generated if not provided
-}
-
-export interface TracerSession extends BaseTracerSessionV2 {
-  id: string; // uuid
+  session_name?: string;
 }
 
 export interface LangChainTracerFields {
   exampleId?: string;
-  tenantId?: string;
   sessionName?: string;
-  sessionExtra?: Record<string, unknown>;
   callerParams?: AsyncCallerParams;
+  timeout?: number;
 }
 
 export class LangChainTracer
@@ -48,24 +30,19 @@ export class LangChainTracer
     "Content-Type": "application/json",
   };
 
-  sessionName: string;
-
-  sessionExtra?: LangChainTracerFields["sessionExtra"];
-
-  protected session: TracerSession;
+  sessionName?: string;
 
   exampleId?: string;
 
-  tenantId?: string;
-
   caller: AsyncCaller;
+
+  timeout = 5000;
 
   constructor({
     exampleId,
-    tenantId,
     sessionName,
-    sessionExtra,
     callerParams,
+    timeout,
   }: LangChainTracerFields = {}) {
     super();
 
@@ -74,71 +51,17 @@ export class LangChainTracer
       this.headers["x-api-key"] = apiKey;
     }
 
-    this.tenantId = tenantId ?? getEnvironmentVariable("LANGCHAIN_TENANT_ID");
     this.sessionName =
-      sessionName ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? "default";
-    this.sessionExtra = sessionExtra;
+      sessionName ?? getEnvironmentVariable("LANGCHAIN_SESSION");
     this.exampleId = exampleId;
-    this.caller = new AsyncCaller(callerParams ?? {});
-  }
-
-  protected async ensureSession(): Promise<TracerSession> {
-    if (this.session) {
-      return this.session;
-    }
-    const tenantId = await this.ensureTenantId();
-    const endpoint = `${this.endpoint}/sessions?upsert=true`;
-    const res = await this.caller.call(fetch, endpoint, {
-      method: "POST",
-      headers: this.headers,
-      body: JSON.stringify({
-        name: this.sessionName,
-        tenant_id: tenantId,
-        extra: this.sessionExtra,
-      }),
-    });
-    if (!res.ok) {
-      const body = await res.text();
-      throw new Error(
-        `Failed to create session: ${res.status} ${res.statusText} ${body}`
-      );
-    }
-    const session = await res.json();
-    this.session = session;
-    return session;
-  }
-
-  protected async ensureTenantId(): Promise<string> {
-    if (this.tenantId) {
-      return this.tenantId;
-    }
-    const endpoint = `${this.endpoint}/tenants`;
-    const response = await this.caller.call(fetch, endpoint, {
-      method: "GET",
-      headers: this.headers,
-    });
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(
-        `Failed to fetch tenant ID: ${response.status} ${response.statusText} ${body}`
-      );
-    }
-
-    const tenants = await response.json();
-    if (!tenants || tenants.length === 0) {
-      throw new Error(`No tenants found for endpoint ${endpoint}`);
-    }
-
-    const tenantId = tenants[0].id;
-    this.tenantId = tenantId;
-    return tenantId;
+    this.timeout = timeout ?? this.timeout;
+    this.caller = new AsyncCaller(callerParams ?? { maxRetries: 2 });
   }
 
   private async _convertToCreate(
     run: Run,
     example_id: string | undefined = undefined
   ): Promise<RunCreate> {
-    const session = await this.ensureSession();
     const runExtra = run.extra ?? {};
     runExtra.runtime = await getRuntimeEnvironment();
     const persistedRun: RunCreate = {
@@ -154,7 +77,7 @@ export class LangChainTracer
       error: run.error,
       inputs: run.inputs,
       outputs: run.outputs ?? {},
-      session_id: session.id,
+      session_name: this.sessionName,
       child_runs: await Promise.all(
         run.child_runs.map((child_run) => this._convertToCreate(child_run))
       ),
@@ -172,6 +95,7 @@ export class LangChainTracer
       method: "POST",
       headers: this.headers,
       body: JSON.stringify(persistedRun),
+      signal: AbortSignal.timeout(this.timeout),
     });
     if (!response.ok) {
       const body = await response.text();

--- a/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
+++ b/langchain/src/callbacks/tests/langchain_tracer.int.test.ts
@@ -13,7 +13,6 @@ import { ChatOpenAI } from "../../chat_models/openai.js";
 test("Test LangChain V2 tracer", async () => {
   const tracer = new LangChainTracer({
     sessionName: `JS Int Test - ${uuid.v4()}`,
-    sessionExtra: { source: "langchain-js" },
   });
   const chainRunId = uuid.v4();
   const toolRunId = uuid.v4();

--- a/langchain/src/callbacks/tests/tracer.test.ts
+++ b/langchain/src/callbacks/tests/tracer.test.ts
@@ -1,14 +1,8 @@
 import { test, expect, jest } from "@jest/globals";
 import * as uuid from "uuid";
 import { BaseTracer, Run } from "../handlers/tracer.js";
-import {
-  TracerSession,
-  TracerSessionCreateV2,
-} from "../handlers/tracer_langchain.js";
 import { HumanChatMessage } from "../../schema/index.js";
 
-const TEST_SESSION_ID = `32f2a267-b052-4c45-8c9f-ae5558c94a6a`;
-const TENANT_ID = `531d2426-49c4-40f4-b2c7-775aef1db176`;
 const _DATE = 1620000000000;
 
 Date.now = jest.fn(() => _DATE);
@@ -25,33 +19,6 @@ class FakeTracer extends BaseTracer {
   protected persistRun(run: Run): Promise<void> {
     this.runs.push(run);
     return Promise.resolve();
-  }
-
-  protected persistSession(
-    session: TracerSessionCreateV2
-  ): Promise<TracerSession> {
-    return Promise.resolve({
-      id: TEST_SESSION_ID,
-      ...session,
-    });
-  }
-
-  async loadSession(sessionName: string): Promise<TracerSession> {
-    return Promise.resolve({
-      id: TEST_SESSION_ID,
-      name: sessionName,
-      start_time: _DATE,
-      tenant_id: TENANT_ID,
-    });
-  }
-
-  async loadDefaultSession(): Promise<TracerSession> {
-    return Promise.resolve({
-      id: TEST_SESSION_ID,
-      name: "default",
-      start_time: _DATE,
-      tenant_id: TENANT_ID,
-    });
   }
 }
 

--- a/langchain/src/client/langchainplus.ts
+++ b/langchain/src/client/langchainplus.ts
@@ -226,12 +226,15 @@ export class LangChainPlusClient {
       headers: this.headers,
       signal: AbortSignal.timeout(this.timeout),
     });
+    // consume the response body to release the connection
+    // https://undici.nodejs.org/#/?id=garbage-collection
+    const json = await response.json();
     if (!response.ok) {
       throw new Error(
         `Failed to fetch ${path}: ${response.status} ${response.statusText}`
       );
     }
-    return response.json() as T;
+    return json as T;
   }
 
   public async readRun(runId: string): Promise<Run> {
@@ -332,9 +335,10 @@ export class LangChainPlusClient {
       body: formData,
       signal: AbortSignal.timeout(this.timeout),
     });
-
+    // consume the response body to release the connection
+    // https://undici.nodejs.org/#/?id=garbage-collection
+    const result = await response.json();
     if (!response.ok) {
-      const result = await response.json();
       if (result.detail && result.detail.includes("already exists")) {
         throw new Error(`Dataset ${fileName} already exists`);
       }
@@ -342,8 +346,6 @@ export class LangChainPlusClient {
         `Failed to upload CSV: ${response.status} ${response.statusText}`
       );
     }
-
-    const result = await response.json();
     return result as Dataset;
   }
 
@@ -360,9 +362,10 @@ export class LangChainPlusClient {
       }),
       signal: AbortSignal.timeout(this.timeout),
     });
-
+    // consume the response body to release the connection
+    // https://undici.nodejs.org/#/?id=garbage-collection
+    const result = await response.json();
     if (!response.ok) {
-      const result = await response.json();
       if (result.detail && result.detail.includes("already exists")) {
         throw new Error(`Dataset ${name} already exists`);
       }
@@ -370,8 +373,6 @@ export class LangChainPlusClient {
         `Failed to create dataset ${response.status} ${response.statusText}`
       );
     }
-
-    const result = await response.json();
     return result as Dataset;
   }
 
@@ -450,12 +451,14 @@ export class LangChainPlusClient {
       headers: this.headers,
       signal: AbortSignal.timeout(this.timeout),
     });
+    // consume the response body to release the connection
+    // https://undici.nodejs.org/#/?id=garbage-collection
+    const results = await response.json();
     if (!response.ok) {
       throw new Error(
         `Failed to delete ${path}: ${response.status} ${response.statusText}`
       );
     }
-    const results = await response.json();
     return results as Dataset;
   }
 
@@ -496,14 +499,14 @@ export class LangChainPlusClient {
       body: JSON.stringify(data),
       signal: AbortSignal.timeout(this.timeout),
     });
-
+    // consume the response body to release the connection
+    // https://undici.nodejs.org/#/?id=garbage-collection
+    const result = await response.json();
     if (!response.ok) {
       throw new Error(
         `Failed to create example: ${response.status} ${response.statusText}`
       );
     }
-
-    const result = await response.json();
     return result as Example;
   }
 
@@ -549,12 +552,14 @@ export class LangChainPlusClient {
       headers: this.headers,
       signal: AbortSignal.timeout(this.timeout),
     });
+    // consume the response body to release the connection
+    // https://undici.nodejs.org/#/?id=garbage-collection
+    const result = await response.json();
     if (!response.ok) {
       throw new Error(
         `Failed to delete ${path}: ${response.status} ${response.statusText}`
       );
     }
-    const result = await response.json();
     return result as Example;
   }
 

--- a/langchain/src/client/langchainplus.ts
+++ b/langchain/src/client/langchainplus.ts
@@ -1,8 +1,5 @@
 import { BaseRun, Run, RunType } from "../callbacks/handlers/tracer.js";
-import {
-  LangChainTracer,
-  TracerSession,
-} from "../callbacks/handlers/tracer_langchain.js";
+import { LangChainTracer } from "../callbacks/handlers/tracer_langchain.js";
 import {
   ChainValues,
   LLMResult,
@@ -17,6 +14,12 @@ import { BaseChatModel } from "../chat_models/base.js";
 import { mapStoredMessagesToChatMessages } from "../stores/message/utils.js";
 import { AsyncCaller, AsyncCallerParams } from "../util/async_caller.js";
 import { getEnvironmentVariable } from "../util/env.js";
+
+export interface TracerSession {
+  id: string;
+  tenant_id: string;
+  name: string;
+}
 
 export interface RunResult extends BaseRun {
   name: string;
@@ -79,46 +82,11 @@ const isLocalhost = (url: string): boolean => {
   const strippedUrl = url.replace("http://", "").replace("https://", "");
   const hostname = strippedUrl.split("/")[0].split(":")[0];
   return (
-    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1"
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname === "0.0.0.0"
   );
-};
-
-const getSeededTenantId = async (
-  apiUrl: string,
-  {
-    apiKey,
-    callerOptions,
-  }: { apiKey?: string; callerOptions?: AsyncCallerParams }
-): Promise<string> => {
-  // Get the tenant ID from the seeded tenant
-  const caller = new AsyncCaller(callerOptions ?? {});
-  const url = `${apiUrl}/tenants`;
-  let response;
-
-  try {
-    response = await caller.call(fetch, url, {
-      method: "GET",
-      headers: apiKey ? { "x-api-key": apiKey } : undefined,
-    });
-  } catch (err) {
-    throw new Error("Unable to get seeded tenant ID. Please manually provide.");
-  }
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch seeded tenant ID: ${response.status} ${response.statusText}`
-    );
-  }
-  const tenants = await response.json();
-  if (!Array.isArray(tenants)) {
-    throw new Error(
-      `Expected tenants GET request to return an array, but got ${tenants}`
-    );
-  }
-  if (tenants.length === 0) {
-    throw new Error("No seeded tenant found");
-  }
-
-  return tenants[0].id;
 };
 
 const stringifyError = (err: Error | unknown): string => {
@@ -189,28 +157,20 @@ export class LangChainPlusClient {
   private apiUrl =
     getEnvironmentVariable("LANGCHAIN_ENDPOINT") || "http://localhost:1984";
 
-  private tenantId: string;
-
   private caller: AsyncCaller;
 
+  private timeout = 10000;
+
   constructor(config: {
-    tenantId?: string;
     apiUrl?: string;
     apiKey?: string;
+    timeout?: number;
     callerOptions?: AsyncCallerParams;
   }) {
     this.apiUrl = config.apiUrl ?? this.apiUrl;
     this.apiKey = config.apiKey;
-    const tenantId =
-      config.tenantId ?? getEnvironmentVariable("LANGCHAIN_TENANT_ID");
-    if (tenantId === undefined) {
-      throw new Error(
-        "No tenant ID provided and no LANGCHAIN_TENANT_ID env var"
-      );
-    } else {
-      this.tenantId = tenantId;
-    }
     this.validateApiKeyIfHosted();
+    this.timeout = config.timeout ?? this.timeout;
     this.caller = new AsyncCaller(config.callerOptions ?? {});
   }
 
@@ -218,7 +178,6 @@ export class LangChainPlusClient {
     config: {
       apiUrl?: string;
       apiKey?: string;
-      tenantId?: string;
     } = {}
   ): Promise<LangChainPlusClient> {
     const apiUrl_ =
@@ -226,12 +185,7 @@ export class LangChainPlusClient {
       (getEnvironmentVariable("LANGCHAIN_ENDPOINT") || "http://localhost:1984");
     const apiKey_ =
       config.apiKey ?? getEnvironmentVariable("LANGCHAIN_API_KEY");
-    const tenantId_ =
-      config.tenantId ??
-      (getEnvironmentVariable("LANGCHAIN_TENANT_ID") ||
-        (await getSeededTenantId(apiUrl_, { apiKey: apiKey_ })));
     return new LangChainPlusClient({
-      tenantId: tenantId_,
       apiKey: apiKey_,
       apiUrl: apiUrl_,
     });
@@ -254,24 +208,23 @@ export class LangChainPlusClient {
     return headers;
   }
 
-  private get queryParams(): URLSearchParams {
-    return new URLSearchParams({ tenant_id: this.tenantId });
-  }
-
   private async _get<T>(
     path: string,
     queryParams?: URLSearchParams
   ): Promise<T> {
-    const params = this.queryParams;
+    const params = new URLSearchParams();
     if (queryParams) {
       queryParams.forEach((value, key) => {
         params.append(key, value);
       });
     }
-    const url = `${this.apiUrl}${path}?${params.toString()}`;
+    const url = params.toString()
+      ? `${this.apiUrl}${path}?${params.toString()}`
+      : `${this.apiUrl}${path}`;
     const response = await this.caller.call(fetch, url, {
       method: "GET",
       headers: this.headers,
+      signal: AbortSignal.timeout(this.timeout),
     });
     if (!response.ok) {
       throw new Error(
@@ -369,7 +322,6 @@ export class LangChainPlusClient {
     formData.append("file", csvFile, fileName);
     formData.append("input_keys", inputKeys.join(","));
     formData.append("output_keys", outputKeys.join(","));
-    formData.append("tenant_id", this.tenantId);
     if (description) {
       formData.append("description", description);
     }
@@ -378,6 +330,7 @@ export class LangChainPlusClient {
       method: "POST",
       headers: this.headers,
       body: formData,
+      signal: AbortSignal.timeout(this.timeout),
     });
 
     if (!response.ok) {
@@ -404,8 +357,8 @@ export class LangChainPlusClient {
       body: JSON.stringify({
         name,
         description,
-        tenant_id: this.tenantId,
       }),
+      signal: AbortSignal.timeout(this.timeout),
     });
 
     if (!response.ok) {
@@ -495,6 +448,7 @@ export class LangChainPlusClient {
     const response = await this.caller.call(fetch, this.apiUrl + path, {
       method: "DELETE",
       headers: this.headers,
+      signal: AbortSignal.timeout(this.timeout),
     });
     if (!response.ok) {
       throw new Error(
@@ -540,6 +494,7 @@ export class LangChainPlusClient {
       method: "POST",
       headers: { ...this.headers, "Content-Type": "application/json" },
       body: JSON.stringify(data),
+      signal: AbortSignal.timeout(this.timeout),
     });
 
     if (!response.ok) {
@@ -592,6 +547,7 @@ export class LangChainPlusClient {
     const response = await this.caller.call(fetch, this.apiUrl + path, {
       method: "DELETE",
       headers: this.headers,
+      signal: AbortSignal.timeout(this.timeout),
     });
     if (!response.ok) {
       throw new Error(


### PR DESCRIPTION
- Remove GET /tenants as the API will infer the tenant_id from the api key
- Remove session creation as POST /runs now accepts session name
- Add timeout (default to 5s), limit retries to 2
- Update Client in the same vein