### PR TITLE
Allow passing Anthropic apiUrl to ChatAnthropic constructor

### DIFF
--- a/langchain/src/chat_models/anthropic.ts
+++ b/langchain/src/chat_models/anthropic.ts
@@ -108,6 +108,8 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
 
   apiKey?: string;
 
+  apiUrl?: string;
+
   temperature = 1;
 
   topK = -1;
@@ -134,6 +136,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     fields?: Partial<AnthropicInput> &
       BaseChatModelParams & {
         anthropicApiKey?: string;
+        anthropicApiUrl?: string;
       }
   ) {
     super(fields ?? {});
@@ -147,6 +150,9 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     if (!this.apiKey) {
       throw new Error("Anthropic API key not found");
     }
+
+    // Support overriding the default API URL (i.e., https://api.anthropic.com)
+    this.apiUrl = fields?.anthropicApiUrl;
 
     this.modelName = fields?.modelName ?? this.modelName;
     this.invocationKwargs = fields?.invocationKwargs ?? {};
@@ -258,7 +264,8 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     let makeCompletionRequest;
     if (request.stream) {
       if (!this.streamingClient) {
-        this.streamingClient = new AnthropicApi(this.apiKey);
+        const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
+        this.streamingClient = new AnthropicApi(this.apiKey, options);
       }
       makeCompletionRequest = async () => {
         let currentCompletion = "";
@@ -292,7 +299,8 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
       };
     } else {
       if (!this.batchClient) {
-        this.batchClient = new AnthropicApi(this.apiKey);
+        const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
+        this.batchClient = new AnthropicApi(this.apiKey, options);
       }
       makeCompletionRequest = async () =>
         this.batchClient

--- a/langchain/src/chat_models/tests/chatanthropic.int.test.ts
+++ b/langchain/src/chat_models/tests/chatanthropic.int.test.ts
@@ -175,3 +175,15 @@ test("ChatAnthropic, longer chain of messages", async () => {
 
   console.log(responseA.generations);
 });
+
+test("ChatAnthropic, Anthropic apiUrl set manually via constructor", async () => {
+  // Pass the default URL through (should use this, and work as normal)
+  const anthropicApiUrl = "https://api.anthropic.com";
+  const chat = new ChatAnthropic({
+    modelName: "claude-instant-v1",
+    anthropicApiUrl,
+  });
+  const message = new HumanChatMessage("Hello!");
+  const res = await chat.call([message]);
+  console.log({ res });
+});


### PR DESCRIPTION
Fixes #1255 

This updates `ChatAnthropic` to support passing an overridden `apiUrl` through to `anthropic-sdk-typescript`.  The default API URL is defined here:

https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/index.ts#L22

The Anthropic `Client` allows passing an `apiUrl` on an `options` object:

https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/index.ts#L42