### PR TITLE
fix: broken links in agent docs

### DIFF
--- a/docs/docs/modules/agents/agents/index.mdx
+++ b/docs/docs/modules/agents/agents/index.mdx
@@ -17,10 +17,10 @@ An agent is a stateless wrapper around an agent prompt chain (such as MRKL) whic
 
 The agent you choose depends on the type of task you want to perform. Here's a quick guide to help you pick the right agent for your use case:
 
-- If you're using a text LLM, first try `zero-shot-react-description`, aka. the [MRKL agent for LLMs](./action/llm_mrkl).
-- If you're using a Chat Model, try `chat-zero-shot-react-description`, aka. the [MRKL agent for Chat Models](./action/chat_mrkl).
-- If you're using a Chat Model and want to use memory, try `chat-conversational-react-description`, the [Conversational agent](./action/conversational_agent).
-- If you have a complex task that requires many steps and you're interested in experimenting with a new type of agent, try the [Plan-and-Execute agent](./plan_execute/).
+- If you're using a text LLM, first try `zero-shot-react-description`, aka. the [MRKL agent for LLMs](./agents/action/llm_mrkl).
+- If you're using a Chat Model, try `chat-zero-shot-react-description`, aka. the [MRKL agent for Chat Models](./agents/action/chat_mrkl).
+- If you're using a Chat Model and want to use memory, try `chat-conversational-react-description`, the [Conversational agent](./agents/action/conversational_agent).
+- If you have a complex task that requires many steps and you're interested in experimenting with a new type of agent, try the [Plan-and-Execute agent](./agents/plan_execute/).
 
 ## All Agents
 


### PR DESCRIPTION
The links in the index page of the agents docs were broken and redirected to a 404 page. This fixes that.