### PR TITLE
Factor out and wrap environment variable access in a try/catch

### DIFF
--- a/langchain/src/callbacks/handlers/tracer_langchain.ts
+++ b/langchain/src/callbacks/handlers/tracer_langchain.ts
@@ -1,5 +1,8 @@
 import { AsyncCaller, AsyncCallerParams } from "../../util/async_caller.js";
-import { getRuntimeEnvironment } from "../../util/env.js";
+import {
+  getEnvironmentVariable,
+  getRuntimeEnvironment,
+} from "../../util/env.js";
 import { BaseTracer, Run, BaseRun } from "./tracer.js";
 
 export interface RunCreate extends BaseRun {
@@ -39,10 +42,7 @@ export class LangChainTracer
   name = "langchain_tracer";
 
   protected endpoint =
-    (typeof process !== "undefined"
-      ? // eslint-disable-next-line no-process-env
-        process.env?.LANGCHAIN_ENDPOINT
-      : undefined) || "http://localhost:1984";
+    getEnvironmentVariable("LANGCHAIN_ENDPOINT") || "http://localhost:1984";
 
   protected headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -69,25 +69,14 @@ export class LangChainTracer
   }: LangChainTracerFields = {}) {
     super();
 
-    // eslint-disable-next-line no-process-env
-    if (typeof process !== "undefined" && process.env?.LANGCHAIN_API_KEY) {
-      // eslint-disable-next-line no-process-env
-      this.headers["x-api-key"] = process.env?.LANGCHAIN_API_KEY;
+    const apiKey = getEnvironmentVariable("LANGCHAIN_API_KEY");
+    if (apiKey) {
+      this.headers["x-api-key"] = apiKey;
     }
 
-    this.tenantId =
-      tenantId ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.LANGCHAIN_TENANT_ID
-        : undefined);
+    this.tenantId = tenantId ?? getEnvironmentVariable("LANGCHAIN_TENANT_ID");
     this.sessionName =
-      sessionName ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.LANGCHAIN_SESSION
-        : undefined) ??
-      "default";
+      sessionName ?? getEnvironmentVariable("LANGCHAIN_SESSION") ?? "default";
     this.sessionExtra = sessionExtra;
     this.exampleId = exampleId;
     this.caller = new AsyncCaller(callerParams ?? {});

--- a/langchain/src/callbacks/handlers/tracer_langchain_v1.ts
+++ b/langchain/src/callbacks/handlers/tracer_langchain_v1.ts
@@ -1,5 +1,6 @@
 import { getBufferString } from "../../memory/base.js";
 import { BaseChatMessage, ChainValues, LLMResult } from "../../schema/index.js";
+import { getEnvironmentVariable } from "../../util/env.js";
 
 import { BaseTracer, RunType, Run } from "./tracer.js";
 
@@ -53,10 +54,7 @@ export class LangChainTracerV1 extends BaseTracer {
   name = "langchain_tracer";
 
   protected endpoint =
-    (typeof process !== "undefined"
-      ? // eslint-disable-next-line no-process-env
-        process.env?.LANGCHAIN_ENDPOINT
-      : undefined) || "http://localhost:1984";
+    getEnvironmentVariable("LANGCHAIN_ENDPOINT") || "http://localhost:1984";
 
   protected headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -66,10 +64,9 @@ export class LangChainTracerV1 extends BaseTracer {
 
   constructor() {
     super();
-    // eslint-disable-next-line no-process-env
-    if (typeof process !== "undefined" && process.env?.LANGCHAIN_API_KEY) {
-      // eslint-disable-next-line no-process-env
-      this.headers["x-api-key"] = process.env?.LANGCHAIN_API_KEY;
+    const apiKey = getEnvironmentVariable("LANGCHAIN_API_KEY");
+    if (apiKey) {
+      this.headers["x-api-key"] = apiKey;
     }
   }
 

--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -13,6 +13,7 @@ import {
   getTracingV2CallbackHandler,
 } from "./handlers/initialize.js";
 import { getBufferString } from "../memory/base.js";
+import { getEnvironmentVariable } from "../util/env.js";
 
 type BaseCallbackManagerMethods = {
   [K in keyof CallbackHandlerMethods]?: (
@@ -506,21 +507,12 @@ export class CallbackManager
       );
     }
     const verboseEnabled =
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.LANGCHAIN_VERBOSE !== undefined
-        : false) || options?.verbose;
+      getEnvironmentVariable("LANGCHAIN_VERBOSE") || options?.verbose;
     const tracingV2Enabled =
-      typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.LANGCHAIN_TRACING_V2 !== undefined
-        : false;
+      getEnvironmentVariable("LANGCHAIN_TRACING_V2") ?? false;
     const tracingEnabled =
       tracingV2Enabled ||
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.LANGCHAIN_TRACING !== undefined
-        : false);
+      (getEnvironmentVariable("LANGCHAIN_TRACING") ?? false);
     if (verboseEnabled || tracingEnabled) {
       if (!callbackManager) {
         callbackManager = new CallbackManager();
@@ -543,11 +535,7 @@ export class CallbackManager
         if (tracingV2Enabled) {
           callbackManager.addHandler(await getTracingV2CallbackHandler(), true);
         } else {
-          const session =
-            typeof process !== "undefined"
-              ? // eslint-disable-next-line no-process-env
-                process.env?.LANGCHAIN_SESSION
-              : undefined;
+          const session = getEnvironmentVariable("LANGCHAIN_SESSION");
           callbackManager.addHandler(
             await getTracingCallbackHandler(session),
             true

--- a/langchain/src/chains/openai_moderation.ts
+++ b/langchain/src/chains/openai_moderation.ts
@@ -9,6 +9,7 @@ import { BaseChain, ChainInputs } from "./base.js";
 import { ChainValues } from "../schema/index.js";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
 import { AsyncCaller, AsyncCallerParams } from "../util/async_caller.js";
+import { getEnvironmentVariable } from "../util/env.js";
 
 export interface OpenAIModerationChainInput
   extends ChainInputs,
@@ -43,9 +44,7 @@ export class OpenAIModerationChain
     super(fields);
     this.throwError = fields?.throwError ?? false;
     this.openAIApiKey =
-      fields?.openAIApiKey ??
-      // eslint-disable-next-line no-process-env
-      (typeof process !== "undefined" ? process.env.OPENAI_API_KEY : undefined);
+      fields?.openAIApiKey ?? getEnvironmentVariable("OPENAI_API_KEY");
 
     if (!this.openAIApiKey) {
       throw new Error("OpenAI API key not found");

--- a/langchain/src/chat_models/anthropic.ts
+++ b/langchain/src/chat_models/anthropic.ts
@@ -15,6 +15,7 @@ import {
 } from "../schema/index.js";
 import { CallbackManagerForLLMRun } from "../callbacks/manager.js";
 import { BaseLanguageModelCallOptions } from "../base_language/index.js";
+import { getEnvironmentVariable } from "../util/env.js";
 
 function getAnthropicPromptFromMessage(type: MessageType): string {
   switch (type) {
@@ -142,11 +143,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     super(fields ?? {});
 
     this.apiKey =
-      fields?.anthropicApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.ANTHROPIC_API_KEY
-        : undefined);
+      fields?.anthropicApiKey ?? getEnvironmentVariable("ANTHROPIC_API_KEY");
     if (!this.apiKey) {
       throw new Error("Anthropic API key not found");
     }

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -7,7 +7,7 @@ import {
   ChatCompletionResponseMessageRoleEnum,
   ChatCompletionRequestMessage,
 } from "openai";
-import { isNode } from "../util/env.js";
+import { getEnvironmentVariable, isNode } from "../util/env.js";
 import {
   AzureOpenAIInput,
   OpenAICallOptions,
@@ -149,42 +149,26 @@ export class ChatOpenAI
     super(fields ?? {});
 
     const apiKey =
-      fields?.openAIApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.OPENAI_API_KEY
-        : undefined);
+      fields?.openAIApiKey ?? getEnvironmentVariable("OPENAI_API_KEY");
 
     const azureApiKey =
       fields?.azureOpenAIApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_KEY
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_KEY");
     if (!azureApiKey && !apiKey) {
       throw new Error("(Azure) OpenAI API key not found");
     }
 
     const azureApiInstanceName =
       fields?.azureOpenAIApiInstanceName ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_INSTANCE_NAME
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_INSTANCE_NAME");
 
     const azureApiDeploymentName =
       fields?.azureOpenAIApiDeploymentName ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_DEPLOYMENT_NAME
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_DEPLOYMENT_NAME");
 
     const azureApiVersion =
       fields?.azureOpenAIApiVersion ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_VERSION
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_VERSION");
 
     this.modelName = fields?.modelName ?? this.modelName;
     this.modelKwargs = fields?.modelKwargs ?? {};

--- a/langchain/src/client/langchainplus.ts
+++ b/langchain/src/client/langchainplus.ts
@@ -16,6 +16,7 @@ import { BaseLLM } from "../llms/base.js";
 import { BaseChatModel } from "../chat_models/base.js";
 import { mapStoredMessagesToChatMessages } from "../stores/message/utils.js";
 import { AsyncCaller, AsyncCallerParams } from "../util/async_caller.js";
+import { getEnvironmentVariable } from "../util/env.js";
 
 export interface RunResult extends BaseRun {
   name: string;
@@ -183,17 +184,10 @@ async function getModelOrFactoryType(
 }
 
 export class LangChainPlusClient {
-  private apiKey?: string =
-    typeof process !== "undefined"
-      ? // eslint-disable-next-line no-process-env
-        process.env?.LANGCHAIN_API_KEY
-      : undefined;
+  private apiKey?: string = getEnvironmentVariable("LANGCHAIN_API_KEY");
 
   private apiUrl =
-    (typeof process !== "undefined"
-      ? // eslint-disable-next-line no-process-env
-        process.env?.LANGCHAIN_ENDPOINT
-      : undefined) || "http://localhost:1984";
+    getEnvironmentVariable("LANGCHAIN_ENDPOINT") || "http://localhost:1984";
 
   private tenantId: string;
 
@@ -208,11 +202,7 @@ export class LangChainPlusClient {
     this.apiUrl = config.apiUrl ?? this.apiUrl;
     this.apiKey = config.apiKey;
     const tenantId =
-      config.tenantId ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.LANGCHAIN_TENANT_ID
-        : undefined);
+      config.tenantId ?? getEnvironmentVariable("LANGCHAIN_TENANT_ID");
     if (tenantId === undefined) {
       throw new Error(
         "No tenant ID provided and no LANGCHAIN_TENANT_ID env var"
@@ -233,23 +223,12 @@ export class LangChainPlusClient {
   ): Promise<LangChainPlusClient> {
     const apiUrl_ =
       config.apiUrl ??
-      ((typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.LANGCHAIN_ENDPOINT
-        : undefined) ||
-        "http://localhost:1984");
+      (getEnvironmentVariable("LANGCHAIN_ENDPOINT") || "http://localhost:1984");
     const apiKey_ =
-      config.apiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.LANGCHAIN_API_KEY
-        : undefined);
+      config.apiKey ?? getEnvironmentVariable("LANGCHAIN_API_KEY");
     const tenantId_ =
       config.tenantId ??
-      ((typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.LANGCHAIN_TENANT_ID
-        : undefined) ||
+      (getEnvironmentVariable("LANGCHAIN_TENANT_ID") ||
         (await getSeededTenantId(apiUrl_, { apiKey: apiKey_ })));
     return new LangChainPlusClient({
       tenantId: tenantId_,

--- a/langchain/src/document_loaders/web/apify_dataset.ts
+++ b/langchain/src/document_loaders/web/apify_dataset.ts
@@ -6,6 +6,7 @@ import {
 
 import { Document } from "../../document.js";
 import { BaseDocumentLoader, DocumentLoader } from "../base.js";
+import { getEnvironmentVariable } from "../../util/env.js";
 
 export type ApifyDatasetMappingFunction = (
   item: Record<string | number, unknown>
@@ -43,11 +44,7 @@ export class ApifyDatasetLoader
   }
 
   private static _getApifyApiToken(config?: { token?: string }) {
-    return (
-      config?.token ??
-      // eslint-disable-next-line no-process-env
-      (typeof process !== "undefined" ? process.env.APIFY_API_TOKEN : undefined)
-    );
+    return config?.token ?? getEnvironmentVariable("APIFY_API_TOKEN");
   }
 
   async load(): Promise<Document[]> {

--- a/langchain/src/document_loaders/web/github.ts
+++ b/langchain/src/document_loaders/web/github.ts
@@ -4,6 +4,7 @@ import { Document } from "../../document.js";
 import { BaseDocumentLoader } from "../base.js";
 import { UnknownHandling } from "../fs/directory.js";
 import { extname } from "../../util/extname.js";
+import { getEnvironmentVariable } from "../../util/env.js";
 
 const extensions = new Set(binaryExtensions);
 
@@ -64,10 +65,7 @@ export class GithubRepoLoader
   constructor(
     githubUrl: string,
     {
-      accessToken = typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.GITHUB_ACCESS_TOKEN
-        : undefined,
+      accessToken = getEnvironmentVariable("GITHUB_ACCESS_TOKEN"),
       branch = "main",
       recursive = true,
       unknown = UnknownHandling.Warn,

--- a/langchain/src/embeddings/cohere.ts
+++ b/langchain/src/embeddings/cohere.ts
@@ -1,4 +1,5 @@
 import { chunkArray } from "../util/chunk.js";
+import { getEnvironmentVariable } from "../util/env.js";
 import { Embeddings, EmbeddingsParams } from "./base.js";
 
 export interface CohereEmbeddingsParams extends EmbeddingsParams {
@@ -38,12 +39,7 @@ export class CohereEmbeddings
   ) {
     super(fields ?? {});
 
-    const apiKey =
-      fields?.apiKey ||
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.COHERE_API_KEY
-        : undefined);
+    const apiKey = fields?.apiKey || getEnvironmentVariable("COHERE_API_KEY");
 
     if (!apiKey) {
       throw new Error("Cohere API key not found");

--- a/langchain/src/embeddings/hf.ts
+++ b/langchain/src/embeddings/hf.ts
@@ -1,5 +1,6 @@
 import { HfInference } from "@huggingface/inference";
 import { Embeddings, EmbeddingsParams } from "./base.js";
+import { getEnvironmentVariable } from "../util/env.js";
 
 export interface HuggingFaceInferenceEmbeddingsParams extends EmbeddingsParams {
   apiKey?: string;
@@ -22,11 +23,7 @@ export class HuggingFaceInferenceEmbeddings
     this.model =
       fields?.model ?? "sentence-transformers/distilbert-base-nli-mean-tokens";
     this.apiKey =
-      fields?.apiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.HUGGINGFACEHUB_API_KEY
-        : undefined);
+      fields?.apiKey ?? getEnvironmentVariable("HUGGINGFACEHUB_API_KEY");
     this.client = new HfInference(this.apiKey);
   }
 

--- a/langchain/src/embeddings/openai.ts
+++ b/langchain/src/embeddings/openai.ts
@@ -5,7 +5,7 @@ import {
   ConfigurationParameters,
 } from "openai";
 import type { AxiosRequestConfig } from "axios";
-import { isNode } from "../util/env.js";
+import { getEnvironmentVariable, isNode } from "../util/env.js";
 import { AzureOpenAIInput } from "../types/openai-types.js";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
 import { chunkArray } from "../util/chunk.js";
@@ -68,45 +68,28 @@ export class OpenAIEmbeddings
     super(fields ?? {});
 
     const apiKey =
-      fields?.openAIApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.OPENAI_API_KEY
-        : undefined);
+      fields?.openAIApiKey ?? getEnvironmentVariable("OPENAI_API_KEY");
 
     const azureApiKey =
       fields?.azureOpenAIApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_KEY
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_KEY");
     if (!azureApiKey && !apiKey) {
       throw new Error("(Azure) OpenAI API key not found");
     }
 
     const azureApiInstanceName =
       fields?.azureOpenAIApiInstanceName ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_INSTANCE_NAME
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_INSTANCE_NAME");
 
     const azureApiDeploymentName =
       (fields?.azureOpenAIApiEmbeddingsDeploymentName ||
         fields?.azureOpenAIApiDeploymentName) ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME ||
-          // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_DEPLOYMENT_NAME
-        : undefined);
+      (getEnvironmentVariable("AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME") ||
+        getEnvironmentVariable("AZURE_OPENAI_API_DEPLOYMENT_NAME"));
 
     const azureApiVersion =
       fields?.azureOpenAIApiVersion ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_VERSION
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_VERSION");
 
     this.modelName = fields?.modelName ?? this.modelName;
     this.batchSize = fields?.batchSize ?? this.batchSize;

--- a/langchain/src/llms/cohere.ts
+++ b/langchain/src/llms/cohere.ts
@@ -1,3 +1,4 @@
+import { getEnvironmentVariable } from "../util/env.js";
 import { LLM, BaseLLMParams } from "./base.js";
 
 export interface CohereInput extends BaseLLMParams {
@@ -27,12 +28,7 @@ export class Cohere extends LLM implements CohereInput {
   constructor(fields?: CohereInput) {
     super(fields ?? {});
 
-    const apiKey =
-      fields?.apiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.COHERE_API_KEY
-        : undefined);
+    const apiKey = fields?.apiKey ?? getEnvironmentVariable("COHERE_API_KEY");
 
     if (!apiKey) {
       throw new Error(

--- a/langchain/src/llms/hf.ts
+++ b/langchain/src/llms/hf.ts
@@ -1,3 +1,4 @@
+import { getEnvironmentVariable } from "../util/env.js";
 import { LLM, BaseLLMParams } from "./base.js";
 
 export interface HFInput {
@@ -50,11 +51,7 @@ export class HuggingFaceInference extends LLM implements HFInput {
     this.topK = fields?.topK ?? this.topK;
     this.frequencyPenalty = fields?.frequencyPenalty ?? this.frequencyPenalty;
     this.apiKey =
-      fields?.apiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.HUGGINGFACEHUB_API_KEY
-        : undefined);
+      fields?.apiKey ?? getEnvironmentVariable("HUGGINGFACEHUB_API_KEY");
     if (!this.apiKey) {
       throw new Error(
         "Please set an API key for HuggingFace Hub in the environment variable HUGGINGFACEHUB_API_KEY or in the apiKey field of the HuggingFaceInference constructor."

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -7,7 +7,7 @@ import {
   ChatCompletionResponseMessageRoleEnum,
   CreateChatCompletionResponse,
 } from "openai";
-import { isNode } from "../util/env.js";
+import { isNode, getEnvironmentVariable } from "../util/env.js";
 import {
   AzureOpenAIInput,
   OpenAICallOptions,
@@ -101,42 +101,29 @@ export class OpenAIChat
     super(fields ?? {});
 
     const apiKey =
-      fields?.openAIApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.OPENAI_API_KEY
-        : undefined);
+      fields?.openAIApiKey ?? getEnvironmentVariable("OPENAI_API_KEY");
 
     const azureApiKey =
       fields?.azureOpenAIApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_KEY
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_KEY");
+
     if (!azureApiKey && !apiKey) {
       throw new Error("(Azure) OpenAI API key not found");
     }
 
     const azureApiInstanceName =
       fields?.azureOpenAIApiInstanceName ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_INSTANCE_NAME
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_INSTANCE_NAME");
 
     const azureApiDeploymentName =
-      fields?.azureOpenAIApiDeploymentName ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_DEPLOYMENT_NAME
-        : undefined);
+      (fields?.azureOpenAIApiCompletionsDeploymentName ||
+        fields?.azureOpenAIApiDeploymentName) ??
+      (getEnvironmentVariable("AZURE_OPENAI_API_COMPLETIONS_DEPLOYMENT_NAME") ||
+        getEnvironmentVariable("AZURE_OPENAI_API_DEPLOYMENT_NAME"));
 
     const azureApiVersion =
       fields?.azureOpenAIApiVersion ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_VERSION
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_VERSION");
 
     this.modelName = fields?.modelName ?? this.modelName;
     this.prefixMessages = fields?.prefixMessages ?? this.prefixMessages;
@@ -415,10 +402,7 @@ export class PromptLayerOpenAIChat extends OpenAIChat {
     this.plTags = fields?.plTags ?? [];
     this.promptLayerApiKey =
       fields?.promptLayerApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.PROMPTLAYER_API_KEY
-        : undefined);
+      getEnvironmentVariable("PROMPTLAYER_API_KEY");
 
     if (!this.promptLayerApiKey) {
       throw new Error("Missing PromptLayer API key");

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -116,10 +116,8 @@ export class OpenAIChat
       getEnvironmentVariable("AZURE_OPENAI_API_INSTANCE_NAME");
 
     const azureApiDeploymentName =
-      (fields?.azureOpenAIApiCompletionsDeploymentName ||
-        fields?.azureOpenAIApiDeploymentName) ??
-      (getEnvironmentVariable("AZURE_OPENAI_API_COMPLETIONS_DEPLOYMENT_NAME") ||
-        getEnvironmentVariable("AZURE_OPENAI_API_DEPLOYMENT_NAME"));
+      fields?.azureOpenAIApiDeploymentName ??
+      getEnvironmentVariable("AZURE_OPENAI_API_DEPLOYMENT_NAME");
 
     const azureApiVersion =
       fields?.azureOpenAIApiVersion ??

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -7,7 +7,7 @@ import {
   CreateCompletionResponseChoicesInner,
   OpenAIApi,
 } from "openai";
-import { isNode } from "../util/env.js";
+import { isNode, getEnvironmentVariable } from "../util/env.js";
 import {
   AzureOpenAIInput,
   OpenAICallOptions,
@@ -114,45 +114,29 @@ export class OpenAI extends BaseLLM implements OpenAIInput, AzureOpenAIInput {
     super(fields ?? {});
 
     const apiKey =
-      fields?.openAIApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.OPENAI_API_KEY
-        : undefined);
+      fields?.openAIApiKey ?? getEnvironmentVariable("OPENAI_API_KEY");
 
     const azureApiKey =
       fields?.azureOpenAIApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_KEY
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_KEY");
+
     if (!azureApiKey && !apiKey) {
       throw new Error("(Azure) OpenAI API key not found");
     }
 
     const azureApiInstanceName =
       fields?.azureOpenAIApiInstanceName ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_INSTANCE_NAME
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_INSTANCE_NAME");
 
     const azureApiDeploymentName =
       (fields?.azureOpenAIApiCompletionsDeploymentName ||
         fields?.azureOpenAIApiDeploymentName) ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_COMPLETIONS_DEPLOYMENT_NAME ||
-          // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_DEPLOYMENT_NAME
-        : undefined);
+      (getEnvironmentVariable("AZURE_OPENAI_API_COMPLETIONS_DEPLOYMENT_NAME") ||
+        getEnvironmentVariable("AZURE_OPENAI_API_DEPLOYMENT_NAME"));
 
     const azureApiVersion =
       fields?.azureOpenAIApiVersion ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.AZURE_OPENAI_API_VERSION
-        : undefined);
+      getEnvironmentVariable("AZURE_OPENAI_API_VERSION");
 
     this.modelName = fields?.modelName ?? this.modelName;
     this.modelKwargs = fields?.modelKwargs ?? {};
@@ -478,10 +462,7 @@ export class PromptLayerOpenAI extends OpenAI {
     this.plTags = fields?.plTags ?? [];
     this.promptLayerApiKey =
       fields?.promptLayerApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.PROMPTLAYER_API_KEY
-        : undefined);
+      getEnvironmentVariable("PROMPTLAYER_API_KEY");
 
     if (!this.promptLayerApiKey) {
       throw new Error("Missing PromptLayer API key");

--- a/langchain/src/llms/replicate.ts
+++ b/langchain/src/llms/replicate.ts
@@ -1,3 +1,4 @@
+import { getEnvironmentVariable } from "../util/env.js";
 import { LLM, BaseLLMParams } from "./base.js";
 
 export interface ReplicateInput {
@@ -23,9 +24,7 @@ export class Replicate extends LLM implements ReplicateInput {
     super(fields);
 
     const apiKey =
-      fields?.apiKey ??
-      // eslint-disable-next-line no-process-env
-      (typeof process !== "undefined" && process.env?.REPLICATE_API_KEY);
+      fields?.apiKey ?? getEnvironmentVariable("REPLICATE_API_KEY");
 
     if (!apiKey) {
       throw new Error("Please set the REPLICATE_API_KEY environment variable");

--- a/langchain/src/tools/bingserpapi.ts
+++ b/langchain/src/tools/bingserpapi.ts
@@ -1,3 +1,4 @@
+import { getEnvironmentVariable } from "../util/env.js";
 import { Tool } from "./base.js";
 
 class BingSerpAPI extends Tool {
@@ -11,10 +12,7 @@ class BingSerpAPI extends Tool {
   params: Record<string, string>;
 
   constructor(
-    apiKey: string | undefined = typeof process !== "undefined"
-      ? // eslint-disable-next-line no-process-env
-        process.env?.BingApiKey
-      : undefined,
+    apiKey: string | undefined = getEnvironmentVariable("BingApiKey"),
     params: Record<string, string> = {}
   ) {
     super();

--- a/langchain/src/tools/google_custom_search.ts
+++ b/langchain/src/tools/google_custom_search.ts
@@ -1,3 +1,4 @@
+import { getEnvironmentVariable } from "../util/env.js";
 import { Tool } from "./base.js";
 
 export interface GoogleCustomSearchParams {
@@ -17,16 +18,8 @@ export class GoogleCustomSearch extends Tool {
 
   constructor(
     fields: GoogleCustomSearchParams = {
-      apiKey:
-        typeof process !== "undefined"
-          ? // eslint-disable-next-line no-process-env
-            process.env.GOOGLE_API_KEY
-          : undefined,
-      googleCSEId:
-        typeof process !== "undefined"
-          ? // eslint-disable-next-line no-process-env
-            process.env.GOOGLE_CSE_ID
-          : undefined,
+      apiKey: getEnvironmentVariable("GOOGLE_API_KEY"),
+      googleCSEId: getEnvironmentVariable("GOOGLE_CSE_ID"),
     }
   ) {
     super();

--- a/langchain/src/tools/serpapi.ts
+++ b/langchain/src/tools/serpapi.ts
@@ -1,3 +1,4 @@
+import { getEnvironmentVariable } from "../util/env.js";
 import { Tool } from "./base.js";
 
 /**
@@ -296,10 +297,7 @@ export class SerpAPI extends Tool {
   protected baseUrl: string;
 
   constructor(
-    apiKey: string | undefined = typeof process !== "undefined"
-      ? // eslint-disable-next-line no-process-env
-        process.env?.SERPAPI_API_KEY
-      : undefined,
+    apiKey: string | undefined = getEnvironmentVariable("SERPAPI_API_KEY"),
     params: Partial<SerpAPIParameters> = {},
     baseUrl = "https://serpapi.com"
   ) {

--- a/langchain/src/tools/serper.ts
+++ b/langchain/src/tools/serper.ts
@@ -1,3 +1,4 @@
+import { getEnvironmentVariable } from "../util/env.js";
 import { Tool } from "./base.js";
 
 export type SerperParameters = {
@@ -18,10 +19,7 @@ export class Serper extends Tool {
   protected params: Partial<SerperParameters>;
 
   constructor(
-    apiKey: string | undefined = typeof process !== "undefined"
-      ? // eslint-disable-next-line no-process-env
-        process.env?.SERPER_API_KEY
-      : undefined,
+    apiKey: string | undefined = getEnvironmentVariable("SERPER_API_KEY"),
     params: Partial<SerperParameters> = {}
   ) {
     super();

--- a/langchain/src/tools/zapier.ts
+++ b/langchain/src/tools/zapier.ts
@@ -1,6 +1,7 @@
 import { Tool } from "./base.js";
 import { renderTemplate } from "../prompts/template.js";
 import { AsyncCaller, AsyncCallerParams } from "../util/async_caller.js";
+import { getEnvironmentVariable } from "../util/env.js";
 
 const zapierNLABaseDescription: string =
   "A wrapper around Zapier NLA actions. " +
@@ -34,11 +35,7 @@ export class ZapierNLAWrapper {
     const zapierNlaApiKey =
       typeof params === "string" ? params : params?.apiKey;
     const apiKey =
-      zapierNlaApiKey ??
-      (typeof process !== "undefined"
-        ? // eslint-disable-next-line no-process-env
-          process.env?.ZAPIER_NLA_API_KEY
-        : undefined);
+      zapierNlaApiKey ?? getEnvironmentVariable("ZAPIER_NLA_API_KEY");
     if (!apiKey) {
       throw new Error("ZAPIER_NLA_API_KEY not set");
     }

--- a/langchain/src/util/env.ts
+++ b/langchain/src/util/env.ts
@@ -73,3 +73,16 @@ export async function getRuntimeEnvironment(): Promise<RuntimeEnvironment> {
   }
   return runtimeEnvironment;
 }
+
+export function getEnvironmentVariable(name: string): string | undefined {
+  // Certain Deno setups will throw an error if you try to access environment variables
+  // https://github.com/hwchase17/langchainjs/issues/1412
+  try {
+    return typeof process !== "undefined"
+      ? // eslint-disable-next-line no-process-env
+        process.env?.[name]
+      : undefined;
+  } catch (e) {
+    return undefined;
+  }
+}

--- a/langchain/src/util/hub.ts
+++ b/langchain/src/util/hub.ts
@@ -2,6 +2,7 @@ import pRetry from "p-retry";
 
 import { FileLoader, LoadValues } from "./load.js";
 import { extname } from "./extname.js";
+import { getEnvironmentVariable } from "../util/env.js";
 
 const fetchWithTimeout = async (
   url: string,
@@ -27,15 +28,9 @@ export const loadFromHub = async <T>(
   values: LoadValues = {}
 ): Promise<T | undefined> => {
   const LANGCHAIN_HUB_DEFAULT_REF =
-    (typeof process !== "undefined"
-      ? // eslint-disable-next-line no-process-env
-        process.env?.LANGCHAIN_HUB_DEFAULT_REF
-      : undefined) ?? "master";
+    getEnvironmentVariable("LANGCHAIN_HUB_DEFAULT_REF") ?? "master";
   const LANGCHAIN_HUB_URL_BASE =
-    (typeof process !== "undefined"
-      ? // eslint-disable-next-line no-process-env
-        process.env?.LANGCHAIN_HUB_URL_BASE
-      : undefined) ??
+    getEnvironmentVariable("LANGCHAIN_HUB_URL_BASE") ??
     "https://raw.githubusercontent.com/hwchase17/langchain-hub/";
 
   const match = uri.match(HUB_PATH_REGEX);

--- a/langchain/src/vectorstores/milvus.ts
+++ b/langchain/src/vectorstores/milvus.ts
@@ -12,6 +12,7 @@ import {
 import { Embeddings } from "../embeddings/base.js";
 import { VectorStore } from "./base.js";
 import { Document } from "../document.js";
+import { getEnvironmentVariable } from "../util/env.js";
 
 export interface MilvusLibArgs {
   collectionName?: string;
@@ -96,10 +97,7 @@ export class Milvus extends VectorStore {
     this.vectorField = args.vectorField ?? MILVUS_VECTOR_FIELD_NAME;
     this.fields = [];
 
-    const url =
-      args.url ??
-      // eslint-disable-next-line no-process-env
-      (typeof process !== "undefined" ? process.env?.MILVUS_URL : undefined);
+    const url = args.url ?? getEnvironmentVariable("MILVUS_URL");
     if (!url) {
       throw new Error("Milvus URL address is not provided.");
     }

--- a/langchain/src/vectorstores/qdrant.ts
+++ b/langchain/src/vectorstores/qdrant.ts
@@ -5,6 +5,7 @@ import { v4 as uuid } from "uuid";
 import { Embeddings } from "../embeddings/base.js";
 import { VectorStore } from "./base.js";
 import { Document } from "../document.js";
+import { getEnvironmentVariable } from "../util/env.js";
 
 export interface QdrantLibArgs {
   client?: QdrantClient;
@@ -30,10 +31,7 @@ export class QdrantVectorStore extends VectorStore {
   constructor(embeddings: Embeddings, args: QdrantLibArgs) {
     super(embeddings, args);
 
-    const url =
-      args.url ??
-      // eslint-disable-next-line no-process-env
-      (typeof process !== "undefined" ? process.env?.QDRANT_URL : undefined);
+    const url = args.url ?? getEnvironmentVariable("QDRANT_URL");
 
     if (!args.client && !url) {
       throw new Error("Qdrant client or url address must be set.");


### PR DESCRIPTION
Some Deno configurations will throw an error if any attempt is made to access an environment variable. This PR refactors `process.env` access into a util method. Should also remove the need to have TS compiler ignore comments in many places as well.

Fixes #1412 