### PR TITLE
Update structured chat prompt syntax and output parser

### DIFF
--- a/langchain/src/agents/structured_chat/outputParser.ts
+++ b/langchain/src/agents/structured_chat/outputParser.ts
@@ -16,13 +16,14 @@ export class StructuredChatOutputParser extends AgentActionOutputParser {
 
   async parse(text: string): Promise<AgentAction | AgentFinish> {
     try {
-      const regex = /```(?:json)?(.*)(```)/gs;
+      const regex = /(?:```\s*\n*)+(?:json)?(.*)(```)/gs;
       const actionMatch = regex.exec(text);
       if (actionMatch === null) {
         throw new OutputParserException(
           `Could not parse an action. The agent action must be within a markdown code block, and "action" must be a provided tool or "Final Answer"`
         );
       }
+
       const response = JSON.parse(actionMatch[1].trim());
       const { action, action_input } = response;
 

--- a/langchain/src/agents/structured_chat/prompt.ts
+++ b/langchain/src/agents/structured_chat/prompt.ts
@@ -13,7 +13,7 @@ The $JSON_BLOB must be valid, parseable JSON and only contain a SINGLE action. H
 }}
 \`\`\`
 
-Remember to include the surrounding markdown code snippet delimiters (begin with "\`\`\`" json and close with "\`\`\`")!
+Remember to include the surrounding markdown code snippet delimiters (begin with "\`\`\`json" and end with "\`\`\`")!
 `;
 export const FORMAT_INSTRUCTIONS = `You have access to the following tools.
 You must format your inputs to these tools to match their "JSON schema" definitions below.

--- a/langchain/src/agents/tests/structured_chat_output_parser.test.ts
+++ b/langchain/src/agents/tests/structured_chat_output_parser.test.ts
@@ -22,6 +22,15 @@ test("Can parse JSON with text in front of it", async () => {
       toolInput:
         "```sql\nSELECT * FROM orders\nJOIN users ON users.id = orders.user_id\nWHERE users.email = 'bud'```",
     },
+    {
+      input:
+        'Here we have some boilerplate nonsense```\n```json\n{\n \t\r\n"action": "blogpost",\n\t\r  "action_input": "```sql\\nSELECT * FROM orders\\nJOIN users ON users.id = orders.user_id\\nWHERE users.email = \'bud\'```"\n\t\r}\n\n\n\t\r``` and at the end there is more nonsense',
+      output:
+        '{"action":"blogpost","action_input":"```sql\\nSELECT * FROM orders\\nJOIN users ON users.id = orders.user_id\\nWHERE users.email = \'bud\'```"}',
+      tool: "blogpost",
+      toolInput:
+        "```sql\nSELECT * FROM orders\nJOIN users ON users.id = orders.user_id\nWHERE users.email = 'bud'```",
+    },
   ];
 
   const p = new StructuredChatOutputParser(["blogpost"]);

--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -68,7 +68,7 @@ ${JSON.stringify(zodToJsonSchema(this.schema))}
   async parse(text: string): Promise<z.infer<T>> {
     try {
       const json = text.includes("```")
-        ? text.trim().split(/```(?:json)?/)[1]
+        ? text.trim().split(/(?:```\s*\n*)+(?:json)?/)[1]
         : text.trim();
       return this.schema.parseAsync(JSON.parse(json));
     } catch (e) {

--- a/langchain/src/output_parsers/tests/structured.test.ts
+++ b/langchain/src/output_parsers/tests/structured.test.ts
@@ -87,7 +87,34 @@ test("StructuredOutputParser.fromZodSchema", async () => {
 
   expect(
     await parser.parse(
+      '```\n```\n{"answer": "value", "sources": ["this-source"]}```'
+    )
+  ).toEqual({
+    answer: "value",
+    sources: ["this-source"],
+  });
+
+  expect(
+    await parser.parse(
       '```json\n{"answer": "value", "sources": ["this-source"]}```'
+    )
+  ).toEqual({
+    answer: "value",
+    sources: ["this-source"],
+  });
+
+  expect(
+    await parser.parse(
+      '```\n```json\n{"answer": "value", "sources": ["this-source"]}```'
+    )
+  ).toEqual({
+    answer: "value",
+    sources: ["this-source"],
+  });
+
+  expect(
+    await parser.parse(
+      'some stuff\n``` \n```json\n{"answer": "value", "sources": ["this-source"]}```'
     )
   ).toEqual({
     answer: "value",


### PR DESCRIPTION
# Update structured chat prompt syntax and output parser

Running into weird issues running the structured agent with tools having invalid syntax with the backtick `
Hope this fixes it 🙂 
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.
-->
