### PR TITLE
ci: ensure ci step uses yarn 2.x, cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
     env:
       PUPPETEER_SKIP_DOWNLOAD: "true"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "true"
-      DOCKER_COMPOSE_YARN_CACHE: "/home/runner/work/langchainjs/langchainjs/.yarn/cache"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
     env:
       PUPPETEER_SKIP_DOWNLOAD: "true"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "true"
+      DOCKER_COMPOSE_YARN_CACHE: "/home/runner/work/langchainjs/langchainjs/.yarn/cache"
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 18.x

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     working_dir: /app
     volumes:
       - ./yarn.lock:/root/yarn.lock
+      - ./.yarnrc.yml:/root/.yarnrc.yml
+      - ./.yarn:/root/.yarn
+      - yarn-cache:/root/.yarn/berry/cache
       - ./test-exports-esbuild:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -14,6 +17,9 @@ services:
     working_dir: /app
     volumes:
       - ./yarn.lock:/root/yarn.lock
+      - ./.yarnrc.yml:/root/.yarnrc.yml
+      - ./.yarn:/root/.yarn
+      - yarn-cache:/root/.yarn/berry/cache
       - ./test-exports-esm:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -23,6 +29,9 @@ services:
     working_dir: /app
     volumes:
       - ./yarn.lock:/root/yarn.lock
+      - ./.yarnrc.yml:/root/.yarnrc.yml
+      - ./.yarn:/root/.yarn
+      - yarn-cache:/root/.yarn/berry/cache
       - ./test-exports-cjs:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -32,6 +41,9 @@ services:
     working_dir: /app
     volumes:
       - ./yarn.lock:/root/yarn.lock
+      - ./.yarnrc.yml:/root/.yarnrc.yml
+      - ./.yarn:/root/.yarn
+      - yarn-cache:/root/.yarn/berry/cache
       - ./test-exports-cra:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -41,6 +53,9 @@ services:
     working_dir: /app
     volumes:
       - ./yarn.lock:/root/yarn.lock
+      - ./.yarnrc.yml:/root/.yarnrc.yml
+      - ./.yarn:/root/.yarn
+      - yarn-cache:/root/.yarn/berry/cache
       - ./test-exports-cf:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -50,6 +65,9 @@ services:
     working_dir: /app
     volumes:
       - ./yarn.lock:/root/yarn.lock
+      - ./.yarnrc.yml:/root/.yarnrc.yml
+      - ./.yarn:/root/.yarn
+      - yarn-cache:/root/.yarn/berry/cache
       - ./test-exports-vercel:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -59,6 +77,9 @@ services:
     working_dir: /app
     volumes:
       - ./yarn.lock:/root/yarn.lock
+      - ./.yarnrc.yml:/root/.yarnrc.yml
+      - ./.yarn:/root/.yarn
+      - yarn-cache:/root/.yarn/berry/cache
       - ./test-exports-vite:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -81,3 +102,6 @@ services:
         condition: service_completed_successfully
       test-exports-vite:
         condition: service_completed_successfully
+
+volumes:
+  yarn-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   test-exports-esbuild:
     image: node:18
@@ -7,7 +7,6 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-esbuild:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -19,7 +18,6 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-esm:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -31,7 +29,6 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-cjs:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -43,7 +40,6 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-cra:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -55,7 +51,6 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-cf:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -67,7 +62,6 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-vercel:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -79,7 +73,6 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-vite:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -102,6 +95,3 @@ services:
         condition: service_completed_successfully
       test-exports-vite:
         condition: service_completed_successfully
-
-volumes:
-  yarn-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - yarn-cache:/root/.yarn/berry/cache
+      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-esbuild:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -19,7 +19,7 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - yarn-cache:/root/.yarn/berry/cache
+      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-esm:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -31,7 +31,7 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - yarn-cache:/root/.yarn/berry/cache
+      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-cjs:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -43,7 +43,7 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - yarn-cache:/root/.yarn/berry/cache
+      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-cra:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -55,7 +55,7 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - yarn-cache:/root/.yarn/berry/cache
+      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-cf:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -67,7 +67,7 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - yarn-cache:/root/.yarn/berry/cache
+      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-vercel:/package
       - ./langchain:/langchain
       - ./scripts:/scripts
@@ -79,7 +79,7 @@ services:
       - ./yarn.lock:/root/yarn.lock
       - ./.yarnrc.yml:/root/.yarnrc.yml
       - ./.yarn:/root/.yarn
-      - yarn-cache:/root/.yarn/berry/cache
+      - ${DOCKER_COMPOSE_YARN_CACHE:-yarn-cache}:/app/.yarn/cache
       - ./test-exports-vite:/package
       - ./langchain:/langchain
       - ./scripts:/scripts

--- a/scripts/docker-ci-entrypoint.sh
+++ b/scripts/docker-ci-entrypoint.sh
@@ -4,9 +4,16 @@ set -euxo pipefail
 
 export CI=true
 
-cp -r ../package/* .
+# enable extended globbing for omitting build artifacts
+shopt -s extglob
 
-cp ../root/yarn.lock .
+# avoid copying build artifacts from the host
+cp -r ../package/!(node_modules|dist|dist-cjs|dist-esm|build|.next|.turbo) .
+
+# copy cache
+mkdir -p ./.yarn
+cp -r ../root/.yarn/!(berry|cache) ./.yarn
+cp ../root/yarn.lock ../root/.yarnrc.yml .
 
 # Replace the workspace dependency with the local copy, and install all others
 yarn add ../langchain

--- a/scripts/docker-ci-entrypoint.sh
+++ b/scripts/docker-ci-entrypoint.sh
@@ -16,7 +16,10 @@ cp -r ../root/.yarn/!(berry|cache) ./.yarn
 cp ../root/yarn.lock ../root/.yarnrc.yml .
 
 # Replace the workspace dependency with the local copy, and install all others
-yarn add ../langchain
+# Avoid calling "yarn add ../langchain" as yarn berry does seem to hang for ~30s
+# before installation actually occurs
+sed -i 's/"langchain": "workspace:\*"/"langchain": "..\/langchain"/g' package.json
+yarn install --no-immutable
 
 # Check the build command completes successfully
 yarn build


### PR DESCRIPTION
Noticed that when running `yarn test:exports:docker`, `yarn` packages are always being pulled, even with `yarn.lock` being present.

This PR fixes the following:
- Copy both .yarn folder and .yarnrc.yml to use Yarn Berry to match the correct version found in yarn.lock
- Avoid copying inner node_modules and build artifacts in the entrypoint
- Mount a volume to cache downloaded packages

