### PR TITLE
Adds new initialize QA chain methods that allow custom prompt prefix passing

### DIFF
--- a/docs/docs/modules/chains/prompt_selectors/index.mdx
+++ b/docs/docs/modules/chains/prompt_selectors/index.mdx
@@ -34,11 +34,11 @@ This will return `DEFAULT_QA_PROMPT` if the model is not a chat model, and `CHAT
 The example below shows how to use a prompt selector when loading a chain:
 
 ```typescript
-const loadQAStuffChain = (
+const initializeQAStuffChain = async (
   llm: BaseLanguageModel,
   params: StuffQAChainParams = {}
 ) => {
-  const { prompt = QA_PROMPT_SELECTOR.getPrompt(llm) } = params;
+  const { prompt = await QA_PROMPT_SELECTOR.getPromptAsync(llm) } = params;
   const llmChain = new LLMChain({ prompt, llm });
   const chain = new StuffDocumentsChain({ llmChain });
   return chain;

--- a/examples/src/chains/qa_refine.ts
+++ b/examples/src/chains/qa_refine.ts
@@ -1,4 +1,4 @@
-import { loadQARefineChain } from "langchain/chains";
+import { initializeQARefineChain } from "langchain/chains";
 import { OpenAI } from "langchain/llms/openai";
 import { TextLoader } from "langchain/document_loaders/fs/text";
 import { MemoryVectorStore } from "langchain/vectorstores/memory";
@@ -8,7 +8,7 @@ export async function run() {
   // Create the models and chain
   const embeddings = new OpenAIEmbeddings();
   const model = new OpenAI({ temperature: 0 });
-  const chain = loadQARefineChain(model);
+  const chain = await initializeQARefineChain(model);
 
   // Load the documents and create the vector store
   const loader = new TextLoader("./state_of_the_union.txt");

--- a/examples/src/chains/question_answering.ts
+++ b/examples/src/chains/question_answering.ts
@@ -1,11 +1,14 @@
 import { OpenAI } from "langchain/llms/openai";
-import { loadQAStuffChain, loadQAMapReduceChain } from "langchain/chains";
+import {
+  initializeQAStuffChain,
+  initializeQAMapReduceChain,
+} from "langchain/chains";
 import { Document } from "langchain/document";
 
 export const run = async () => {
   // This first example uses the `StuffDocumentsChain`.
   const llmA = new OpenAI({});
-  const chainA = loadQAStuffChain(llmA);
+  const chainA = await initializeQAStuffChain(llmA);
   const docs = [
     new Document({ pageContent: "Harrison went to Harvard." }),
     new Document({ pageContent: "Ankush went to Princeton." }),
@@ -20,7 +23,7 @@ export const run = async () => {
   // This second example uses the `MapReduceChain`.
   // Optionally limit the number of concurrent requests to the language model.
   const llmB = new OpenAI({ maxConcurrency: 10 });
-  const chainB = loadQAMapReduceChain(llmB);
+  const chainB = await initializeQAMapReduceChain(llmB);
   const resB = await chainB.call({
     input_documents: docs,
     question: "Where did Harrison go to college?",

--- a/examples/src/chains/question_answering_map_reduce.ts
+++ b/examples/src/chains/question_answering_map_reduce.ts
@@ -1,10 +1,10 @@
 import { OpenAI } from "langchain/llms/openai";
-import { loadQAMapReduceChain } from "langchain/chains";
+import { initializeQAMapReduceChain } from "langchain/chains";
 import { Document } from "langchain/document";
 
 export const run = async () => {
   const model = new OpenAI({ temperature: 0 });
-  const chain = loadQAMapReduceChain(model);
+  const chain = await initializeQAMapReduceChain(model);
   const docs = [
     new Document({ pageContent: "harrison went to harvard" }),
     new Document({ pageContent: "ankush went to princeton" }),

--- a/langchain/src/chains/index.ts
+++ b/langchain/src/chains/index.ts
@@ -37,9 +37,13 @@ export {
 } from "./question_answering/load.js";
 export {
   initializeQAChain,
+  InitializeQAChainParams,
   initializeQAStuffChain,
+  InitializeStuffQAChainParams,
   initializeQAMapReduceChain,
+  InitializeMapReduceQAChainParams,
   initializeQARefineChain,
+  InitializeRefineQAChainParams,
 } from "./question_answering/initialize.js";
 export {
   loadSummarizationChain,

--- a/langchain/src/chains/index.ts
+++ b/langchain/src/chains/index.ts
@@ -36,6 +36,12 @@ export {
   RefineQAChainParams,
 } from "./question_answering/load.js";
 export {
+  initializeQAChain,
+  initializeQAStuffChain,
+  initializeQAMapReduceChain,
+  initializeQARefineChain,
+} from "./question_answering/initialize.js";
+export {
   loadSummarizationChain,
   SummarizationChainParams,
 } from "./summarization/load.js";

--- a/langchain/src/chains/question_answering/initialize.ts
+++ b/langchain/src/chains/question_answering/initialize.ts
@@ -48,16 +48,19 @@ export const initializeQAChain = async (
 export interface InitializeStuffQAChainParams {
   prefix?: string;
   prompt?: BasePromptTemplate;
-  verbose?: boolean;}
+  verbose?: boolean;
+}
 
 export async function initializeQAStuffChain(
   llm: BaseLanguageModel,
   params: InitializeStuffQAChainParams = {}
 ) {
-  const { prompt = await QA_PROMPT_SELECTOR.getPromptAsync(llm, {
-    partialVariables: {prefix: params.prefix ?? ""}
-  }), verbose } =
-    params;
+  const {
+    prompt = await QA_PROMPT_SELECTOR.getPromptAsync(llm, {
+      partialVariables: { prefix: params.prefix ?? "" },
+    }),
+    verbose,
+  } = params;
   const llmChain = new LLMChain({ prompt, llm, verbose });
   const chain = new StuffDocumentsChain({ llmChain, verbose });
   return chain;
@@ -86,12 +89,16 @@ export async function initializeQAMapReduceChain(
     verbose,
     returnIntermediateSteps,
   } = params;
-  const mapPrompt = mapChainOptions?.prompt ?? await COMBINE_QA_PROMPT_SELECTOR.getPromptAsync(llm, {
-    partialVariables: {prefix: mapChainOptions?.prefix ?? ""}
-  });
-  const combinePrompt = combineChainOptions?.prompt ?? await COMBINE_PROMPT_SELECTOR.getPromptAsync(llm, {
-    partialVariables: {prefix: combineChainOptions?.prefix ?? ""}
-  });
+  const mapPrompt =
+    mapChainOptions?.prompt ??
+    (await COMBINE_QA_PROMPT_SELECTOR.getPromptAsync(llm, {
+      partialVariables: { prefix: mapChainOptions?.prefix ?? "" },
+    }));
+  const combinePrompt =
+    combineChainOptions?.prompt ??
+    (await COMBINE_PROMPT_SELECTOR.getPromptAsync(llm, {
+      partialVariables: { prefix: combineChainOptions?.prefix ?? "" },
+    }));
   const llmChain = new LLMChain({ prompt: mapPrompt, llm, verbose });
   const combineLLMChain = new LLMChain({ prompt: combinePrompt, llm, verbose });
   const combineDocumentChain = new StuffDocumentsChain({
@@ -116,7 +123,7 @@ export interface InitializeRefineQAChainParams {
   refineChainOptions?: {
     prefix?: string;
     prompt?: BasePromptTemplate;
-  }
+  };
   verbose?: boolean;
 }
 
@@ -124,17 +131,17 @@ export async function initializeQARefineChain(
   llm: BaseLanguageModel,
   params: InitializeRefineQAChainParams = {}
 ) {
-  const {
-    questionChainOptions,
-    refineChainOptions,
-    verbose,
-  } = params;
-  const questionPrompt = questionChainOptions?.prompt ?? await QUESTION_PROMPT_SELECTOR.getPromptAsync(llm, {
-    partialVariables: {prefix: questionChainOptions?.prefix ?? ""}
-  });
-  const refinePrompt = refineChainOptions?.prompt ?? await REFINE_PROMPT_SELECTOR.getPromptAsync(llm, {
-    partialVariables: {prefix: refineChainOptions?.prefix ?? ""}
-  });
+  const { questionChainOptions, refineChainOptions, verbose } = params;
+  const questionPrompt =
+    questionChainOptions?.prompt ??
+    (await QUESTION_PROMPT_SELECTOR.getPromptAsync(llm, {
+      partialVariables: { prefix: questionChainOptions?.prefix ?? "" },
+    }));
+  const refinePrompt =
+    refineChainOptions?.prompt ??
+    (await REFINE_PROMPT_SELECTOR.getPromptAsync(llm, {
+      partialVariables: { prefix: refineChainOptions?.prefix ?? "" },
+    }));
   const llmChain = new LLMChain({ prompt: questionPrompt, llm, verbose });
   const refineLLMChain = new LLMChain({ prompt: refinePrompt, llm, verbose });
 

--- a/langchain/src/chains/question_answering/initialize.ts
+++ b/langchain/src/chains/question_answering/initialize.ts
@@ -1,0 +1,147 @@
+import { LLMChain } from "../llm_chain.js";
+import { BasePromptTemplate } from "../../prompts/base.js";
+import {
+  StuffDocumentsChain,
+  MapReduceDocumentsChain,
+  RefineDocumentsChain,
+  MapReduceDocumentsChainInput,
+} from "../combine_docs_chain.js";
+import { QA_PROMPT_SELECTOR } from "./initialize_stuff_prompts.js";
+import {
+  COMBINE_PROMPT_SELECTOR,
+  COMBINE_QA_PROMPT_SELECTOR,
+} from "./initialize_map_reduce_prompts.js";
+import { BaseLanguageModel } from "../../base_language/index.js";
+import {
+  QUESTION_PROMPT_SELECTOR,
+  REFINE_PROMPT_SELECTOR,
+} from "./initialize_refine_prompts.js";
+
+export type InitializeQAChainParams =
+  | ({
+      type?: "stuff";
+    } & InitializeStuffQAChainParams)
+  | ({
+      type?: "map_reduce";
+    } & InitializeMapReduceQAChainParams)
+  | ({
+      type?: "refine";
+    } & InitializeRefineQAChainParams);
+
+export const initializeQAChain = async (
+  llm: BaseLanguageModel,
+  params: InitializeQAChainParams = { type: "stuff" }
+) => {
+  const { type } = params;
+  if (type === "stuff") {
+    return initializeQAStuffChain(llm, params);
+  }
+  if (type === "map_reduce") {
+    return initializeQAMapReduceChain(llm, params);
+  }
+  if (type === "refine") {
+    return initializeQARefineChain(llm, params);
+  }
+  throw new Error(`Invalid _type: ${type}`);
+};
+
+export interface InitializeStuffQAChainParams {
+  prefix?: string;
+  prompt?: BasePromptTemplate;
+  verbose?: boolean;}
+
+export async function initializeQAStuffChain(
+  llm: BaseLanguageModel,
+  params: InitializeStuffQAChainParams = {}
+) {
+  const { prompt = await QA_PROMPT_SELECTOR.getPromptAsync(llm, {
+    partialVariables: {prefix: params.prefix ?? ""}
+  }), verbose } =
+    params;
+  const llmChain = new LLMChain({ prompt, llm, verbose });
+  const chain = new StuffDocumentsChain({ llmChain, verbose });
+  return chain;
+}
+
+export interface InitializeMapReduceQAChainParams {
+  returnIntermediateSteps?: MapReduceDocumentsChainInput["returnIntermediateSteps"];
+  mapChainOptions?: {
+    prefix?: string;
+    prompt?: BasePromptTemplate;
+  };
+  combineChainOptions?: {
+    prefix?: string;
+    prompt?: BasePromptTemplate;
+  };
+  verbose?: boolean;
+}
+
+export async function initializeQAMapReduceChain(
+  llm: BaseLanguageModel,
+  params: InitializeMapReduceQAChainParams = {}
+) {
+  const {
+    mapChainOptions,
+    combineChainOptions,
+    verbose,
+    returnIntermediateSteps,
+  } = params;
+  const mapPrompt = mapChainOptions?.prompt ?? await COMBINE_QA_PROMPT_SELECTOR.getPromptAsync(llm, {
+    partialVariables: {prefix: mapChainOptions?.prefix ?? ""}
+  });
+  const combinePrompt = combineChainOptions?.prompt ?? await COMBINE_PROMPT_SELECTOR.getPromptAsync(llm, {
+    partialVariables: {prefix: combineChainOptions?.prefix ?? ""}
+  });
+  const llmChain = new LLMChain({ prompt: mapPrompt, llm, verbose });
+  const combineLLMChain = new LLMChain({ prompt: combinePrompt, llm, verbose });
+  const combineDocumentChain = new StuffDocumentsChain({
+    llmChain: combineLLMChain,
+    documentVariableName: "summaries",
+    verbose,
+  });
+  const chain = new MapReduceDocumentsChain({
+    llmChain,
+    combineDocumentChain,
+    returnIntermediateSteps,
+    verbose,
+  });
+  return chain;
+}
+
+export interface InitializeRefineQAChainParams {
+  questionChainOptions?: {
+    prefix?: string;
+    prompt?: BasePromptTemplate;
+  };
+  refineChainOptions?: {
+    prefix?: string;
+    prompt?: BasePromptTemplate;
+  }
+  verbose?: boolean;
+}
+
+export async function initializeQARefineChain(
+  llm: BaseLanguageModel,
+  params: InitializeRefineQAChainParams = {}
+) {
+  const {
+    questionChainOptions,
+    refineChainOptions,
+    verbose,
+  } = params;
+  const questionPrompt = questionChainOptions?.prompt ?? await QUESTION_PROMPT_SELECTOR.getPromptAsync(llm, {
+    partialVariables: {prefix: questionChainOptions?.prefix ?? ""}
+  });
+  const refinePrompt = refineChainOptions?.prompt ?? await REFINE_PROMPT_SELECTOR.getPromptAsync(llm, {
+    partialVariables: {prefix: refineChainOptions?.prefix ?? ""}
+  });
+  const llmChain = new LLMChain({ prompt: questionPrompt, llm, verbose });
+  const refineLLMChain = new LLMChain({ prompt: refinePrompt, llm, verbose });
+
+  const chain = new RefineDocumentsChain({
+    llmChain,
+    refineLLMChain,
+    verbose,
+  });
+  return chain;
+}

--- a/langchain/src/chains/question_answering/initialize_map_reduce_prompts.ts
+++ b/langchain/src/chains/question_answering/initialize_map_reduce_prompts.ts
@@ -1,0 +1,87 @@
+/* eslint-disable spaced-comment */
+import { PromptTemplate } from "../../prompts/prompt.js";
+import {
+  ChatPromptTemplate,
+  SystemMessagePromptTemplate,
+  HumanMessagePromptTemplate,
+} from "../../prompts/chat.js";
+import {
+  ConditionalPromptSelector,
+  isChatModel,
+} from "../../prompts/selectors/conditional.js";
+
+const qa_template = `{prefix} Use the following portion of a long document to see if any of the text is relevant to answer the question.
+Return any relevant text verbatim.
+{context}
+Question: {question}
+Relevant text, if any:`;
+export const DEFAULT_COMBINE_QA_PROMPT =
+  /*#__PURE__*/
+  PromptTemplate.fromTemplate(qa_template);
+
+const system_template = `{prefix} Use the following portion of a long document to see if any of the text is relevant to answer the question.
+Return any relevant text verbatim.
+----------------
+{context}`;
+const messages = [
+  /*#__PURE__*/ SystemMessagePromptTemplate.fromTemplate(system_template),
+  /*#__PURE__*/ HumanMessagePromptTemplate.fromTemplate("{question}"),
+];
+const CHAT_QA_PROMPT =
+  /*#__PURE__*/ ChatPromptTemplate.fromPromptMessages(messages);
+
+export const COMBINE_QA_PROMPT_SELECTOR =
+  /*#__PURE__*/ new ConditionalPromptSelector(DEFAULT_COMBINE_QA_PROMPT, [
+    [isChatModel, CHAT_QA_PROMPT],
+  ]);
+
+const combine_prompt = `{prefix} Given the following extracted parts of a long document and a question, create a final answer.
+If you don't know the answer, just say that you don't know. Don't try to make up an answer.
+
+QUESTION: Which state/country's law governs the interpretation of the contract?
+=========
+Content: This Agreement is governed by English law and the parties submit to the exclusive jurisdiction of the English courts in  relation to any dispute (contractual or non-contractual) concerning this Agreement save that either party may apply to any court for an  injunction or other relief to protect its Intellectual Property Rights.
+
+Content: No Waiver. Failure or delay in exercising any right or remedy under this Agreement shall not constitute a waiver of such (or any other)  right or remedy.\n\n11.7 Severability. The invalidity, illegality or unenforceability of any term (or part of a term) of this Agreement shall not affect the continuation  in force of the remainder of the term (if any) and this Agreement.\n\n11.8 No Agency. Except as expressly stated otherwise, nothing in this Agreement shall create an agency, partnership or joint venture of any  kind between the parties.\n\n11.9 No Third-Party Beneficiaries.
+
+Content: (b) if Google believes, in good faith, that the Distributor has violated or caused Google to violate any Anti-Bribery Laws (as  defined in Clause 8.5) or that such a violation is reasonably likely to occur,
+=========
+FINAL ANSWER: This Agreement is governed by English law.
+
+QUESTION: What did the president say about Michael Jackson?
+=========
+Content: Madam Speaker, Madam Vice President, our First Lady and Second Gentleman. Members of Congress and the Cabinet. Justices of the Supreme Court. My fellow Americans.  \n\nLast year COVID-19 kept us apart. This year we are finally together again. \n\nTonight, we meet as Democrats Republicans and Independents. But most importantly as Americans. \n\nWith a duty to one another to the American people to the Constitution. \n\nAnd with an unwavering resolve that freedom will always triumph over tyranny. \n\nSix days ago, Russia’s Vladimir Putin sought to shake the foundations of the free world thinking he could make it bend to his menacing ways. But he badly miscalculated. \n\nHe thought he could roll into Ukraine and the world would roll over. Instead he met a wall of strength he never imagined. \n\nHe met the Ukrainian people. \n\nFrom President Zelenskyy to every Ukrainian, their fearlessness, their courage, their determination, inspires the world. \n\nGroups of citizens blocking tanks with their bodies. Everyone from students to retirees teachers turned soldiers defending their homeland.
+
+Content: And we won’t stop. \n\nWe have lost so much to COVID-19. Time with one another. And worst of all, so much loss of life. \n\nLet’s use this moment to reset. Let’s stop looking at COVID-19 as a partisan dividing line and see it for what it is: A God-awful disease.  \n\nLet’s stop seeing each other as enemies, and start seeing each other for who we really are: Fellow Americans.  \n\nWe can’t change how divided we’ve been. But we can change how we move forward—on COVID-19 and other issues we must face together. \n\nI recently visited the New York City Police Department days after the funerals of Officer Wilbert Mora and his partner, Officer Jason Rivera. \n\nThey were responding to a 9-1-1 call when a man shot and killed them with a stolen gun. \n\nOfficer Mora was 27 years old. \n\nOfficer Rivera was 22. \n\nBoth Dominican Americans who’d grown up on the same streets they later chose to patrol as police officers. \n\nI spoke with their families and told them that we are forever in debt for their sacrifice, and we will carry on their mission to restore the trust and safety every community deserves.
+
+Content: And a proud Ukrainian people, who have known 30 years  of independence, have repeatedly shown that they will not tolerate anyone who tries to take their country backwards.  \n\nTo all Americans, I will be honest with you, as I’ve always promised. A Russian dictator, invading a foreign country, has costs around the world. \n\nAnd I’m taking robust action to make sure the pain of our sanctions  is targeted at Russia’s economy. And I will use every tool at our disposal to protect American businesses and consumers. \n\nTonight, I can announce that the United States has worked with 30 other countries to release 60 Million barrels of oil from reserves around the world.  \n\nAmerica will lead that effort, releasing 30 Million barrels from our own Strategic Petroleum Reserve. And we stand ready to do more if necessary, unified with our allies.  \n\nThese steps will help blunt gas prices here at home. And I know the news about what’s happening can seem alarming. \n\nBut I want you to know that we are going to be okay.
+
+Content: More support for patients and families. \n\nTo get there, I call on Congress to fund ARPA-H, the Advanced Research Projects Agency for Health. \n\nIt’s based on DARPA—the Defense Department project that led to the Internet, GPS, and so much more.  \n\nARPA-H will have a singular purpose—to drive breakthroughs in cancer, Alzheimer’s, diabetes, and more. \n\nA unity agenda for the nation. \n\nWe can do this. \n\nMy fellow Americans—tonight , we have gathered in a sacred space—the citadel of our democracy. \n\nIn this Capitol, generation after generation, Americans have debated great questions amid great strife, and have done great things. \n\nWe have fought for freedom, expanded liberty, defeated totalitarianism and terror. \n\nAnd built the strongest, freest, and most prosperous nation the world has ever known. \n\nNow is the hour. \n\nOur moment of responsibility. \n\nOur test of resolve and conscience, of history itself. \n\nIt is in this moment that our character is formed. Our purpose is found. Our future is forged. \n\nWell I know this nation.
+=========
+FINAL ANSWER: The president did not mention Michael Jackson.
+
+QUESTION: {question}
+=========
+{summaries}
+=========
+FINAL ANSWER:`;
+export const COMBINE_PROMPT =
+  /*#__PURE__*/ PromptTemplate.fromTemplate(combine_prompt);
+
+const system_combine_template = `{prefix} Given the following extracted parts of a long document and a question, create a final answer.
+If you don't know the answer, just say that you don't know. Don't try to make up an answer.
+----------------
+{summaries}`;
+const combine_messages = [
+  /*#__PURE__*/ SystemMessagePromptTemplate.fromTemplate(
+    system_combine_template
+  ),
+  /*#__PURE__*/ HumanMessagePromptTemplate.fromTemplate("{question}"),
+];
+const CHAT_COMBINE_PROMPT =
+  /*#__PURE__*/ ChatPromptTemplate.fromPromptMessages(combine_messages);
+
+export const COMBINE_PROMPT_SELECTOR =
+  /*#__PURE__*/ new ConditionalPromptSelector(COMBINE_PROMPT, [
+    [isChatModel, CHAT_COMBINE_PROMPT],
+  ]);

--- a/langchain/src/chains/question_answering/initialize_refine_prompts.ts
+++ b/langchain/src/chains/question_answering/initialize_refine_prompts.ts
@@ -23,7 +23,7 @@ If the context isn't useful, return the original answer.`;
 export const DEFAULT_REFINE_PROMPT = /*#__PURE__*/ new PromptTemplate({
   inputVariables: ["question", "existing_answer", "context"],
   template: DEFAULT_REFINE_PROMPT_TMPL,
-  validateTemplate: false
+  validateTemplate: false,
 });
 
 const refineTemplate = `{prefix} The original question is as follows: {question}

--- a/langchain/src/chains/question_answering/initialize_refine_prompts.ts
+++ b/langchain/src/chains/question_answering/initialize_refine_prompts.ts
@@ -1,0 +1,80 @@
+/* eslint-disable spaced-comment */
+import {
+  PromptTemplate,
+  ChatPromptTemplate,
+  SystemMessagePromptTemplate,
+  HumanMessagePromptTemplate,
+  AIMessagePromptTemplate,
+} from "../../prompts/index.js";
+import {
+  ConditionalPromptSelector,
+  isChatModel,
+} from "../../prompts/selectors/conditional.js";
+
+export const DEFAULT_REFINE_PROMPT_TMPL = `{prefix} The original question is as follows: {question}
+We have provided an existing answer: {existing_answer}
+We have the opportunity to refine the existing answer
+(only if needed) with some more context below.
+------------
+{context}
+------------
+Given the new context, refine the original answer to better answer the question.
+If the context isn't useful, return the original answer.`;
+export const DEFAULT_REFINE_PROMPT = /*#__PURE__*/ new PromptTemplate({
+  inputVariables: ["question", "existing_answer", "context"],
+  template: DEFAULT_REFINE_PROMPT_TMPL,
+  validateTemplate: false
+});
+
+const refineTemplate = `{prefix} The original question is as follows: {question}
+We have provided an existing answer: {existing_answer}
+We have the opportunity to refine the existing answer
+(only if needed) with some more context below.
+------------
+{context}
+------------
+Given the new context, refine the original answer to better answer the question.
+If the context isn't useful, return the original answer.`;
+
+const messages = [
+  /*#__PURE__*/ HumanMessagePromptTemplate.fromTemplate("{question}"),
+  /*#__PURE__*/ AIMessagePromptTemplate.fromTemplate("{existing_answer}"),
+  /*#__PURE__*/ HumanMessagePromptTemplate.fromTemplate(refineTemplate),
+];
+
+export const CHAT_REFINE_PROMPT =
+  /*#__PURE__*/ ChatPromptTemplate.fromPromptMessages(messages);
+
+export const REFINE_PROMPT_SELECTOR =
+  /*#__PURE__*/ new ConditionalPromptSelector(DEFAULT_REFINE_PROMPT, [
+    [isChatModel, CHAT_REFINE_PROMPT],
+  ]);
+
+export const DEFAULT_TEXT_QA_PROMPT_TMPL = `{prefix} Context information is below.
+---------------------
+{context}
+---------------------
+Given the context information and not prior knowledge, answer the question: {question}`;
+export const DEFAULT_TEXT_QA_PROMPT = /*#__PURE__*/ new PromptTemplate({
+  inputVariables: ["context", "question"],
+  template: DEFAULT_TEXT_QA_PROMPT_TMPL,
+  validateTemplate: false,
+});
+
+const chat_qa_prompt_template = `{prefix} Context information is below.
+---------------------
+{context}
+---------------------
+Given the context information and not prior knowledge, answer any questions`;
+const chat_messages = [
+  /*#__PURE__*/ SystemMessagePromptTemplate.fromTemplate(
+    chat_qa_prompt_template
+  ),
+  /*#__PURE__*/ HumanMessagePromptTemplate.fromTemplate("{question}"),
+];
+export const CHAT_QUESTION_PROMPT =
+  /*#__PURE__*/ ChatPromptTemplate.fromPromptMessages(chat_messages);
+export const QUESTION_PROMPT_SELECTOR =
+  /*#__PURE__*/ new ConditionalPromptSelector(DEFAULT_TEXT_QA_PROMPT, [
+    [isChatModel, CHAT_QUESTION_PROMPT],
+  ]);

--- a/langchain/src/chains/question_answering/initialize_stuff_prompts.ts
+++ b/langchain/src/chains/question_answering/initialize_stuff_prompts.ts
@@ -14,7 +14,7 @@ export const DEFAULT_QA_PROMPT = /*#__PURE__*/ new PromptTemplate({
   template:
     "{prefix} Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.\n\n{context}\n\nQuestion: {question}\nHelpful Answer:",
   inputVariables: ["context", "question"],
-  validateTemplate: false
+  validateTemplate: false,
 });
 
 const system_template = `{prefix} Use the following pieces of context to answer the users question.

--- a/langchain/src/chains/question_answering/initialize_stuff_prompts.ts
+++ b/langchain/src/chains/question_answering/initialize_stuff_prompts.ts
@@ -1,0 +1,34 @@
+/* eslint-disable spaced-comment */
+import { PromptTemplate } from "../../prompts/prompt.js";
+import {
+  ChatPromptTemplate,
+  SystemMessagePromptTemplate,
+  HumanMessagePromptTemplate,
+} from "../../prompts/chat.js";
+import {
+  ConditionalPromptSelector,
+  isChatModel,
+} from "../../prompts/selectors/conditional.js";
+
+export const DEFAULT_QA_PROMPT = /*#__PURE__*/ new PromptTemplate({
+  template:
+    "{prefix} Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.\n\n{context}\n\nQuestion: {question}\nHelpful Answer:",
+  inputVariables: ["context", "question"],
+  validateTemplate: false
+});
+
+const system_template = `{prefix} Use the following pieces of context to answer the users question.
+If you don't know the answer, just say that you don't know, don't try to make up an answer.
+----------------
+{context}`;
+const messages = [
+  /*#__PURE__*/ SystemMessagePromptTemplate.fromTemplate(system_template),
+  /*#__PURE__*/ HumanMessagePromptTemplate.fromTemplate("{question}"),
+];
+const CHAT_PROMPT =
+  /*#__PURE__*/ ChatPromptTemplate.fromPromptMessages(messages);
+
+export const QA_PROMPT_SELECTOR = /*#__PURE__*/ new ConditionalPromptSelector(
+  DEFAULT_QA_PROMPT,
+  [[isChatModel, CHAT_PROMPT]]
+);

--- a/langchain/src/chains/question_answering/load.ts
+++ b/langchain/src/chains/question_answering/load.ts
@@ -1,3 +1,4 @@
+// Deprecated. Use methods and classes from initialize.ts instead.
 import { LLMChain } from "../llm_chain.js";
 import { BasePromptTemplate } from "../../prompts/base.js";
 import {
@@ -6,16 +7,16 @@ import {
   RefineDocumentsChain,
   MapReduceDocumentsChainInput,
 } from "../combine_docs_chain.js";
-import { QA_PROMPT_SELECTOR } from "./stuff_prompts.js";
+import { QA_PROMPT_SELECTOR } from "./load_stuff_prompts.js";
 import {
   COMBINE_PROMPT_SELECTOR,
   COMBINE_QA_PROMPT_SELECTOR,
-} from "./map_reduce_prompts.js";
+} from "./load_map_reduce_prompts.js";
 import { BaseLanguageModel } from "../../base_language/index.js";
 import {
   QUESTION_PROMPT_SELECTOR,
   REFINE_PROMPT_SELECTOR,
-} from "./refine_prompts.js";
+} from "./load_refine_prompts.js";
 
 export type QAChainParams =
   | ({
@@ -28,6 +29,9 @@ export type QAChainParams =
       type?: "refine";
     } & RefineQAChainParams);
 
+/**
+ * @deprecated Import and use "initializeQAChain" instead
+ */
 export const loadQAChain = (
   llm: BaseLanguageModel,
   params: QAChainParams = { type: "stuff" }
@@ -50,6 +54,9 @@ export interface StuffQAChainParams {
   verbose?: boolean;
 }
 
+/**
+ * @deprecated Import and use "initializeQAChain" instead
+ */
 export function loadQAStuffChain(
   llm: BaseLanguageModel,
   params: StuffQAChainParams = {}
@@ -67,6 +74,9 @@ export interface MapReduceQAChainParams {
   verbose?: boolean;
 }
 
+/**
+ * @deprecated Import and use "initializeQAChain" instead
+ */
 export function loadQAMapReduceChain(
   llm: BaseLanguageModel,
   params: MapReduceQAChainParams = {}
@@ -99,6 +109,9 @@ export interface RefineQAChainParams {
   verbose?: boolean;
 }
 
+/**
+ * @deprecated Import and use "initializeQAChain" instead
+ */
 export function loadQARefineChain(
   llm: BaseLanguageModel,
   params: RefineQAChainParams = {}

--- a/langchain/src/chains/question_answering/load_map_reduce_prompts.ts
+++ b/langchain/src/chains/question_answering/load_map_reduce_prompts.ts
@@ -10,7 +10,7 @@ import {
   isChatModel,
 } from "../../prompts/selectors/conditional.js";
 
-const qa_template = `Use the following portion of a long document to see if any of the text is relevant to answer the question.
+const qa_template = `Use the following portion of a long document to see if any of the text is relevant to answer the question. 
 Return any relevant text verbatim.
 {context}
 Question: {question}
@@ -19,7 +19,7 @@ export const DEFAULT_COMBINE_QA_PROMPT =
   /*#__PURE__*/
   PromptTemplate.fromTemplate(qa_template);
 
-const system_template = `Use the following portion of a long document to see if any of the text is relevant to answer the question.
+const system_template = `Use the following portion of a long document to see if any of the text is relevant to answer the question. 
 Return any relevant text verbatim.
 ----------------
 {context}`;
@@ -35,7 +35,7 @@ export const COMBINE_QA_PROMPT_SELECTOR =
     [isChatModel, CHAT_QA_PROMPT],
   ]);
 
-const combine_prompt = `Given the following extracted parts of a long document and a question, create a final answer.
+const combine_prompt = `Given the following extracted parts of a long document and a question, create a final answer. 
 If you don't know the answer, just say that you don't know. Don't try to make up an answer.
 
 QUESTION: Which state/country's law governs the interpretation of the contract?
@@ -68,7 +68,7 @@ FINAL ANSWER:`;
 export const COMBINE_PROMPT =
   /*#__PURE__*/ PromptTemplate.fromTemplate(combine_prompt);
 
-const system_combine_template = `Given the following extracted parts of a long document and a question, create a final answer.
+const system_combine_template = `Given the following extracted parts of a long document and a question, create a final answer. 
 If you don't know the answer, just say that you don't know. Don't try to make up an answer.
 ----------------
 {summaries}`;

--- a/langchain/src/chains/question_answering/load_map_reduce_prompts.ts
+++ b/langchain/src/chains/question_answering/load_map_reduce_prompts.ts
@@ -10,7 +10,7 @@ import {
   isChatModel,
 } from "../../prompts/selectors/conditional.js";
 
-const qa_template = `Use the following portion of a long document to see if any of the text is relevant to answer the question. 
+const qa_template = `Use the following portion of a long document to see if any of the text is relevant to answer the question.
 Return any relevant text verbatim.
 {context}
 Question: {question}
@@ -19,7 +19,7 @@ export const DEFAULT_COMBINE_QA_PROMPT =
   /*#__PURE__*/
   PromptTemplate.fromTemplate(qa_template);
 
-const system_template = `Use the following portion of a long document to see if any of the text is relevant to answer the question. 
+const system_template = `Use the following portion of a long document to see if any of the text is relevant to answer the question.
 Return any relevant text verbatim.
 ----------------
 {context}`;
@@ -35,7 +35,7 @@ export const COMBINE_QA_PROMPT_SELECTOR =
     [isChatModel, CHAT_QA_PROMPT],
   ]);
 
-const combine_prompt = `Given the following extracted parts of a long document and a question, create a final answer. 
+const combine_prompt = `Given the following extracted parts of a long document and a question, create a final answer.
 If you don't know the answer, just say that you don't know. Don't try to make up an answer.
 
 QUESTION: Which state/country's law governs the interpretation of the contract?
@@ -68,7 +68,7 @@ FINAL ANSWER:`;
 export const COMBINE_PROMPT =
   /*#__PURE__*/ PromptTemplate.fromTemplate(combine_prompt);
 
-const system_combine_template = `Given the following extracted parts of a long document and a question, create a final answer. 
+const system_combine_template = `Given the following extracted parts of a long document and a question, create a final answer.
 If you don't know the answer, just say that you don't know. Don't try to make up an answer.
 ----------------
 {summaries}`;

--- a/langchain/src/chains/question_answering/load_refine_prompts.ts
+++ b/langchain/src/chains/question_answering/load_refine_prompts.ts
@@ -18,7 +18,7 @@ We have the opportunity to refine the existing answer
 ------------
 {context}
 ------------
-Given the new context, refine the original answer to better answer the question. 
+Given the new context, refine the original answer to better answer the question.
 If the context isn't useful, return the original answer.`;
 export const DEFAULT_REFINE_PROMPT = /*#__PURE__*/ new PromptTemplate({
   inputVariables: ["question", "existing_answer", "context"],
@@ -32,7 +32,7 @@ We have the opportunity to refine the existing answer
 ------------
 {context}
 ------------
-Given the new context, refine the original answer to better answer the question. 
+Given the new context, refine the original answer to better answer the question.
 If the context isn't useful, return the original answer.`;
 
 const messages = [
@@ -49,7 +49,7 @@ export const REFINE_PROMPT_SELECTOR =
     [isChatModel, CHAT_REFINE_PROMPT],
   ]);
 
-export const DEFAULT_TEXT_QA_PROMPT_TMPL = `Context information is below. 
+export const DEFAULT_TEXT_QA_PROMPT_TMPL = `Context information is below.
 ---------------------
 {context}
 ---------------------
@@ -59,7 +59,7 @@ export const DEFAULT_TEXT_QA_PROMPT = /*#__PURE__*/ new PromptTemplate({
   template: DEFAULT_TEXT_QA_PROMPT_TMPL,
 });
 
-const chat_qa_prompt_template = `Context information is below. 
+const chat_qa_prompt_template = `Context information is below.
 ---------------------
 {context}
 ---------------------

--- a/langchain/src/chains/question_answering/load_refine_prompts.ts
+++ b/langchain/src/chains/question_answering/load_refine_prompts.ts
@@ -18,7 +18,7 @@ We have the opportunity to refine the existing answer
 ------------
 {context}
 ------------
-Given the new context, refine the original answer to better answer the question.
+Given the new context, refine the original answer to better answer the question. 
 If the context isn't useful, return the original answer.`;
 export const DEFAULT_REFINE_PROMPT = /*#__PURE__*/ new PromptTemplate({
   inputVariables: ["question", "existing_answer", "context"],
@@ -32,7 +32,7 @@ We have the opportunity to refine the existing answer
 ------------
 {context}
 ------------
-Given the new context, refine the original answer to better answer the question.
+Given the new context, refine the original answer to better answer the question. 
 If the context isn't useful, return the original answer.`;
 
 const messages = [
@@ -49,7 +49,7 @@ export const REFINE_PROMPT_SELECTOR =
     [isChatModel, CHAT_REFINE_PROMPT],
   ]);
 
-export const DEFAULT_TEXT_QA_PROMPT_TMPL = `Context information is below.
+export const DEFAULT_TEXT_QA_PROMPT_TMPL = `Context information is below. 
 ---------------------
 {context}
 ---------------------
@@ -59,7 +59,7 @@ export const DEFAULT_TEXT_QA_PROMPT = /*#__PURE__*/ new PromptTemplate({
   template: DEFAULT_TEXT_QA_PROMPT_TMPL,
 });
 
-const chat_qa_prompt_template = `Context information is below.
+const chat_qa_prompt_template = `Context information is below. 
 ---------------------
 {context}
 ---------------------

--- a/langchain/src/chains/question_answering/load_stuff_prompts.ts
+++ b/langchain/src/chains/question_answering/load_stuff_prompts.ts
@@ -16,7 +16,7 @@ export const DEFAULT_QA_PROMPT = /*#__PURE__*/ new PromptTemplate({
   inputVariables: ["context", "question"],
 });
 
-const system_template = `Use the following pieces of context to answer the users question. 
+const system_template = `Use the following pieces of context to answer the users question.
 If you don't know the answer, just say that you don't know, don't try to make up an answer.
 ----------------
 {context}`;

--- a/langchain/src/chains/question_answering/load_stuff_prompts.ts
+++ b/langchain/src/chains/question_answering/load_stuff_prompts.ts
@@ -16,7 +16,7 @@ export const DEFAULT_QA_PROMPT = /*#__PURE__*/ new PromptTemplate({
   inputVariables: ["context", "question"],
 });
 
-const system_template = `Use the following pieces of context to answer the users question.
+const system_template = `Use the following pieces of context to answer the users question. 
 If you don't know the answer, just say that you don't know, don't try to make up an answer.
 ----------------
 {context}`;

--- a/langchain/src/chains/question_answering/tests/initialize.int.test.ts
+++ b/langchain/src/chains/question_answering/tests/initialize.int.test.ts
@@ -69,7 +69,7 @@ test("Test initializeQAMapReduceChain with a custom combine chain prefix", async
   const chain = await initializeQAMapReduceChain(model, {
     combineChainOptions: {
       prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
-    }
+    },
   });
   const docs = [
     new Document({ pageContent: "Harrison went to Harvard." }),
@@ -87,7 +87,7 @@ test("Test initializeQAMapReduceChain with a custom combine chain prefix and a c
   const chain = await initializeQAMapReduceChain(model, {
     combineChainOptions: {
       prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
-    }
+    },
   });
   const docs = [
     new Document({ pageContent: "Harrison went to Harvard." }),
@@ -119,7 +119,7 @@ test("Test initializeQARefineChain with a custom refine chain prefix", async () 
   const chain = await initializeQARefineChain(model, {
     refineChainOptions: {
       prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
-    }
+    },
   });
   const docs = [
     new Document({ pageContent: "Harrison went to Harvard." }),
@@ -137,7 +137,7 @@ test("Test initializeQARefineChain with a custom refine chain prefix and a chat 
   const chain = await initializeQARefineChain(model, {
     refineChainOptions: {
       prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
-    }
+    },
   });
   const docs = [
     new Document({ pageContent: "Harrison went to Harvard." }),

--- a/langchain/src/chains/question_answering/tests/initialize.int.test.ts
+++ b/langchain/src/chains/question_answering/tests/initialize.int.test.ts
@@ -1,0 +1,151 @@
+import { test } from "@jest/globals";
+import { OpenAI } from "../../../llms/openai.js";
+import { ChatOpenAI } from "../../../chat_models/openai.js";
+import {
+  initializeQAMapReduceChain,
+  initializeQARefineChain,
+  initializeQAStuffChain,
+} from "../initialize.js";
+import { Document } from "../../../document.js";
+
+test("Test initializeQAStuffChain", async () => {
+  const model = new OpenAI({ modelName: "text-davinci-003" });
+  const chain = await initializeQAStuffChain(model);
+  const docs = [
+    new Document({ pageContent: "foo" }),
+    new Document({ pageContent: "bar" }),
+    new Document({ pageContent: "baz" }),
+  ];
+  const res = await chain.call({ input_documents: docs, question: "Whats up" });
+  console.log({ res });
+});
+
+test("Test initializeQAStuffChain with a custom prefix", async () => {
+  const model = new OpenAI({ modelName: "text-davinci-003" });
+  const chain = await initializeQAStuffChain(model, {
+    prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
+  });
+  const docs = [
+    new Document({ pageContent: "Harrison went to Harvard." }),
+    new Document({ pageContent: "Ankush went to Princeton." }),
+  ];
+  const res = await chain.call({
+    input_documents: docs,
+    question: "Where did Harrison go to college?",
+  });
+  console.log({ res });
+});
+
+test("Test initializeQAStuffChain with a custom prefix and a chat model", async () => {
+  const model = new ChatOpenAI({ modelName: "gpt-3.5-turbo" });
+  const chain = await initializeQAStuffChain(model, {
+    prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
+  });
+  const docs = [
+    new Document({ pageContent: "Harrison went to Harvard." }),
+    new Document({ pageContent: "Ankush went to Princeton." }),
+  ];
+  const res = await chain.call({
+    input_documents: docs,
+    question: "Where did Harrison go to college?",
+  });
+  console.log({ res });
+});
+
+test("Test initializeQAMapReduceChain", async () => {
+  const model = new OpenAI({ modelName: "text-davinci-003" });
+  const chain = await initializeQAMapReduceChain(model);
+  const docs = [
+    new Document({ pageContent: "foo" }),
+    new Document({ pageContent: "bar" }),
+    new Document({ pageContent: "baz" }),
+  ];
+  const res = await chain.call({ input_documents: docs, question: "Whats up" });
+  console.log({ res });
+});
+
+test("Test initializeQAMapReduceChain with a custom combine chain prefix", async () => {
+  const model = new OpenAI({ modelName: "text-davinci-003" });
+  const chain = await initializeQAMapReduceChain(model, {
+    combineChainOptions: {
+      prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
+    }
+  });
+  const docs = [
+    new Document({ pageContent: "Harrison went to Harvard." }),
+    new Document({ pageContent: "Ankush went to Princeton." }),
+  ];
+  const res = await chain.call({
+    input_documents: docs,
+    question: "Where did Harrison go to college?",
+  });
+  console.log({ res });
+});
+
+test("Test initializeQAMapReduceChain with a custom combine chain prefix and a chat model", async () => {
+  const model = new ChatOpenAI({ modelName: "gpt-3.5-turbo" });
+  const chain = await initializeQAMapReduceChain(model, {
+    combineChainOptions: {
+      prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
+    }
+  });
+  const docs = [
+    new Document({ pageContent: "Harrison went to Harvard." }),
+    new Document({ pageContent: "Ankush went to Princeton." }),
+  ];
+  const res = await chain.call({
+    input_documents: docs,
+    question: "Where did Harrison go to college?",
+  });
+  console.log({ res });
+});
+
+test("Test initializeQARefineChain", async () => {
+  const model = new OpenAI({ modelName: "text-davinci-003" });
+  const chain = await initializeQARefineChain(model);
+  const docs = [
+    new Document({ pageContent: "Harrison went to Harvard." }),
+    new Document({ pageContent: "Ankush went to Princeton." }),
+  ];
+  const res = await chain.call({
+    input_documents: docs,
+    question: "Where did Harrison go to college?",
+  });
+  console.log({ res });
+});
+
+test("Test initializeQARefineChain with a custom refine chain prefix", async () => {
+  const model = new OpenAI({ modelName: "text-davinci-003" });
+  const chain = await initializeQARefineChain(model, {
+    refineChainOptions: {
+      prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
+    }
+  });
+  const docs = [
+    new Document({ pageContent: "Harrison went to Harvard." }),
+    new Document({ pageContent: "Ankush went to Princeton." }),
+  ];
+  const res = await chain.call({
+    input_documents: docs,
+    question: "Where did Harrison go to college?",
+  });
+  console.log({ res });
+});
+
+test("Test initializeQARefineChain with a custom refine chain prefix and a chat model", async () => {
+  const model = new ChatOpenAI({ modelName: "gpt-3.5-turbo" });
+  const chain = await initializeQARefineChain(model, {
+    refineChainOptions: {
+      prefix: `You must be verbose, and output your answer like a pirate. Use plenty of args!`,
+    }
+  });
+  const docs = [
+    new Document({ pageContent: "Harrison went to Harvard." }),
+    new Document({ pageContent: "Ankush went to Princeton." }),
+  ];
+  const res = await chain.call({
+    input_documents: docs,
+    question: "Where did Harrison go to college?",
+  });
+  console.log({ res });
+});

--- a/langchain/src/chains/tests/combine_docs_chain.int.test.ts
+++ b/langchain/src/chains/tests/combine_docs_chain.int.test.ts
@@ -6,9 +6,9 @@ import { loadChain } from "../load.js";
 import { StuffDocumentsChain } from "../combine_docs_chain.js";
 import { Document } from "../../document.js";
 import {
-  loadQAMapReduceChain,
-  loadQARefineChain,
-} from "../question_answering/load.js";
+  initializeQAMapReduceChain,
+  initializeQARefineChain,
+} from "../question_answering/initialize.js";
 
 test("Test StuffDocumentsChain", async () => {
   const model = new OpenAI({ modelName: "text-ada-001" });
@@ -32,7 +32,7 @@ test("Test StuffDocumentsChain", async () => {
 
 test("Test MapReduceDocumentsChain with QA chain", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-ada-001" });
-  const chain = loadQAMapReduceChain(model);
+  const chain = await initializeQAMapReduceChain(model);
   const docs = [
     new Document({ pageContent: "harrison went to harvard" }),
     new Document({ pageContent: "ankush went to princeton" }),
@@ -46,7 +46,7 @@ test("Test MapReduceDocumentsChain with QA chain", async () => {
 
 test("Test RefineDocumentsChain with QA chain", async () => {
   const model = new OpenAI({ temperature: 0, modelName: "text-ada-001" });
-  const chain = loadQARefineChain(model);
+  const chain = await initializeQARefineChain(model);
   const docs = [
     new Document({ pageContent: "harrison went to harvard" }),
     new Document({ pageContent: "ankush went to princeton" }),


### PR DESCRIPTION
# Allow custom prompt prefix passing into QA combine docs chains

This will allow people to customize the behavior of the various QA-focused combine document chains without needing to completely override the default prompts and losing the convenience of the load methods.

This required a deprecation of the existing sync `loadQAChain` methods in favor of async `initializeQAChain` methods to support applying partial variables to the default prompt.