### PR TITLE
Support string arrays in Pinecone metadata

### DIFF
--- a/langchain/src/vectorstores/tests/pinecone.test.ts
+++ b/langchain/src/vectorstores/tests/pinecone.test.ts
@@ -21,10 +21,7 @@ test("PineconeStore with external ids", async () => {
     [
       {
         pageContent: "hello",
-        metadata: {
-          a: 1,
-          b: { nested: [1, { a: 4 }] },
-        },
+        metadata: { a: 1 },
       },
     ],
     ["id1"]
@@ -38,7 +35,7 @@ test("PineconeStore with external ids", async () => {
       vectors: [
         {
           id: "id1",
-          metadata: { a: 1, "b.nested.0": 1, "b.nested.1.a": 4, text: "hello" },
+          metadata: { a: 1, text: "hello" },
           values: [0.1, 0.2, 0.3, 0.4],
         },
       ],
@@ -70,4 +67,61 @@ test("PineconeStore with generated ids", async () => {
   const results = await store.similaritySearch("hello", 1);
 
   expect(results).toHaveLength(0);
+});
+
+test("PineconeStore flattens metadata values and removes null values when adding documents", async () => {
+  const client = { upsert: jest.fn() };
+  const embeddings = new FakeEmbeddings();
+  const store = new PineconeStore(embeddings, { pineconeIndex: client as any });
+
+  const document = {
+    pageContent: "hello",
+    metadata: {
+      string: "some_string",
+      number: 3.14,
+      boolean: true,
+      string_array: ["string_0", "string_1"],
+      null: null,
+      number_array: [0, 1],
+      object: {
+        string_in_nested_object: "some_string",
+        string_array_in_nested_object: ["string_0", "string_1"]
+      },
+    }
+  }
+
+  await store.addDocuments([document], ["some_id"]);
+
+  expect(client.upsert).toHaveBeenCalledTimes(1);
+
+  expect(client.upsert).toHaveBeenLastCalledWith({
+    upsertRequest: {
+      namespace: undefined,
+      vectors: [
+        {
+          id: "some_id",
+          metadata: {
+            string: "some_string",
+            boolean: true,
+            number: 3.14,
+            "string_array.0": "string_0",
+            "string_array.1": "string_1",
+            "number_array.0": 0,
+            "number_array.1": 1,
+            "object.string_in_nested_object": "some_string",
+            "object.string_array_in_nested_object.0": "string_0",
+            "object.string_array_in_nested_object.1": "string_1",
+            // pageContent
+            "text": "hello"
+          },
+          values: [
+            0.1,
+            0.2,
+            0.3,
+            0.4
+          ]
+        }
+      ]
+    }
+  });
 });

--- a/langchain/src/vectorstores/tests/pinecone.test.ts
+++ b/langchain/src/vectorstores/tests/pinecone.test.ts
@@ -69,7 +69,7 @@ test("PineconeStore with generated ids", async () => {
   expect(results).toHaveLength(0);
 });
 
-test("PineconeStore flattens metadata values and removes null values when adding documents", async () => {
+test("PineconeStore flattens unsupported metadata values and removes null values when adding documents", async () => {
   const client = { upsert: jest.fn() };
   const embeddings = new FakeEmbeddings();
   const store = new PineconeStore(embeddings, { pineconeIndex: client as any });
@@ -77,10 +77,12 @@ test("PineconeStore flattens metadata values and removes null values when adding
   const document = {
     pageContent: "hello",
     metadata: {
+      // Supported
       string: "some_string",
       number: 3.14,
       boolean: true,
       string_array: ["string_0", "string_1"],
+      // Unsupported
       null: null,
       number_array: [0, 1],
       object: {
@@ -101,11 +103,12 @@ test("PineconeStore flattens metadata values and removes null values when adding
         {
           id: "some_id",
           metadata: {
+            // Supported
             string: "some_string",
             boolean: true,
             number: 3.14,
-            "string_array.0": "string_0",
-            "string_array.1": "string_1",
+            string_array: ["string_0", "string_1"],
+            // Unsupported
             "number_array.0": 0,
             "number_array.1": 1,
             "object.string_in_nested_object": "some_string",


### PR DESCRIPTION
# Support string arrays in Pinecone metadata

Since #415, PineconeStore automatically flattens metadata (all nested objects and arrays) when adding documents.
However Pinecone officially supports list of strings in metadata, so this PR will add support for string arrays in Pinecone metadata by not flattening them.

https://docs.pinecone.io/docs/metadata-filtering#supported-metadata-types