### PR TITLE
Initial implementation for Structured Conversational agent

### DIFF
--- a/langchain/src/agents/structured_chat_convo/index.ts
+++ b/langchain/src/agents/structured_chat_convo/index.ts
@@ -1,0 +1,168 @@
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { JsonSchema7ObjectType } from "zod-to-json-schema/src/parsers/object.js";
+
+import { BaseLanguageModel } from "../../base_language/index.js";
+import { LLMChain } from "../../chains/llm_chain.js";
+import { PromptTemplate } from "../../prompts/prompt.js";
+import {
+  ChatPromptTemplate,
+  HumanMessagePromptTemplate,
+  MessagesPlaceholder,
+} from "../../prompts/chat.js";
+import { AgentStep } from "../../schema/index.js";
+import { StructuredTool } from "../../tools/base.js";
+import { Optional } from "../../types/type-utils.js";
+import { Agent, AgentArgs, OutputParserArgs } from "../agent.js";
+import { AgentInput } from "../types.js";
+import { StructuredChatConversationalOutputParserWithRetries } from "./outputParser.js";
+import { FORMAT_INSTRUCTIONS, PREFIX, SUFFIX } from "./prompt.js";
+
+export interface StructuredChatConversationalCreatePromptArgs {
+  /** String to put after the list of tools. */
+  suffix?: string;
+  /** String to put before the list of tools. */
+  prefix?: string;
+  /** List of input variables the final prompt will expect. */
+  inputVariables?: string[];
+}
+
+export type StructuredChatConversationalAgentInput = Optional<
+  AgentInput,
+  "outputParser"
+>;
+
+/**
+ * Agent that interoperates with Structured Tools using React logic.
+ * @augments Agent
+ */
+export class StructuredChatConversationalAgent extends Agent {
+  constructor(input: StructuredChatConversationalAgentInput) {
+    const outputParser =
+      input?.outputParser ??
+      StructuredChatConversationalAgent.getDefaultOutputParser();
+    super({ ...input, outputParser });
+  }
+
+  _agentType() {
+    return "structured-chat-conversational-zero-shot-react-description" as const;
+  }
+
+  observationPrefix() {
+    return "Observation: ";
+  }
+
+  llmPrefix() {
+    return "Thought:";
+  }
+
+  _stop(): string[] {
+    return ["Observation:"];
+  }
+
+  static validateTools(tools: StructuredTool[]) {
+    const descriptionlessTool = tools.find((tool) => !tool.description);
+    if (descriptionlessTool) {
+      const msg =
+        `Got a tool ${descriptionlessTool.name} without a description.` +
+        ` This agent requires descriptions for all tools.`;
+      throw new Error(msg);
+    }
+  }
+
+  static getDefaultOutputParser(
+    fields?: OutputParserArgs & {
+      toolNames: string[];
+    }
+  ) {
+    if (fields?.llm) {
+      return StructuredChatConversationalOutputParserWithRetries.fromLLM(
+        fields.llm,
+        {
+          toolNames: fields.toolNames,
+        }
+      );
+    }
+    return new StructuredChatConversationalOutputParserWithRetries({
+      toolNames: fields?.toolNames,
+    });
+  }
+
+  async constructScratchPad(steps: AgentStep[]): Promise<string> {
+    const agentScratchpad = await super.constructScratchPad(steps);
+    if (agentScratchpad) {
+      return `This was your previous work (but I haven't seen any of it! I only see what you return as final answer):\n${agentScratchpad}`;
+    }
+    return agentScratchpad;
+  }
+
+  static createToolSchemasString(tools: StructuredTool[]) {
+    return tools
+      .map(
+        (tool) =>
+          `${tool.name}: ${tool.description}, args: ${JSON.stringify(
+            (zodToJsonSchema(tool.schema) as JsonSchema7ObjectType).properties
+          )}`
+      )
+      .join("\n");
+  }
+
+  /**
+   * Create prompt in the style of the agent.
+   *
+   * @param tools - List of tools the agent will have access to, used to format the prompt.
+   * @param args - Arguments to create the prompt with.
+   * @param args.suffix - String to put after the list of tools.
+   * @param args.prefix - String to put before the list of tools.
+   */
+  static createPrompt(
+    tools: StructuredTool[],
+    args?: StructuredChatConversationalCreatePromptArgs
+  ) {
+    const { prefix = PREFIX, suffix = SUFFIX } = args ?? {};
+    const template = [prefix, FORMAT_INSTRUCTIONS, suffix].join("\n\n");
+    const messages = [
+      new HumanMessagePromptTemplate(
+        new PromptTemplate({
+          template,
+          inputVariables: [],
+          partialVariables: {
+            tool_schemas:
+              StructuredChatConversationalAgent.createToolSchemasString(tools),
+            tool_names: tools.map((tool) => tool.name).join(", "),
+          },
+        })
+      ),
+      new MessagesPlaceholder("chat_history"),
+      HumanMessagePromptTemplate.fromTemplate(
+        "{input} (Don't forget using tools and the $JSON_BLOB format)\n\n{agent_scratchpad}"
+      ),
+    ];
+    return ChatPromptTemplate.fromPromptMessages(messages);
+  }
+
+  static fromLLMAndTools(
+    llm: BaseLanguageModel,
+    tools: StructuredTool[],
+    args?: StructuredChatConversationalCreatePromptArgs & AgentArgs
+  ) {
+    StructuredChatConversationalAgent.validateTools(tools);
+    const prompt = StructuredChatConversationalAgent.createPrompt(tools, args);
+    const outputParser =
+      args?.outputParser ??
+      StructuredChatConversationalAgent.getDefaultOutputParser({
+        llm,
+        toolNames: tools.map((tool) => tool.name),
+      });
+    const chain = new LLMChain({
+      prompt,
+      llm,
+      callbacks: args?.callbacks,
+    });
+
+    return new StructuredChatConversationalAgent({
+      llmChain: chain,
+      outputParser,
+      allowedTools: tools.map((t) => t.name),
+    });
+  }
+}

--- a/langchain/src/agents/structured_chat_convo/outputParser.ts
+++ b/langchain/src/agents/structured_chat_convo/outputParser.ts
@@ -1,0 +1,99 @@
+import { AgentActionOutputParser } from "../types.js";
+import {
+  AGENT_ACTION_FORMAT_INSTRUCTIONS,
+  FORMAT_INSTRUCTIONS,
+} from "./prompt.js";
+import { OutputFixingParser } from "../../output_parsers/fix.js";
+import { BaseLanguageModel } from "../../base_language/index.js";
+import { AgentAction, AgentFinish } from "../../schema/index.js";
+import { OutputParserException } from "../../schema/output_parser.js";
+import { renderTemplate } from "../../prompts/index.js";
+
+export class StructuredChatConversationalOutputParser extends AgentActionOutputParser {
+  constructor(private toolNames: string[]) {
+    super();
+  }
+
+  async parse(text: string): Promise<AgentAction | AgentFinish> {
+    try {
+      const regex = /```(?:json)?(.*)(```)/gs;
+      const actionMatch = regex.exec(text);
+      if (actionMatch === null) {
+        throw new OutputParserException(
+          `Could not parse an action. The agent action must be within a markdown code block, and "action" must be a provided tool or "Final Answer"`
+        );
+      }
+      const response = JSON.parse(actionMatch[1].trim());
+      const { action, action_input } = response;
+
+      if (action === "Final Answer") {
+        return { returnValues: { output: action_input }, log: text };
+      }
+      return { tool: action, toolInput: action_input || {}, log: text };
+    } catch (e) {
+      throw new OutputParserException(
+        `Failed to parse. Text: "${text}". Error: ${e}`
+      );
+    }
+  }
+
+  getFormatInstructions(): string {
+    return renderTemplate(AGENT_ACTION_FORMAT_INSTRUCTIONS, "f-string", {
+      tool_names: this.toolNames.join(", "),
+    });
+  }
+}
+
+export interface StructuredChatConversationalOutputParserArgs {
+  baseParser?: StructuredChatConversationalOutputParser;
+  outputFixingParser?: OutputFixingParser<AgentAction | AgentFinish>;
+  toolNames?: string[];
+}
+
+export class StructuredChatConversationalOutputParserWithRetries extends AgentActionOutputParser {
+  private baseParser: StructuredChatConversationalOutputParser;
+
+  private outputFixingParser?: OutputFixingParser<AgentAction | AgentFinish>;
+
+  private toolNames: string[] = [];
+
+  constructor(fields: StructuredChatConversationalOutputParserArgs) {
+    super();
+    this.toolNames = fields.toolNames ?? this.toolNames;
+    this.baseParser =
+      fields?.baseParser ??
+      new StructuredChatConversationalOutputParser(this.toolNames);
+    this.outputFixingParser = fields?.outputFixingParser;
+  }
+
+  async parse(text: string): Promise<AgentAction | AgentFinish> {
+    if (this.outputFixingParser !== undefined) {
+      return this.outputFixingParser.parse(text);
+    }
+    return this.baseParser.parse(text);
+  }
+
+  getFormatInstructions(): string {
+    return renderTemplate(FORMAT_INSTRUCTIONS, "f-string", {
+      tool_names: this.toolNames.join(", "),
+    });
+  }
+
+  static fromLLM(
+    llm: BaseLanguageModel,
+    options: Omit<
+      StructuredChatConversationalOutputParserArgs,
+      "outputFixingParser"
+    >
+  ): StructuredChatConversationalOutputParserWithRetries {
+    const baseParser =
+      options.baseParser ??
+      new StructuredChatConversationalOutputParser(options.toolNames ?? []);
+    const outputFixingParser = OutputFixingParser.fromLLM(llm, baseParser);
+    return new StructuredChatConversationalOutputParserWithRetries({
+      baseParser,
+      outputFixingParser,
+      toolNames: options.toolNames,
+    });
+  }
+}

--- a/langchain/src/agents/structured_chat_convo/prompt.ts
+++ b/langchain/src/agents/structured_chat_convo/prompt.ts
@@ -1,0 +1,59 @@
+export const PREFIX = `Answer the following questions truthfully and as best you can.`;
+export const AGENT_ACTION_FORMAT_INSTRUCTIONS = `Output a JSON markdown code snippet containing a valid JSON blob (denoted below by $JSON_BLOB).
+This $JSON_BLOB must have a "action" key (with the name of the tool to use) and an "action_input" key (tool input).
+
+Valid "action" values: "Final Answer" (which you must use when giving your final response to the user), or one of [{tool_names}].
+
+The $JSON_BLOB must be valid, parseable JSON and only contain a SINGLE action. Here is an example of an acceptable output:
+
+\`\`\`json
+{{
+  "action": $TOOL_NAME
+  "action_input": $INPUT
+}}
+\`\`\`
+
+Remember to include the surrounding markdown code snippet delimiters (begin with "\`\`\`" json and close with "\`\`\`")!
+`;
+export const FORMAT_INSTRUCTIONS = `You have access to the following tools.
+You must format your inputs to these tools to match their "JSON schema" definitions below.
+
+"JSON Schema" is a declarative language that allows you to annotate and validate JSON documents.
+
+For example, the example "JSON Schema" instance {{"properties": {{"foo": {{"description": "a list of test words", "type": "array", "items": {{"type": "string"}}}}}}, "required": ["foo"]}}}}
+would match an object with one required property, "foo". The "type" property specifies "foo" must be an "array", and the "description" property semantically describes it as "a list of test words". The items within "foo" must be strings.
+Thus, the object {{"foo": ["bar", "baz"]}} is a well-formatted instance of this example "JSON Schema". The object {{"properties": {{"foo": ["bar", "baz"]}}}} is not well-formatted.
+
+Here are the JSON Schema instances for the tools you have access to:
+
+{tool_schemas}
+
+The way you use the tools is as follows:
+
+------------------------
+
+${AGENT_ACTION_FORMAT_INSTRUCTIONS}
+
+If you are using a tool, "action_input" must adhere to the tool's input schema, given above.
+
+------------------------
+
+ALWAYS use the following format:
+
+Question: the input question you must answer
+Thought: you should always think about what to do
+Action:
+\`\`\`json
+$JSON_BLOB
+\`\`\`
+Observation: the result of the action
+... (this Thought/Action/Observation can repeat N times)
+Thought: I now know the final answer
+Action:
+\`\`\`json
+{{
+  "action": "Final Answer",
+  "action_input": "Final response to human"
+}}
+\`\`\``;
+export const SUFFIX = `Begin! Reminder to ALWAYS use the above format, and to use tools if appropriate.`;

--- a/langchain/src/agents/tests/evaluation.int.test.ts
+++ b/langchain/src/agents/tests/evaluation.int.test.ts
@@ -32,6 +32,14 @@ const agents = [
       new ChatOpenAI({ temperature: 0 }),
       { agentType: "structured-chat-zero-shot-react-description" }
     ),
+  (tools) =>
+    initializeAgentExecutorWithOptions(
+      tools,
+      new ChatOpenAI({ temperature: 0 }),
+      {
+        agentType: "structured-chat-conversational-zero-shot-react-description",
+      }
+    ),
 ] as ((
   tools: Tool[]
 ) => ReturnType<typeof initializeAgentExecutorWithOptions>)[];


### PR DESCRIPTION
Implements Structured Conversational Agent.

This is a continuation of the conversation from GH-1414. @jacoblee93 prefers this to be a new agent so the original StructuredAgent could be kept closer to the python version.

Note that it has a slight modification to the prompt to ensure better performance with the memory, as introducing the memory caused it to very frequently forget instructions.

It also uses a Human prompt rather than a System prompt because according to [OpenAI docs](https://platform.openai.com/docs/guides/chat/introduction) `gpt-3.5-turbo-0301` does not always pay strong attention to  system messages. And since that's a very popular chat model, it'd hinder the performance of the agent.

