### PR TITLE
Make the get request tool more reliable for StructuredAgent

### DIFF
--- a/langchain/src/tools/requests.ts
+++ b/langchain/src/tools/requests.ts
@@ -33,7 +33,7 @@ export class RequestsGetTool extends Tool implements RequestTool {
   }
 
   description = `A portal to the internet. Use this when you need to get specific content from a website. 
-  Input should be a  url (i.e. https://www.google.com). The output will be the text response of the GET request.`;
+  Input should be a url string (i.e. "https://www.google.com"). The output will be the text response of the GET request.`;
 }
 
 export class RequestsPostTool extends Tool implements RequestTool {


### PR DESCRIPTION
StructuredAgent needs to format this to {action, action_input} format where `action_input: string`. However, gpt-3.5-turbo very frequently fails to do so. Instead it generates formats like this: `{action, action_input: {url}}`.

This tiny prompt change makes it more reliable.
