### PR TITLE
Refactor conversational retrieval QA chain factory method

### DIFF
--- a/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
+++ b/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
@@ -25,8 +25,11 @@ static fromLLM(
   llm: BaseLanguageModel,
   retriever: BaseRetriever,
   options?: {
-    questionGeneratorTemplate?: string;
-    qaTemplate?: string;
+    questionGeneratorChainOptions?: {
+      llm?: BaseLanguageModel;
+      template?: string;
+    };
+    qaChainOptions?: QAChainParams;
     returnSourceDocuments?: boolean;
   }
 ): ConversationalRetrievalQAChain
@@ -34,8 +37,13 @@ static fromLLM(
 
 Here's an explanation of each of the attributes of the options object:
 
-- `questionGeneratorTemplate`: A string that specifies a question generation template. If provided, the `ConversationalRetrievalQAChain` will use this template to generate a question from the conversation context, instead of using the question provided in the question parameter. This can be useful if the original question does not contain enough information to retrieve a suitable answer.
-- `qaTemplate`: A string that specifies a response template. If provided, the `ConversationalRetrievalQAChain` will use this template to format a response before returning the result. This can be useful if you want to customize the way the response is presented to the end user.
+- `questionGeneratorChainOptions`: An object that allows you to pass a custom template and LLM to the underlying question generation chain.
+  - If the template is provided, the `ConversationalRetrievalQAChain` will use this template to generate a question from the conversation context instead of using the question provided in the question parameter.
+    This can be useful if the original question does not contain enough information to retrieve a suitable answer.
+  - Passing in a separate LLM here allows you to use a cheaper/faster model to create the condensed question while using a more powerful model for the final response, and can reduce unnecessary latency.
+- `qaChainOptions`: Options that allow you to customize the specific QA chain used in the final step. The default is the [`StuffDocumentsChain`](/docs/modules/chains/index_related_chains/document_qa), but you can customize which chain is used by passing in a `type` parameter.
+  Passing specific options here can be useful if you want to customize the way the response is presented to the end user, or if you have too many documents for a `StuffDocumentsChain`.
+  You can see [documentation about the usable fields here](/docs/api/chains/types/QAChainParams).
 - `returnSourceDocuments`: A boolean value that indicates whether the `ConversationalRetrievalQAChain` should return the source documents that were used to retrieve the answer. If set to true, the documents will be included in the result returned by the call() method. This can be useful if you want to allow the user to see the sources used to generate the answer. If not set, the default value will be false.
 
-In summary, the `questionGeneratorTemplate`, `qaTemplate`, and `returnSourceDocuments` options allow the user to customize the behavior of the `ConversationalRetrievalQAChain`
+In summary, the `questionGeneratorChainOptions`, `qaChainOptions`, and `returnSourceDocuments` options allow the user to customize the behavior of the `ConversationalRetrievalQAChain`

--- a/langchain/src/chains/tests/conversational_retrieval_chain.int.test.ts
+++ b/langchain/src/chains/tests/conversational_retrieval_chain.int.test.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "@jest/globals";
+import { OpenAI } from "../../llms/openai.js";
+import { ConversationalRetrievalQAChain } from "../conversational_retrieval_chain.js";
+import { HNSWLib } from "../../vectorstores/hnswlib.js";
+import { OpenAIEmbeddings } from "../../embeddings/openai.js";
+import { ChatOpenAI } from "../../chat_models/openai.js";
+import { PromptTemplate } from "../../prompts/index.js";
+
+test("Test ConversationalRetrievalQAChain from LLM", async () => {
+  const model = new OpenAI({ modelName: "text-ada-001" });
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new OpenAIEmbeddings()
+  );
+  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever());
+  const res = await chain.call({ question: "foo", chat_history: "bar" });
+  console.log({ res });
+});
+
+test("Test ConversationalRetrievalQAChain from LLM with flag option to return source", async () => {
+  const model = new OpenAI({ modelName: "text-ada-001" });
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new OpenAIEmbeddings()
+  );
+  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever(), {
+    returnSourceDocuments: true,
+  });
+  const res = await chain.call({ question: "foo", chat_history: "bar" });
+
+  expect(res).toEqual(
+    expect.objectContaining({
+      text: expect.any(String),
+      sourceDocuments: expect.arrayContaining([
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            id: expect.any(Number),
+          }),
+          pageContent: expect.any(String),
+        }),
+      ]),
+    })
+  );
+});
+
+test("Test ConversationalRetrievalQAChain from LLM with override default prompts", async () => {
+  const model = new OpenAI({ modelName: "text-ada-001", temperature: 0 });
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new OpenAIEmbeddings()
+  );
+
+  const qa_template = `Use the following pieces of context to answer the question at the end. If you don't know the answer, just say "Sorry I dont know, I am learning from Aliens", don't try to make up an answer.
+  {context}
+
+  Question: {question}
+  Helpful Answer:`;
+
+  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever(), {
+    qaTemplate: qa_template,
+  });
+  const res = await chain.call({
+    question: "What is better programming Language Python or Javascript ",
+    chat_history: "bar",
+  });
+  expect(res.text).toContain("I am learning from Aliens");
+  console.log({ res });
+});
+
+test("Test ConversationalRetrievalQAChain from LLM with a chat model", async () => {
+  const model = new ChatOpenAI({
+    modelName: "gpt-3.5-turbo",
+    temperature: 0
+  });
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new OpenAIEmbeddings()
+  );
+  const qa_template = `Use the following pieces of context to answer the question at the end. If you don't know the answer, just say "Sorry I dont know, I am learning from Aliens", don't try to make up an answer.
+  {context}
+
+  Question: {question}
+  Helpful Answer:`;
+
+  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever(), {
+    qaChainOptions: {
+      type: "stuff",
+      prompt: PromptTemplate.fromTemplate(qa_template)
+    }
+  });
+  const res = await chain.call({
+    question: "What is better programming Language Python or Javascript ",
+    chat_history: "bar",
+  });
+  expect(res.text).toContain("I am learning from Aliens");
+  console.log({ res });
+});
+
+test("Test ConversationalRetrievalQAChain from LLM with a map reduce chain", async () => {
+  const model = new ChatOpenAI({
+    modelName: "gpt-3.5-turbo",
+    temperature: 0
+  });
+  const vectorStore = await HNSWLib.fromTexts(
+    ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new OpenAIEmbeddings()
+  );
+
+  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever(), {
+    qaChainOptions: {
+      type: "map_reduce"
+    }
+  });
+  const res = await chain.call({
+    question: "What is better programming Language Python or Javascript ",
+    chat_history: "bar",
+  });
+
+  console.log({ res });
+});

--- a/langchain/src/chains/tests/conversational_retrieval_chain.int.test.ts
+++ b/langchain/src/chains/tests/conversational_retrieval_chain.int.test.ts
@@ -13,7 +13,10 @@ test("Test ConversationalRetrievalQAChain from LLM", async () => {
     [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
     new OpenAIEmbeddings()
   );
-  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever());
+  const chain = ConversationalRetrievalQAChain.fromLLM(
+    model,
+    vectorStore.asRetriever()
+  );
   const res = await chain.call({ question: "foo", chat_history: "bar" });
   console.log({ res });
 });
@@ -25,9 +28,13 @@ test("Test ConversationalRetrievalQAChain from LLM with flag option to return so
     [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
     new OpenAIEmbeddings()
   );
-  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever(), {
-    returnSourceDocuments: true,
-  });
+  const chain = ConversationalRetrievalQAChain.fromLLM(
+    model,
+    vectorStore.asRetriever(),
+    {
+      returnSourceDocuments: true,
+    }
+  );
   const res = await chain.call({ question: "foo", chat_history: "bar" });
 
   expect(res).toEqual(
@@ -59,9 +66,13 @@ test("Test ConversationalRetrievalQAChain from LLM with override default prompts
   Question: {question}
   Helpful Answer:`;
 
-  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever(), {
-    qaTemplate: qa_template,
-  });
+  const chain = ConversationalRetrievalQAChain.fromLLM(
+    model,
+    vectorStore.asRetriever(),
+    {
+      qaTemplate: qa_template,
+    }
+  );
   const res = await chain.call({
     question: "What is better programming Language Python or Javascript ",
     chat_history: "bar",
@@ -73,7 +84,7 @@ test("Test ConversationalRetrievalQAChain from LLM with override default prompts
 test("Test ConversationalRetrievalQAChain from LLM with a chat model", async () => {
   const model = new ChatOpenAI({
     modelName: "gpt-3.5-turbo",
-    temperature: 0
+    temperature: 0,
   });
   const vectorStore = await HNSWLib.fromTexts(
     ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
@@ -86,12 +97,16 @@ test("Test ConversationalRetrievalQAChain from LLM with a chat model", async () 
   Question: {question}
   Helpful Answer:`;
 
-  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever(), {
-    qaChainOptions: {
-      type: "stuff",
-      prompt: PromptTemplate.fromTemplate(qa_template)
+  const chain = ConversationalRetrievalQAChain.fromLLM(
+    model,
+    vectorStore.asRetriever(),
+    {
+      qaChainOptions: {
+        type: "stuff",
+        prompt: PromptTemplate.fromTemplate(qa_template),
+      },
     }
-  });
+  );
   const res = await chain.call({
     question: "What is better programming Language Python or Javascript ",
     chat_history: "bar",
@@ -103,7 +118,7 @@ test("Test ConversationalRetrievalQAChain from LLM with a chat model", async () 
 test("Test ConversationalRetrievalQAChain from LLM with a map reduce chain", async () => {
   const model = new ChatOpenAI({
     modelName: "gpt-3.5-turbo",
-    temperature: 0
+    temperature: 0,
   });
   const vectorStore = await HNSWLib.fromTexts(
     ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
@@ -111,11 +126,15 @@ test("Test ConversationalRetrievalQAChain from LLM with a map reduce chain", asy
     new OpenAIEmbeddings()
   );
 
-  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever(), {
-    qaChainOptions: {
-      type: "map_reduce"
+  const chain = ConversationalRetrievalQAChain.fromLLM(
+    model,
+    vectorStore.asRetriever(),
+    {
+      qaChainOptions: {
+        type: "map_reduce",
+      },
     }
-  });
+  );
   const res = await chain.call({
     question: "What is better programming Language Python or Javascript ",
     chat_history: "bar",


### PR DESCRIPTION
# Support easier customization for the ConversationalRetrievalQAChain

Fixes #1417 (which is supported in Python), and adds the ability to use different LLMs for the combination step. 