### PR TITLE
Minor documentation updates

### DIFF
--- a/docs/docs/getting-started/guide-llm.mdx
+++ b/docs/docs/getting-started/guide-llm.mdx
@@ -91,7 +91,7 @@ We will then need to set the environment variable for the OpenAI key. Three opti
      azureOpenAIApiInstanceName: "....",
      azureOpenAIApiDeploymentName: "....",
      azureOpenAIApiVersion: "....",
-     temperature: 0.9
+     temperature: 0.9,
    });
    ```
 

--- a/docs/docs/getting-started/guide-llm.mdx
+++ b/docs/docs/getting-started/guide-llm.mdx
@@ -85,7 +85,7 @@ We will then need to set the environment variable for the OpenAI key. Three opti
 
    3.2. For Azure OpenAI:
 
-   ```bash
+   ```typescript
    const model = new OpenAI({
      azureOpenAIApiKey: "...",
      azureOpenAIApiInstanceName: "....",

--- a/examples/src/prompts/structured_parser.ts
+++ b/examples/src/prompts/structured_parser.ts
@@ -27,13 +27,18 @@ const response = await model.call(input);
 console.log(input);
 /*
 Answer the users question as best as possible.
-The output should be formatted as a JSON instance that conforms to the JSON schema below.
+You must format your output as a JSON value that adheres to a given "JSON Schema" instance.
 
-As an example, for the schema {{"properties": {{"foo": {{"title": "Foo", "description": "a list of strings", "type": "array", "items": {{"type": "string"}}}}}}, "required": ["foo"]}}}}
-the object {{"foo": ["bar", "baz"]}} is a well-formatted instance of the schema. The object {{"properties": {{"foo": ["bar", "baz"]}}}} is not well-formatted.
+"JSON Schema" is a declarative language that allows you to annotate and validate JSON documents.
 
-Here is the output schema:
-```
+For example, the example "JSON Schema" instance {{"properties": {{"foo": {{"description": "a list of test words", "type": "array", "items": {{"type": "string"}}}}}}, "required": ["foo"]}}}}
+would match an object with one required property, "foo". The "type" property specifies "foo" must be an "array", and the "description" property semantically describes it as "a list of test words". The items within "foo" must be strings.
+Thus, the object {{"foo": ["bar", "baz"]}} is a well-formatted instance of this example "JSON Schema". The object {{"properties": {{"foo": ["bar", "baz"]}}}} is not well-formatted.
+
+Your output will be parsed and type-checked according to the provided schema instance, so make sure all fields in your output match the schema exactly and there are no trailing commas!
+
+Here is the JSON Schema instance your output must adhere to. Include the enclosing markdown codeblock:
+```json
 {"type":"object","properties":{"answer":{"type":"string","description":"answer to the user's question"},"source":{"type":"string","description":"source used to answer the user's question, should be a website."}},"required":["answer","source"],"additionalProperties":false,"$schema":"http://json-schema.org/draft-07/schema#"}
 ```
 
@@ -46,4 +51,4 @@ console.log(response);
 */
 
 console.log(await parser.parse(response));
-// { answer: 'Paris', source: 'https://en.wikipedia.org/wiki/France' }
+// { answer: 'Paris', source: 'https://en.wikipedia.org/wiki/Paris' }


### PR DESCRIPTION
# Minor documentation updates

There are three changes are made in this PR:

1. Code-block 3.2 on https://js.langchain.com/docs/getting-started/guide-llm is updated from `bash` to `typescript`
    - [Preview](https://langchainjs-docs-git-fork-m14t-fix-docs-paris-3d0cf4-langchain.vercel.app/docs/getting-started/guide-llm#building-a-language-model-application)
3. The parsed JSON on [Structured Output Parser](https://js.langchain.com/docs/modules/prompts/output_parsers/#structured-output-parser) now matches the string version
    - Previously the string was referencing `https://en.wikipedia.org/wiki/Paris` but somehow it parsed to `https://en.wikipedia.org/wiki/France`
    - [Preview](https://langchainjs-docs-git-fork-m14t-fix-docs-paris-3d0cf4-langchain.vercel.app/docs/modules/prompts/output_parsers/#structured-output-parser)
4. Update the Structured Output Parser to match the most recent copy. [[source code](https://github.com/hwchase17/langchainjs/blob/main/langchain/src/output_parsers/structured.ts#L51)]
    - [Preview](https://langchainjs-docs-git-fork-m14t-fix-docs-paris-3d0cf4-langchain.vercel.app/docs/modules/prompts/output_parsers/#structured-output-parser)

Mastodon: https://hachyderm.io/@m14t
Twitter: https://twitter.com/m14t