### PR TITLE
Add unit tests to chromadb integration

### DIFF
--- a/langchain/src/vectorstores/tests/chroma.test.ts
+++ b/langchain/src/vectorstores/tests/chroma.test.ts
@@ -1,11 +1,112 @@
-import { test, expect } from "@jest/globals";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { jest, test, expect } from "@jest/globals";
 
+import { type Collection } from "chromadb";
 import { Chroma } from "../chroma.js";
 
-// We'd want a much more thorough test here,
-// but sadly Chroma isn't very easy to test locally at the moment.
-test("Chroma imports correctly", async () => {
-  const { ChromaClient } = await Chroma.imports();
+const mockCollection = {
+  add: jest.fn<Collection["add"]>().mockResolvedValue(undefined as any),
+  count: jest.fn<Collection["count"]>().mockResolvedValue(5),
+  // not used, so leave out for now.
+  // upsert: jest.fn<Collection["upsert"]>().mockResolvedValue(undefined as any),
+  // modify: jest.fn<Collection["modify"]>().mockResolvedValue(undefined as any),
+  // get: jest.fn<Collection["get"]>().mockResolvedValue(undefined as any),
+  // update: jest.fn<Collection["update"]>().mockResolvedValue({ success: true }),
+  // query: jest.fn<Collection["query"]>().mockResolvedValue(undefined as any),
+  // peek: jest.fn<Collection["peek"]>().mockResolvedValue(undefined as any),
+  // delete: jest.fn<Collection["delete"]>().mockResolvedValue(undefined as any),
+} as any;
 
-  expect(ChromaClient).toBeDefined();
+const mockClient = {
+  getOrCreateCollection: jest.fn<any>().mockResolvedValue(mockCollection),
+} as any;
+
+const createMockEmbeddings = (): any => ({
+  embedDocuments: jest.fn<any>().mockResolvedValue([
+    [1, 2],
+    [3, 4],
+  ]),
+  embedQuery: jest.fn<any>().mockResolvedValue([1, 2]),
+});
+
+describe("Chroma", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  test("imports correctly", async () => {
+    const { ChromaClient } = await Chroma.imports();
+
+    expect(ChromaClient).toBeDefined();
+  });
+
+  test("constructor works", async () => {
+    const chromaStore = new Chroma(createMockEmbeddings(), {
+      index: mockClient,
+      collectionName: "test-collection",
+    });
+
+    expect(chromaStore).toBeDefined();
+  });
+  test("should add vectors to the collection", async () => {
+    const expectedPageContents = ["Document 1", "Document 2"];
+    const embeddings = createMockEmbeddings();
+
+    const args = { collectionName: "testCollection", index: mockClient };
+    const documents = expectedPageContents.map((pc) => ({ pageContent: pc }));
+
+    const chroma = new Chroma(embeddings, args);
+    await chroma.addDocuments(documents as any);
+
+    expect(mockClient.getOrCreateCollection).toHaveBeenCalled();
+    expect(embeddings.embedDocuments).toHaveBeenCalledWith(
+      expectedPageContents
+    );
+    expect(mockCollection.add).toHaveBeenCalled();
+  });
+
+  test("should throw an error for mismatched vector lengths", async () => {
+    const args = { collectionName: "testCollection" };
+    const vectors = [
+      [1, 2],
+      [3, 4],
+    ];
+    const documents = [
+      { metadata: { id: 1 }, pageContent: "Document 1" },
+      { metadata: { id: 2 }, pageContent: "Document 2" },
+    ];
+
+    const chroma = new Chroma(createMockEmbeddings(), args);
+    chroma.numDimensions = 3; // Mismatched numDimensions
+
+    await expect(chroma.addVectors(vectors, documents)).rejects.toThrowError();
+  });
+
+  test("should perform similarity search and return results", async () => {
+    const args = { collectionName: "testCollection" };
+    const query = [1, 2];
+    const expectedResultCount = 5;
+    mockCollection.query = jest.fn<Collection["query"]>().mockResolvedValue({
+      ids: [["0", "1", "2", "3", "4"]],
+      distances: [[0.1, 0.2, 0.3, 0.4, 0.5]],
+      documents: [
+        ["Document 1", "Document 2", "Document 3", "Document 4", "Document 5"],
+      ],
+      metadatas: [[{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]],
+    } as any);
+
+    const chroma = new Chroma(createMockEmbeddings(), args);
+    chroma.collection = mockCollection;
+
+    const results = await chroma.similaritySearchVectorWithScore(
+      query,
+      expectedResultCount
+    );
+
+    expect(mockCollection.query).toHaveBeenCalledWith({
+      query_embeddings: query,
+      n_results: expectedResultCount,
+      where: {},
+    });
+    expect(results).toHaveLength(5);
+  });
 });


### PR DESCRIPTION
# Add unit tests for chromadb integration

Per request, mocked out the chroma backend, and wrote unit tests that validate basic functionality of the Chroma VectorStore class

![image](https://github.com/hwchase17/langchainjs/assets/4615465/bbcae654-ec5c-4462-ac83-77cc1b7b227b)


Fixes #96  (issue)

Twitter handle: https://twitter.com/cparker7
