### PR TITLE
Add new filetypes supported by Unstructured

### DIFF
--- a/langchain/src/document_loaders/fs/unstructured.ts
+++ b/langchain/src/document_loaders/fs/unstructured.ts
@@ -106,7 +106,8 @@ export class UnstructuredLoader extends BaseDocumentLoader {
 
     if (!response.ok) {
       throw new Error(
-        `Failed to partition file ${this.filePath} with error ${response.status
+        `Failed to partition file ${this.filePath} with error ${
+          response.status
         } and message ${await response.text()}`
       );
     }

--- a/langchain/src/document_loaders/fs/unstructured.ts
+++ b/langchain/src/document_loaders/fs/unstructured.ts
@@ -29,7 +29,6 @@ const UNSTRUCTURED_API_FILETYPES = [
   ".xls",
   ".odt",
   ".epub",
-  ".json",
 ];
 
 type Element = {
@@ -107,8 +106,7 @@ export class UnstructuredLoader extends BaseDocumentLoader {
 
     if (!response.ok) {
       throw new Error(
-        `Failed to partition file ${this.filePath} with error ${
-          response.status
+        `Failed to partition file ${this.filePath} with error ${response.status
         } and message ${await response.text()}`
       );
     }

--- a/langchain/src/document_loaders/fs/unstructured.ts
+++ b/langchain/src/document_loaders/fs/unstructured.ts
@@ -107,7 +107,8 @@ export class UnstructuredLoader extends BaseDocumentLoader {
 
     if (!response.ok) {
       throw new Error(
-        `Failed to partition file ${this.filePath} with error ${response.status
+        `Failed to partition file ${this.filePath} with error ${
+          response.status
         } and message ${await response.text()}`
       );
     }

--- a/langchain/src/document_loaders/fs/unstructured.ts
+++ b/langchain/src/document_loaders/fs/unstructured.ts
@@ -19,10 +19,17 @@ const UNSTRUCTURED_API_FILETYPES = [
   ".jpeg",
   ".eml",
   ".html",
+  ".htm",
   ".md",
   ".pptx",
   ".ppt",
   ".msg",
+  ".rtf",
+  ".xlsx",
+  ".xls",
+  ".odt",
+  ".epub",
+  ".json",
 ];
 
 type Element = {
@@ -100,8 +107,7 @@ export class UnstructuredLoader extends BaseDocumentLoader {
 
     if (!response.ok) {
       throw new Error(
-        `Failed to partition file ${this.filePath} with error ${
-          response.status
+        `Failed to partition file ${this.filePath} with error ${response.status
         } and message ${await response.text()}`
       );
     }


### PR DESCRIPTION
# Expands list of file types supported by Unstructured to reflect updated to Unstructured library/API

Update the list of file extensions supported by Unstructured to add the following:
* `.htm` (`.html` was already supported, no reason this shouldn't be included)
* `.rtf` (Rich Text Format)
* `.xlsx`(MS Excel files since 2007)
* `.xls` (older MS Excel files)
* `.odt` (OpenDocument files)
* `.epub` (open e-book format)