### PR TITLE
Upgrade Chroma to 1.5.2

### DIFF
--- a/langchain/package.json
+++ b/langchain/package.json
@@ -428,7 +428,7 @@
     "apify-client": "^2.7.1",
     "axios": "^0.26.0",
     "cheerio": "^1.0.0-rc.12",
-    "chromadb": "^1.5.1",
+    "chromadb": "^1.5.2",
     "cohere-ai": "^5.0.2",
     "d3-dsv": "^2.0.0",
     "dotenv": "^16.0.3",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -428,7 +428,7 @@
     "apify-client": "^2.7.1",
     "axios": "^0.26.0",
     "cheerio": "^1.0.0-rc.12",
-    "chromadb": "^1.4.2",
+    "chromadb": "^1.5.1",
     "cohere-ai": "^5.0.2",
     "d3-dsv": "^2.0.0",
     "dotenv": "^16.0.3",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -491,7 +491,7 @@
     "apify-client": "^2.7.1",
     "axios": "*",
     "cheerio": "^1.0.0-rc.12",
-    "chromadb": "^1.4.2",
+    "chromadb": "^1.5.2",
     "cohere-ai": "^5.0.2",
     "d3-dsv": "^2.0.0",
     "epub2": "^3.0.1",

--- a/langchain/src/vectorstores/chroma.ts
+++ b/langchain/src/vectorstores/chroma.ts
@@ -117,8 +117,8 @@ export class Chroma extends VectorStore {
     // similaritySearchVectorWithScore supports one query vector at a time
     // chroma supports multiple query vectors at a time
     const result = await collection.query({
-      query_embeddings: query,
-      n_results: k,
+      queryEmbeddings: query,
+      nResults: k,
       where: { ..._filter },
     });
 

--- a/langchain/src/vectorstores/tests/chroma.test.ts
+++ b/langchain/src/vectorstores/tests/chroma.test.ts
@@ -96,8 +96,8 @@ describe("Chroma", () => {
     );
 
     expect(mockCollection.query).toHaveBeenCalledWith({
-      query_embeddings: query,
-      n_results: expectedResultCount,
+      queryEmbeddings: query,
+      nResults: expectedResultCount,
       where: {},
     });
     expect(results).toHaveLength(5);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10757,10 +10757,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromadb@npm:^1.4.2":
-  version: 1.4.2
-  resolution: "chromadb@npm:1.4.2"
-  checksum: 6fe81e889ae3f6ac39c1a168bcabe12771b0a5271be503db47aa3f8e5c159e29e5eaa7387780fb08d8ef370a42ce58455de1f0622367cb62c4486dfb3b84c20f
+"chromadb@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "chromadb@npm:1.5.1"
+  checksum: e6391aaef158832fc6edb18fc33e3b5c80a9d4c4e1cb549957081ad6134d61061b015d6a04d3ec268aea9a9a2e8bac6ab57fb48a232d725288dbe545f787c19d
   languageName: node
   linkType: hard
 
@@ -18328,7 +18328,7 @@ __metadata:
     axios: ^0.26.0
     binary-extensions: ^2.2.0
     cheerio: ^1.0.0-rc.12
-    chromadb: ^1.4.2
+    chromadb: ^1.5.1
     cohere-ai: ^5.0.2
     d3-dsv: ^2.0.0
     dotenv: ^16.0.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -10757,10 +10757,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromadb@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "chromadb@npm:1.5.1"
-  checksum: e6391aaef158832fc6edb18fc33e3b5c80a9d4c4e1cb549957081ad6134d61061b015d6a04d3ec268aea9a9a2e8bac6ab57fb48a232d725288dbe545f787c19d
+"chromadb@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "chromadb@npm:1.5.2"
+  checksum: 8eace35a0baed74db78695682984ba4263390eaac15e093241bc318ec377e341f12e11c282b76802633df95334203ae1f2173e5ba13cf32b1c5963f0b0a95153
   languageName: node
   linkType: hard
 
@@ -18328,7 +18328,7 @@ __metadata:
     axios: ^0.26.0
     binary-extensions: ^2.2.0
     cheerio: ^1.0.0-rc.12
-    chromadb: ^1.5.1
+    chromadb: ^1.5.2
     cohere-ai: ^5.0.2
     d3-dsv: ^2.0.0
     dotenv: ^16.0.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -18403,7 +18403,7 @@ __metadata:
     apify-client: ^2.7.1
     axios: "*"
     cheerio: ^1.0.0-rc.12
-    chromadb: ^1.4.2
+    chromadb: ^1.5.2
     cohere-ai: ^5.0.2
     d3-dsv: ^2.0.0
     epub2: ^3.0.1


### PR DESCRIPTION
Upgrade chroma to 1.5.2

chomadb@1.5.1 introduces a breaking change, switching from `snake_case` to `camelCase` arguments in `collection.query`. 
chromadb@1.5.2 fixes a type error introduced in 1.5.0

Fixes #1481 

`$ yarn test:single langchain/src/vectorstores/tests/chroma.test.ts ` passes