### PR TITLE
Add pinecone metadata string array support

### DIFF
--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -57,12 +57,24 @@ export class PineconeStore extends VectorStore {
     const documentIds = ids == null ? documents.map(() => uuid.v4()) : ids;
     const pineconeVectors = vectors.map((values, idx) => {
       // Pinecone doesn't support nested objects, so we flatten them
+      const documentMetadata = {...documents[idx].metadata};
+      // preserve string arrays which are allowed
+      const stringArrays: Record<string, string[]> = {};
+      for (const key of Object.keys(documentMetadata)) {
+        if (Array.isArray(documentMetadata[key]) &&
+          // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
+          documentMetadata[key].every((el: any) => typeof el === "string")) {
+          stringArrays[key] = documentMetadata[key];
+          delete documentMetadata[key];
+        }
+      }
       const metadata: {
-        [key: string]: string | number | boolean | null;
-      } = flatten({
-        ...documents[idx].metadata,
+        [key: string]: string | number | boolean | string[] | null;
+      } = {
+        ...flatten(documentMetadata),
+        ...stringArrays,
         [this.textKey]: documents[idx].pageContent,
-      });
+      };
       // Pinecone doesn't support null values, so we remove them
       for (const key of Object.keys(metadata)) {
         if (metadata[key] == null) {
@@ -74,6 +86,7 @@ export class PineconeStore extends VectorStore {
           delete metadata[key];
         }
       }
+
       return {
         id: documentIds[idx],
         metadata,

--- a/langchain/src/vectorstores/pinecone.ts
+++ b/langchain/src/vectorstores/pinecone.ts
@@ -57,13 +57,15 @@ export class PineconeStore extends VectorStore {
     const documentIds = ids == null ? documents.map(() => uuid.v4()) : ids;
     const pineconeVectors = vectors.map((values, idx) => {
       // Pinecone doesn't support nested objects, so we flatten them
-      const documentMetadata = {...documents[idx].metadata};
+      const documentMetadata = { ...documents[idx].metadata };
       // preserve string arrays which are allowed
       const stringArrays: Record<string, string[]> = {};
       for (const key of Object.keys(documentMetadata)) {
-        if (Array.isArray(documentMetadata[key]) &&
+        if (
+          Array.isArray(documentMetadata[key]) &&
           // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/no-explicit-any
-          documentMetadata[key].every((el: any) => typeof el === "string")) {
+          documentMetadata[key].every((el: any) => typeof el === "string")
+        ) {
           stringArrays[key] = documentMetadata[key];
           delete documentMetadata[key];
         }

--- a/langchain/src/vectorstores/tests/pinecone.test.ts
+++ b/langchain/src/vectorstores/tests/pinecone.test.ts
@@ -91,7 +91,7 @@ test("PineconeSo with string arrays", async () => {
           a: 1,
           b: { nested: [1, { a: 4 }] },
           c: ["some", "string", "array"],
-          d: [ 1, { nested: 2 }, "string" ],
+          d: [1, { nested: 2 }, "string"],
         },
       },
     ],
@@ -104,13 +104,19 @@ test("PineconeSo with string arrays", async () => {
       vectors: [
         {
           id: "id1",
-          metadata: { a: 1, "b.nested.0": 1, "b.nested.1.a": 4,
-                      c: ["some", "string", "array"],
-                      "d.0": 1, "d.1.nested": 2, "d.2": "string",
-                      text: "hello" },
+          metadata: {
+            a: 1,
+            "b.nested.0": 1,
+            "b.nested.1.a": 4,
+            c: ["some", "string", "array"],
+            "d.0": 1,
+            "d.1.nested": 2,
+            "d.2": "string",
+            text: "hello",
+          },
           values: [0.1, 0.2, 0.3, 0.4],
         },
       ],
     },
   });
-})
+});

--- a/langchain/src/vectorstores/tests/pinecone.test.ts
+++ b/langchain/src/vectorstores/tests/pinecone.test.ts
@@ -71,3 +71,46 @@ test("PineconeStore with generated ids", async () => {
 
   expect(results).toHaveLength(0);
 });
+
+test("PineconeSo with string arrays", async () => {
+  const client = {
+    upsert: jest.fn(),
+    query: jest.fn<any>().mockResolvedValue({
+      matches: [],
+    }),
+  };
+  const embeddings = new FakeEmbeddings();
+
+  const store = new PineconeStore(embeddings, { pineconeIndex: client as any });
+
+  await store.addDocuments(
+    [
+      {
+        pageContent: "hello",
+        metadata: {
+          a: 1,
+          b: { nested: [1, { a: 4 }] },
+          c: ["some", "string", "array"],
+          d: [ 1, { nested: 2 }, "string" ],
+        },
+      },
+    ],
+    ["id1"]
+  );
+
+  expect(client.upsert).toHaveBeenCalledWith({
+    upsertRequest: {
+      namespace: undefined,
+      vectors: [
+        {
+          id: "id1",
+          metadata: { a: 1, "b.nested.0": 1, "b.nested.1.a": 4,
+                      c: ["some", "string", "array"],
+                      "d.0": 1, "d.1.nested": 2, "d.2": "string",
+                      text: "hello" },
+          values: [0.1, 0.2, 0.3, 0.4],
+        },
+      ],
+    },
+  });
+})


### PR DESCRIPTION
# Add pinecone metadata string array support

Pinecone documents support string arrays, so they shouldn't be flattened.
This fix basically removes all arrays from the metadata object which contain only strings and appends them after the remaining metadata object was flattened.

Fixes #1446 