### PR TITLE
Update docs with a memory + returnSourceDocuments example and test

### DIFF
--- a/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
+++ b/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
@@ -45,14 +45,17 @@ Here's an explanation of each of the attributes of the options object:
   Passing specific options here can be useful if you want to customize the way the response is presented to the end user, or if you have too many documents for a `StuffDocumentsChain`.
   You can see [documentation about the usable fields here](/docs/api/chains/types/QAChainParams).
 - `returnSourceDocuments`: A boolean value that indicates whether the `ConversationalRetrievalQAChain` should return the source documents that were used to retrieve the answer. If set to true, the documents will be included in the result returned by the call() method. This can be useful if you want to allow the user to see the sources used to generate the answer. If not set, the default value will be false.
+  - If you are using this option and passing in a memory instance, set `inputKey` and `outputKey` on the memory instance to the same values as the input and final output, which default to `"question"` and `"text"`, to specify the values that the memory should store.
 
-Here's a customization example using a faster LLM to generate questions and a slower, more comprehensive LLM for the final answer:
+## Built-in Memory
+
+Here's a customization example using a faster LLM to generate questions and a slower, more comprehensive LLM for the final answer, using a built-in memory object and returning source documents.
 
 import ConvoQACustomizationExample from "@examples/chains/conversational_qa_customization.ts";
 
 <CodeBlock language="typescript">{ConvoQACustomizationExample}</CodeBlock>
 
-## External Memory
+## Externally-Managed Memory
 
 If you'd like to format the chat history in a specific way, you can also pass the chat history in explicitly by omitting the `memory` option and passing in
 a `chat_history` string directly into the `chain.call` method:

--- a/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
+++ b/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
@@ -45,7 +45,7 @@ Here's an explanation of each of the attributes of the options object:
   Passing specific options here can be useful if you want to customize the way the response is presented to the end user, or if you have too many documents for a `StuffDocumentsChain`.
   You can see [documentation about the usable fields here](/docs/api/chains/types/QAChainParams).
 - `returnSourceDocuments`: A boolean value that indicates whether the `ConversationalRetrievalQAChain` should return the source documents that were used to retrieve the answer. If set to true, the documents will be included in the result returned by the call() method. This can be useful if you want to allow the user to see the sources used to generate the answer. If not set, the default value will be false.
-  - If you are using this option and passing in a memory instance, set `inputKey` and `outputKey` on the memory instance to the same values as the input and final output, which default to `"question"` and `"text"`, to specify the values that the memory should store.
+  - If you are using this option and passing in a memory instance, set `inputKey` and `outputKey` on the memory instance to the same values as the input and final output. These default to `"question"` and `"text"`, and to specify the values that the memory should store.
 
 ## Built-in Memory
 

--- a/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
+++ b/docs/docs/modules/chains/index_related_chains/conversational_retrieval.mdx
@@ -45,11 +45,11 @@ Here's an explanation of each of the attributes of the options object:
   Passing specific options here can be useful if you want to customize the way the response is presented to the end user, or if you have too many documents for a `StuffDocumentsChain`.
   You can see [documentation about the usable fields here](/docs/api/chains/types/QAChainParams).
 - `returnSourceDocuments`: A boolean value that indicates whether the `ConversationalRetrievalQAChain` should return the source documents that were used to retrieve the answer. If set to true, the documents will be included in the result returned by the call() method. This can be useful if you want to allow the user to see the sources used to generate the answer. If not set, the default value will be false.
-  - If you are using this option and passing in a memory instance, set `inputKey` and `outputKey` on the memory instance to the same values as the input and final output. These default to `"question"` and `"text"`, and to specify the values that the memory should store.
+  - If you are using this option and passing in a memory instance, set `inputKey` and `outputKey` on the memory instance to the same values as the chain input and final conversational chain output. These default to `"question"` and `"text"` respectively, and specify the values that the memory should store.
 
 ## Built-in Memory
 
-Here's a customization example using a faster LLM to generate questions and a slower, more comprehensive LLM for the final answer, using a built-in memory object and returning source documents.
+Here's a customization example using a faster LLM to generate questions and a slower, more comprehensive LLM for the final answer. It uses a built-in memory object and returns the referenced source documents:
 
 import ConvoQACustomizationExample from "@examples/chains/conversational_qa_customization.ts";
 

--- a/examples/src/chains/conversational_qa_customization.ts
+++ b/examples/src/chains/conversational_qa_customization.ts
@@ -21,9 +21,12 @@ export const run = async () => {
     slowerModel,
     vectorStore.asRetriever(),
     {
+      returnSourceDocuments: true,
       memory: new BufferMemory({
         memoryKey: "chat_history",
-        returnMessages: true,
+        inputKey: "question", // The key for the input to the chain
+        outputKey: "text", // The key for the final conversational output of the chain
+        returnMessages: true, // If using with a chat model
       }),
       questionGeneratorChainOptions: {
         llm: fasterModel,


### PR DESCRIPTION
Clarify examples around the `ConversationalRetrievalQAChain`.
