### PR TITLE
Include memory key when getMemory returns NotFoundError.

### DIFF
--- a/langchain/src/memory/zep.ts
+++ b/langchain/src/memory/zep.ts
@@ -67,8 +67,7 @@ export class ZepMemory extends BaseChatMemory implements ZepMemoryInput {
     } catch (error) {
       // eslint-disable-next-line no-instanceof/no-instanceof
       if (error instanceof NotFoundError) {
-        if (this.returnMessages)
-          return { [this.memoryKey]: [] }
+        if (this.returnMessages) return { [this.memoryKey]: [] };
         return [];
       } else {
         throw error;


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # 1539