### PR TITLE
Add Trace Grouping Helper

### DIFF
--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -603,7 +603,7 @@ export class TraceGroup {
   }
 }
 
-export async function traceAsChainGroup<T, A extends any[]>(
+export async function traceAsGroup<T, A extends any[]>(
   groupOptions: {
     name: string;
   } & LangChainTracerFields,

--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -14,6 +14,10 @@ import {
 } from "./handlers/initialize.js";
 import { getBufferString } from "../memory/base.js";
 import { getEnvironmentVariable } from "../util/env.js";
+import {
+  LangChainTracer,
+  LangChainTracerFields,
+} from "./handlers/tracer_langchain.js";
 
 type BaseCallbackManagerMethods = {
   [K in keyof CallbackHandlerMethods]?: (
@@ -555,4 +559,62 @@ function ensureHandler(
   }
 
   return BaseCallbackHandler.fromMethods(handler);
+}
+
+export class TraceGroup {
+  private runManager?: CallbackManagerForChainRun;
+
+  constructor(
+    private groupName: string,
+    private options?: {
+      sessionName?: string;
+      exampleId?: string;
+    }
+  ) {}
+
+  private async getTraceGroupCallbackManager(
+    group_name: string,
+    options?: LangChainTracerFields
+  ): Promise<CallbackManagerForChainRun> {
+    const cb = new LangChainTracer(options);
+    const cm = await CallbackManager.configure([cb]);
+    const runManager = await cm?.handleChainStart({ name: group_name }, {});
+    if (!runManager) {
+      throw new Error("Failed to create run group callback manager.");
+    }
+    return runManager;
+  }
+
+  async start(): Promise<CallbackManager> {
+    if (!this.runManager) {
+      this.runManager = await this.getTraceGroupCallbackManager(
+        this.groupName,
+        this.options
+      );
+    }
+    return this.runManager.getChild();
+  }
+
+  async end(): Promise<void> {
+    if (this.runManager) {
+      await this.runManager.handleChainEnd({});
+      this.runManager = undefined;
+    }
+  }
+}
+
+export async function traceAsChainGroup<T, A extends any[]>(
+  groupOptions: {
+    name: string;
+  } & LangChainTracerFields,
+  enclosedCode: (manager: CallbackManager, ...args: A) => Promise<T>,
+  ...args: A
+): Promise<T> {
+  const traceGroup = new TraceGroup(groupOptions.name, groupOptions);
+  const callbackManager = await traceGroup.start();
+  try {
+    return await enclosedCode(callbackManager, ...args);
+  } finally {
+    await traceGroup.end();
+  }
 }

--- a/langchain/src/callbacks/tests/manager.int.test.ts
+++ b/langchain/src/callbacks/tests/manager.int.test.ts
@@ -4,7 +4,7 @@ import { test } from "@jest/globals";
 import { LLMChain } from "../../chains/llm_chain.js";
 import { PromptTemplate } from "../../prompts/prompt.js";
 import { LLM } from "../../llms/base.js";
-import { CallbackManager, traceAsChainGroup } from "../manager.js";
+import { CallbackManager, traceAsGroup } from "../manager.js";
 import { ChainTool } from "../../tools/chain.js";
 
 class FakeLLM extends LLM {
@@ -31,7 +31,7 @@ test("Test grouping traces", async () => {
 
   const tool = new ChainTool({ chain, name: "fake", description: "fake" });
 
-  const result = await traceAsChainGroup(
+  const result = await traceAsGroup(
     { name: "my_chain_group" },
     async (manager: CallbackManager, arg1: string, { chain, nextChain }) => {
       const result = await chain.call({ input: arg1 }, manager);

--- a/langchain/src/callbacks/tests/manager.int.test.ts
+++ b/langchain/src/callbacks/tests/manager.int.test.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-process-env */
+import { test } from "@jest/globals";
+
+import { LLMChain } from "../../chains/llm_chain.js";
+import { PromptTemplate } from "../../prompts/prompt.js";
+import { LLM } from "../../llms/base.js";
+import { CallbackManager, traceAsChainGroup } from "../manager.js";
+import { ChainTool } from "../../tools/chain.js";
+
+class FakeLLM extends LLM {
+  _llmType() {
+    return "fake";
+  }
+
+  async _call(prompt: string): Promise<string> {
+    return prompt;
+  }
+}
+
+test("Test grouping traces", async () => {
+  process.env.LANGCHAIN_TRACING_V2 = "true";
+  const chain = new LLMChain({
+    llm: new FakeLLM({}),
+    prompt: PromptTemplate.fromTemplate("hello world"),
+  });
+
+  const nextChain = new LLMChain({
+    llm: new FakeLLM({}),
+    prompt: PromptTemplate.fromTemplate("This is the day"),
+  });
+
+  const tool = new ChainTool({ chain, name: "fake", description: "fake" });
+
+  const result = await traceAsChainGroup(
+    { name: "my_chain_group" },
+    async (manager: CallbackManager, arg1: string, { chain, nextChain }) => {
+      const result = await chain.call({ input: arg1 }, manager);
+      const nextResult = await nextChain.call(result, manager);
+      const toolResult = await tool.call(nextResult, manager);
+      return toolResult;
+    },
+    "I'm arg1",
+    { chain, nextChain }
+  );
+
+  console.log(result);
+});


### PR DESCRIPTION
Add helper function for grouping traces similar to the context manager in the [python library](https://github.com/hwchase17/langchain/blob/a0d847f63628c77d34e9e6003f45af6d59d83288/langchain/callbacks/manager.py#L131)