### PR TITLE
docs: Remove `node-only` label from the SingleStoreVectorStore doc

### DIFF
--- a/docs/docs/modules/indexes/vector_stores/integrations/singlestore.mdx
+++ b/docs/docs/modules/indexes/vector_stores/integrations/singlestore.mdx
@@ -1,16 +1,8 @@
----
-sidebar_class_name: node-only
----
-
 import CodeBlock from "@theme/CodeBlock";
 
 # SingleStore
 
 [SingleStoreDB](https://singlestore.com/) is a high-performing, distributed database system. For an extended period, it has offered support for vector functions such as [dot_product](https://docs.singlestore.com/managed-service/en/reference/sql-reference/vector-functions/dot_product.html), thus establishing itself as an optimal solution for AI applications necessitating text similarity matching.
-
-:::tip Compatibility
-Only available on Node.js.
-:::
 
 LangChain.js accepts `mysql2/promise Pool` as the connections pool for SingleStore vectorstore.
 


### PR DESCRIPTION
As the Python implementation is also available, we do not need to mark it as `Node-only` anymore.

@hwchase17 
