### PR TITLE
Add pagination to GoogleVertexAIEmbeddings

### DIFF
--- a/langchain/src/embeddings/tests/googlevertexai.int.test.ts
+++ b/langchain/src/embeddings/tests/googlevertexai.int.test.ts
@@ -11,11 +11,19 @@ test("Test GoogleVertexAIEmbeddings.embedQuery", async () => {
 
 test("Test GoogleVertexAIEmbeddings.embedDocuments", async () => {
   const embeddings = new GoogleVertexAIEmbeddings();
-  const res = await embeddings.embedDocuments(["Hello world", "Bye bye"]);
+  const res = await embeddings.embedDocuments([
+    "Hello world",
+    "Bye bye",
+    "we need",
+    "at least",
+    "six documents",
+    "to test pagination",
+  ]);
   console.log(res);
-  expect(res).toHaveLength(2);
-  expect(typeof res[0][0]).toBe("number");
-  expect(typeof res[1][0]).toBe("number");
+  expect(res).toHaveLength(6);
+  res.forEach((r) => {
+    expect(typeof r[0]).toBe("number");
+  });
 });
 
 test("Test end to end with HNSWLib", async () => {


### PR DESCRIPTION
As mentioned here: https://github.com/hwchase17/langchain/issues/5316 Vertex AI accepts 5 instances max when requesting text embeddings.

This PR chunks the embedding requests to a maximum length of 5.