### PR TITLE
add delete function to hnswlib index

### DIFF
--- a/docs/extras/modules/data_connection/vectorstores/integrations/hnswlib.mdx
+++ b/docs/extras/modules/data_connection/vectorstores/integrations/hnswlib.mdx
@@ -51,3 +51,9 @@ import ExampleSave from "@examples/indexes/vector_stores/hnswlib_saveload.ts";
 import ExampleFilter from "@examples/indexes/vector_stores/hnswlib_filter.ts";
 
 <CodeBlock language="typescript">{ExampleFilter}</CodeBlock>
+
+### Delete index
+
+import ExampleDelete from "@examples/indexes/vector_stores/hnswlib_delete.ts";
+
+<CodeBlock language="typescript">{ExampleDelete}</CodeBlock>

--- a/examples/src/indexes/vector_stores/hnswlib_delete.ts
+++ b/examples/src/indexes/vector_stores/hnswlib_delete.ts
@@ -1,0 +1,7 @@
+import { HNSWLib } from "langchain/vectorstores/hnswlib";
+
+export const run = async () => {
+  // Delete the vector store.
+  const directory = "your/directory/here";
+  await HNSWLib.delete(directory);
+};

--- a/examples/src/indexes/vector_stores/hnswlib_delete.ts
+++ b/examples/src/indexes/vector_stores/hnswlib_delete.ts
@@ -1,7 +1,10 @@
 import { HNSWLib } from "langchain/vectorstores/hnswlib";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 
-export const run = async () => {
-  // Delete the vector store.
-  const directory = "your/directory/here";
-  await HNSWLib.delete(directory);
-};
+// Save the vector store to a directory
+const directory = "your/directory/here";
+
+// Load the vector store from the same directory
+const loadedVectorStore = await HNSWLib.load(directory, new OpenAIEmbeddings());
+
+await loadedVectorStore.delete({ directory });

--- a/langchain/src/vectorstores/hnswlib.ts
+++ b/langchain/src/vectorstores/hnswlib.ts
@@ -166,7 +166,7 @@ export class HNSWLib extends SaveableVectorStore {
     try {
       await fs.access(path.join(directory, "hnswlib.index"));
     } catch (err) {
-      throw new Error(`Directory ${directory} does appear to be a hnswlib index`);
+      throw new Error(`Directory ${directory} does not contain a hnswlib index. Skipping delete.`);
     }
 
     await fs.rm(directory, { recursive: true, force: true });

--- a/langchain/src/vectorstores/hnswlib.ts
+++ b/langchain/src/vectorstores/hnswlib.ts
@@ -178,7 +178,7 @@ export class HNSWLib extends SaveableVectorStore {
       await fs.rm(path.join(params.directory, "docstore.json"), {
         force: true,
       }),
-      await fs.rm(path.join(params.directory, "args.json.x"), { force: true }),
+      await fs.rm(path.join(params.directory, "args.json"), { force: true }),
     ]);
   }
 

--- a/langchain/src/vectorstores/hnswlib.ts
+++ b/langchain/src/vectorstores/hnswlib.ts
@@ -160,16 +160,26 @@ export class HNSWLib extends SaveableVectorStore {
     );
   }
 
-  async delete(directory: string) {
+  async delete(params: { directory: string }) {
     const fs = await import("node:fs/promises");
     const path = await import("node:path");
     try {
-      await fs.access(path.join(directory, "hnswlib.index"));
+      await fs.access(path.join(params.directory, "hnswlib.index"));
     } catch (err) {
-      throw new Error(`Directory ${directory} does not contain a hnswlib index. Skipping delete.`);
+      throw new Error(
+        `Directory ${params.directory} does not contain a hnswlib.index file.`
+      );
     }
 
-    await fs.rm(directory, { recursive: true, force: true });
+    await Promise.all([
+      await fs.rm(path.join(params.directory, "hnswlib.index"), {
+        force: true,
+      }),
+      await fs.rm(path.join(params.directory, "docstore.json"), {
+        force: true,
+      }),
+      await fs.rm(path.join(params.directory, "args.json.x"), { force: true }),
+    ]);
   }
 
   async save(directory: string) {

--- a/langchain/src/vectorstores/hnswlib.ts
+++ b/langchain/src/vectorstores/hnswlib.ts
@@ -160,6 +160,18 @@ export class HNSWLib extends SaveableVectorStore {
     );
   }
 
+  async delete(directory: string) {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    try {
+      await fs.access(path.join(directory, "hnswlib.index"));
+    } catch (err) {
+      throw new Error(`Directory ${directory} does appear to be a hnswlib index`);
+    }
+
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+
   async save(directory: string) {
     const fs = await import("node:fs/promises");
     const path = await import("node:path");

--- a/langchain/src/vectorstores/tests/hnswlib.int.test.ts
+++ b/langchain/src/vectorstores/tests/hnswlib.int.test.ts
@@ -46,7 +46,7 @@ test("Test HNSWLib.fromTexts + addDocuments", async () => {
   expect(resultTwoMetadatas).toEqual([{ id: 2 }, { id: 3 }, { id: 4 }]);
 });
 
-test("Test HNSWLib.load and HNSWLib.save", async () => {
+test("Test HNSWLib.load, HNSWLib.save, and HNSWLib.delete", async () => {
   const vectorStore = await HNSWLib.fromTexts(
     ["Hello world", "Bye bye", "hello nice world"],
     [{ id: 2 }, { id: 1 }, { id: 3 }],
@@ -85,4 +85,12 @@ test("Test HNSWLib.load and HNSWLib.save", async () => {
 
   const resultFourMetadatas = resultFour.map(({ metadata }) => metadata);
   expect(resultFourMetadatas).toEqual([{ id: 2 }, { id: 3 }, { id: 1 }]);
+
+  await loadedVectorStore.delete({
+    directory: tempDirectory,
+  });
+
+  await expect(async () => {
+    await HNSWLib.load(tempDirectory, new OpenAIEmbeddings());
+  }).rejects.toThrow();
 });


### PR DESCRIPTION
Adding delete function for `hnswlib.ts`. Useful when you have limited disk space or use many indexes and need to clean them up.

Fixes #1107