### PR TITLE
Export the agent

### DIFF
--- a/langchain/src/agents/index.ts
+++ b/langchain/src/agents/index.ts
@@ -70,3 +70,8 @@ export {
   StructuredChatOutputParserArgs,
   StructuredChatOutputParserWithRetries,
 } from "./structured_chat/outputParser.js";
+export {
+  OpenAIAgent,
+  OpenAIAgentInput,
+  OpenAIAgentCreatePromptArgs,
+} from "./openai/index.js";


### PR DESCRIPTION
Unlike other agents the new OpenAIAgent and the interfaces related to it are not exported and thus cannot be used directly.
This patch exports them.