### PR TITLE
handle managed motorhead data key

### DIFF
--- a/langchain/src/memory/motorhead_memory.ts
+++ b/langchain/src/memory/motorhead_memory.ts
@@ -19,8 +19,6 @@ export interface MotorheadMemoryMessage {
 export type MotorheadMemoryInput = BaseChatMemoryInput &
   AsyncCallerParams & {
     sessionId: string;
-    /** @deprecated Use "url" instead. */
-    motorheadURL?: string;
     url?: string;
     memoryKey?: string;
     timeout?: number;
@@ -52,7 +50,6 @@ export class MotorheadMemory extends BaseChatMemory {
     const {
       sessionId,
       url,
-      motorheadURL,
       memoryKey,
       timeout,
       returnMessages,
@@ -67,7 +64,7 @@ export class MotorheadMemory extends BaseChatMemory {
 
     this.caller = new AsyncCaller(rest);
     this.sessionId = sessionId;
-    this.url = url ?? motorheadURL ?? this.url;
+    this.url = url ?? this.url;
     this.memoryKey = memoryKey ?? this.memoryKey;
     this.timeout = timeout ?? this.timeout;
     this.apiKey = apiKey;
@@ -108,7 +105,9 @@ export class MotorheadMemory extends BaseChatMemory {
       }
     );
 
-    const { messages = [], context = "NONE" } = await res.json();
+    const json = await res.json();
+    const data = json?.data || json;  // Managed Motorhead returns { data: { messages: [], context: "NONE" } }
+    const { messages = [], context = "NONE" } = data;
 
     await Promise.all(
       messages.reverse().map(async (message: MotorheadMemoryMessage) => {


### PR DESCRIPTION
# Handle Managed Motorhead Data Key
Managed motorhead will return a payload with a data key. we need to handle this to properly access messages from the server.