### PR TITLE
Add Upstash Redis cache

### DIFF
--- a/docs/docs/modules/models/llms/additional_functionality.mdx
+++ b/docs/docs/modules/models/llms/additional_functionality.mdx
@@ -81,6 +81,28 @@ const cache = new RedisCache(client);
 const model = new OpenAI({ cache });
 ```
 
+### Caching with Upstash Redis
+
+LangChain also provides an Upstash Redis-based cache. Like the Redis-based cache, this cache is useful if you want to share the cache across multiple processes or servers. The Upstash Redis client uses HTTP and supports edge environments. To use it, you'll need to install the `@upstash/redis` package:
+
+```bash npm2yarn
+npm install @upstash/redis
+```
+
+You'll also need an [Upstash account](https://docs.upstash.com/redis#create-account) and a [Redis database](https://docs.upstash.com/redis#create-a-database) to connect to. Once you've done that, retrieve your REST URL and REST token.
+
+Then, you can pass a `cache` option when you instantiate the LLM. For example:
+
+import UpstashRedisCacheExample from "@examples/cache/upstash_redis.ts";
+
+<CodeBlock language="typescript">{UpstashRedisCacheExample}</CodeBlock>
+
+You can also directly pass in a previously created [@upstash/redis](https://docs.upstash.com/redis/sdks/javascriptsdk/overview) client instance:
+
+import AdvancedUpstashRedisCacheExample from "@examples/cache/upstash_redis_advanced.ts";
+
+<CodeBlock language="typescript">{AdvancedUpstashRedisCacheExample}</CodeBlock>
+
 ## Adding a timeout
 
 By default, LangChain will wait indefinitely for a response from the model provider. If you want to add a timeout, you can pass a `timeout` option, in milliseconds, when you call the model. For example, for OpenAI:

--- a/examples/src/cache/upstash_redis.ts
+++ b/examples/src/cache/upstash_redis.ts
@@ -1,0 +1,12 @@
+import { OpenAI } from "langchain/llms/openai";
+import { UpstashRedisCache } from "langchain/cache/upstash_redis";
+
+// See https://docs.upstash.com/redis/howto/connectwithupstashredis#quick-start for connection options
+const cache = new UpstashRedisCache({
+  config: {
+    url: "UPSTASH_REDIS_REST_URL",
+    token: "UPSTASH_REDIS_REST_TOKEN",
+  },
+});
+
+const model = new OpenAI({ cache });

--- a/examples/src/cache/upstash_redis_advanced.ts
+++ b/examples/src/cache/upstash_redis_advanced.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { Redis } from "@upstash/redis";
+import https from "https";
+
+import { OpenAI } from "langchain/llms/openai";
+import { UpstashRedisCache } from "langchain/cache/upstash_redis";
+
+// const client = new Redis({
+//   url: process.env.UPSTASH_REDIS_REST_URL!,
+//   token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+//   agent: new https.Agent({ keepAlive: true }),
+// });
+
+// Or simply call Redis.fromEnv() to automatically load the UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN environment variables.
+const client = Redis.fromEnv({
+  agent: new https.Agent({ keepAlive: true }),
+});
+
+const cache = new UpstashRedisCache({ client });
+const model = new OpenAI({ cache });

--- a/examples/src/cache/upstash_redis_advanced.ts
+++ b/examples/src/cache/upstash_redis_advanced.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Redis } from "@upstash/redis";
 import https from "https";
 

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -352,6 +352,9 @@ cache/momento.d.ts
 cache/redis.cjs
 cache/redis.js
 cache/redis.d.ts
+cache/upstash_redis.cjs
+cache/upstash_redis.js
+cache/upstash_redis.d.ts
 stores/doc/in_memory.cjs
 stores/doc/in_memory.js
 stores/doc/in_memory.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -364,6 +364,9 @@
     "cache/redis.cjs",
     "cache/redis.js",
     "cache/redis.d.ts",
+    "cache/upstash_redis.cjs",
+    "cache/upstash_redis.js",
+    "cache/upstash_redis.d.ts",
     "stores/doc/in_memory.cjs",
     "stores/doc/in_memory.js",
     "stores/doc/in_memory.d.ts",
@@ -1355,6 +1358,11 @@
       "types": "./cache/redis.d.ts",
       "import": "./cache/redis.js",
       "require": "./cache/redis.cjs"
+    },
+    "./cache/upstash_redis": {
+      "types": "./cache/upstash_redis.d.ts",
+      "import": "./cache/upstash_redis.js",
+      "require": "./cache/upstash_redis.cjs"
     },
     "./stores/doc/in_memory": {
       "types": "./stores/doc/in_memory.d.ts",

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -147,6 +147,7 @@ const entrypoints = {
   cache: "cache/index",
   "cache/momento": "cache/momento",
   "cache/redis": "cache/redis",
+  "cache/upstash_redis": "cache/upstash_redis",
   // stores
   "stores/doc/in_memory": "stores/doc/in_memory",
   "stores/doc/gcs": "stores/doc/gcs",
@@ -254,6 +255,7 @@ const requiresOptionalDependency = [
   "chains/query_constructor/ir",
   "cache/momento",
   "cache/redis",
+  "cache/upstash_redis",
   "stores/doc/gcs",
   "stores/file/node",
   "stores/message/dynamodb",

--- a/langchain/src/cache/tests/upstash_redis.test.ts
+++ b/langchain/src/cache/tests/upstash_redis.test.ts
@@ -1,0 +1,20 @@
+import { test, expect, jest } from "@jest/globals";
+import hash from "object-hash";
+
+import { UpstashRedisCache } from "../upstash_redis.js";
+
+const sha256 = (str: string) => hash(str);
+
+test("UpstashRedisCache", async () => {
+  const redis = {
+    get: jest.fn(async (key: string) => {
+      if (key === sha256("foo_bar_0")) {
+        return "baz";
+      }
+      return null;
+    }),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cache = new UpstashRedisCache({ client: redis as any });
+  expect(await cache.lookup("foo", "bar")).toEqual([{ text: "baz" }]);
+});

--- a/langchain/src/cache/upstash_redis.ts
+++ b/langchain/src/cache/upstash_redis.ts
@@ -1,0 +1,73 @@
+import { Redis, type RedisConfigNodejs } from "@upstash/redis";
+
+import { BaseCache, Generation } from "../schema/index.js";
+import { getCacheKey } from "./base.js";
+
+export type UpstashRedisCacheProps = {
+  /**
+   * The config to use to instantiate an Upstash Redis client.
+   */
+  config?: RedisConfigNodejs;
+  /**
+   * An existing Upstash Redis client.
+   */
+  client?: Redis;
+};
+
+/**
+ * A cache that uses Upstash as the backing store.
+ * See https://docs.upstash.com/redis.
+ */
+export class UpstashRedisCache extends BaseCache {
+  private redisClient: Redis;
+
+  constructor(props: UpstashRedisCacheProps) {
+    super();
+    const { config, client } = props;
+
+    if (client) {
+      this.redisClient = client;
+    } else if (config) {
+      this.redisClient = new Redis(config);
+    } else {
+      throw new Error(
+        `Upstash Redis caches require either a config object or a pre-configured client.`
+      );
+    }
+  }
+
+  /**
+   * Lookup LLM generations in cache by prompt and associated LLM key.
+   */
+  public async lookup(prompt: string, llmKey: string) {
+    let idx = 0;
+    let key = getCacheKey(prompt, llmKey, String(idx));
+    let value: string | null = await this.redisClient.get(key);
+    const generations: Generation[] = [];
+
+    while (value) {
+      if (!value) {
+        break;
+      }
+
+      generations.push({ text: value });
+      idx += 1;
+      key = getCacheKey(prompt, llmKey, String(idx));
+      value = await this.redisClient.get(key);
+    }
+
+    return generations.length > 0 ? generations : null;
+  }
+
+  /**
+   * Update the cache with the given generations.
+   *
+   * Note this overwrites any existing generations for the given prompt and LLM key.
+   */
+  public async update(prompt: string, llmKey: string, value: Generation[]) {
+    for (let i = 0; i < value.length; i += 1) {
+      const key = getCacheKey(prompt, llmKey, String(i));
+      await this.redisClient.set(key, value[i].text);
+    }
+  }
+}

--- a/langchain/src/load/import_constants.ts
+++ b/langchain/src/load/import_constants.ts
@@ -75,6 +75,7 @@ export const optionalImportEntrypoints = [
   "langchain/retrievers/self_query/weaviate",
   "langchain/cache/momento",
   "langchain/cache/redis",
+  "langchain/cache/upstash_redis",
   "langchain/stores/doc/gcs",
   "langchain/stores/file/node",
   "langchain/stores/message/dynamodb",

--- a/langchain/src/load/import_type.d.ts
+++ b/langchain/src/load/import_type.d.ts
@@ -223,6 +223,9 @@ export interface OptionalImportMap {
   "langchain/cache/redis"?:
     | typeof import("../cache/redis.js")
     | Promise<typeof import("../cache/redis.js")>;
+  "langchain/cache/upstash_redis"?:
+    | typeof import("../cache/upstash_redis.js")
+    | Promise<typeof import("../cache/upstash_redis.js")>;
   "langchain/stores/doc/gcs"?:
     | typeof import("../stores/doc/gcs.js")
     | Promise<typeof import("../stores/doc/gcs.js")>;

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -144,6 +144,7 @@
       "src/cache/index.ts",
       "src/cache/momento.ts",
       "src/cache/redis.ts",
+      "src/cache/upstash_redis.ts",
       "src/stores/doc/in_memory.ts",
       "src/stores/doc/gcs.ts",
       "src/stores/file/in_memory.ts",


### PR DESCRIPTION
This PR adds an Upstash Redis-based cache under `langchain/cache/upstash_redis` to supplement the existing [Redis-based cache](https://js.langchain.com/docs/modules/models/llms/additional_functionality#caching-with-redis) under `langchain/cache/redis`. This adds parity with `langchain/stores/message/redis` and `langchain/stores/message/upstash_redis`.

Closes #1428