### PR TITLE
Update outputParser.ts - Fix TypeError

### DIFF
--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -33,7 +33,9 @@ export class ZeroShotAgentOutputParser extends AgentActionOutputParser {
 
     return {
       tool: match[1].trim(),
-      toolInput: match[2] ? match[2].trim().replace(/^("+)(.*?)(\1)$/, "$2") : "",
+      toolInput: match[2]
+        ? match[2].trim().replace(/^("+)(.*?)(\1)$/, "$2")
+        : "",
       log: text,
     };
   }

--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -33,7 +33,7 @@ export class ZeroShotAgentOutputParser extends AgentActionOutputParser {
 
     return {
       tool: match[1].trim(),
-      toolInput: match[2].trim().replace(/^("+)(.*?)(\1)$/, "$2") ?? "",
+      toolInput: match[2] ? match[2].trim().replace(/^("+)(.*?)(\1)$/, "$2") : "",
       log: text,
     };
   }


### PR DESCRIPTION
Fix for #1673 - TypeError: Cannot read properties of undefined (reading 'trim') 

<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

A "TypeError" occurred when trying to call the "trim()" method on an undefined object. This happened in the parse method of the "ZeroShotAgentOutputParser" class.
```
An error occurred: TypeError: Cannot read properties of undefined (reading 'trim')
    at ZeroShotAgentOutputParser.parse (file:///Users/dev/docker/ai-chatbot/node_modules/langchain/dist/agents/mrkl/outputParser.js:30:33)
    at ZeroShotAgent._plan (file:///Users/dev/docker/ai-chatbot/node_modules/langchain/dist/agents/agent.js:198:34)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async AgentExecutor._call (file:///Users/dev/docker/ai-chatbot/node_modules/langchain/dist/agents/executor.js:82:28)
    at async AgentExecutor.call (file:///Users/dev/docker/ai-chatbot/node_modules/langchain/dist/chains/base.js:65:28)
    at async prompt (file:///Users/dev/docker/ai-chatbot/dist/ChatModel.mjs:71:24)
    at async main (file:///Users/dev/docker/ai-chatbot/dist/ChatModel.mjs:82:7)
```
![Screenshot 2023-06-15 at 9 44 28 PM](https://github.com/hwchase17/langchainjs/assets/20072212/759e849b-80c3-48f8-b38d-42c3a9935f4b)


The error was caused by this line.

The match[2] is undefined when the regular expression does not find a second group match in the text string.

Solution: Replaced line with.
```
 toolInput: match[2] ? match[2].trim().replace(/^("+)(.*?)(\1)$/, "$2") : "",
```
![Screenshot 2023-06-15 at 9 52 57 PM](https://github.com/hwchase17/langchainjs/assets/20072212/abdb355f-b221-4b5e-97f0-4d7ffff3ef37)


Fixes [#1673](https://github.com/hwchase17/langchainjs/issues/1673)