### PR TITLE
added APIchain headers example and fixed an error in dynamic tool example.

### DIFF
--- a/docs/docs/modules/agents/tools/dynamic.mdx
+++ b/docs/docs/modules/agents/tools/dynamic.mdx
@@ -26,13 +26,13 @@ export const run = async () => {
       name: "FOO",
       description:
         "call this to get the value of foo. input should be an empty string.",
-      func: () => "baz",
+      func: async () => "baz",
     }),
     new DynamicTool({
       name: "BAR",
       description:
         "call this to get the value of bar. input should be an empty string.",
-      func: () => "baz1",
+      func: async () => "baz1",
     }),
   ];
 

--- a/docs/docs/modules/chains/other_chains/api_chain.mdx
+++ b/docs/docs/modules/chains/other_chains/api_chain.mdx
@@ -1,14 +1,10 @@
 import CodeBlock from "@theme/CodeBlock";
 import APIExample from "@examples/chains/api_chain.ts";
-import APIHeadersExample from "@examples/chains/api_chain_headers.ts";
 
 # `APIChain`
 
 APIChain enables using LLMs to interact with APIs to retrieve relevant information. Construct the chain by providing a question relevant to the provided API documentation.
 
+If your API requires authentication or other headers, you can pass the chain a `headers` property in the config object.
+
 <CodeBlock language="typescript">{APIExample}</CodeBlock>
-
-
-If your requests need to be authenticated, you can provide the necessary headers to the chain. These headers will be used for all requests made by the chain.
-
-<CodeBlock language="typescript">{APIHeadersExample}</CodeBlock>

--- a/docs/docs/modules/chains/other_chains/api_chain.mdx
+++ b/docs/docs/modules/chains/other_chains/api_chain.mdx
@@ -1,8 +1,14 @@
 import CodeBlock from "@theme/CodeBlock";
 import APIExample from "@examples/chains/api_chain.ts";
+import APIHeadersExample from "@examples/chains/api_chain_headers.ts";
 
 # `APIChain`
 
 APIChain enables using LLMs to interact with APIs to retrieve relevant information. Construct the chain by providing a question relevant to the provided API documentation.
 
 <CodeBlock language="typescript">{APIExample}</CodeBlock>
+
+
+If your requests need to be authenticated, you can provide the necessary headers to the chain. These headers will be used for all requests made by the chain.
+
+<CodeBlock language="typescript">{APIHeadersExample}</CodeBlock>

--- a/examples/src/chains/api_chain.ts
+++ b/examples/src/chains/api_chain.ts
@@ -33,7 +33,11 @@ visibility	Instant	meters	Viewing distance in meters. Influenced by low clouds, 
 
 export async function run() {
   const model = new OpenAI({ modelName: "text-davinci-003" });
-  const chain = APIChain.fromLLMAndAPIDocs(model, OPEN_METEO_DOCS);
+  const chain = APIChain.fromLLMAndAPIDocs(model, OPEN_METEO_DOCS, {
+    headers: {
+      // These headers will be used for API requests made by the chain.
+    },
+  });
 
   const res = await chain.call({
     question:

--- a/examples/src/chains/api_chain_headers.ts
+++ b/examples/src/chains/api_chain_headers.ts
@@ -1,5 +1,0 @@
-const chain = APIChain.fromLLMAndAPIDocs(model,OPEN_METEO_DOCS, {
-    headers:{
-        // You can put your header parameters here as usual.
-    },
-});

--- a/examples/src/chains/api_chain_headers.ts
+++ b/examples/src/chains/api_chain_headers.ts
@@ -1,0 +1,5 @@
+const chain = APIChain.fromLLMAndAPIDocs(model,OPEN_METEO_DOCS, {
+    headers:{
+        // You can put your header parameters here as usual.
+    },
+});


### PR DESCRIPTION

There are 2 changes made to the Documentation in this PR:

1. added an example for using headers with APIChain in [Here](https://js.langchain.com/docs/modules/chains/other_chains/api_chain).
	- [Versel Build Link](https://langchainjs-docs-git-fork-srilals-main-langchain.vercel.app/docs/modules/chains/other_chains/api_chain)
2. fixed the missing async declaration in the dynamic tool example in docs in [Here](https://js.langchain.com/docs/modules/chains/other_chains/api_chain).
	- [Versel Build Link](https://langchainjs-docs-git-fork-srilals-main-langchain.vercel.app/docs/modules/agents/tools/dynamic)

Twitter: [@SrilalSS](https://twitter.com/srilalss)