### PR TITLE
Bug fix: zepMemory needs to return memorykey:[] and not empty string …

### DIFF
--- a/examples/src/memory/zep.ts
+++ b/examples/src/memory/zep.ts
@@ -2,7 +2,7 @@ import { ChatOpenAI } from "langchain/chat_models/openai";
 import { ConversationChain } from "langchain/chains";
 import { ZepMemory } from "langchain/memory/zep";
 
-const sessionId = "TestSession1234";
+const sessionId = "TestSession";
 const zepURL = "http://localhost:8000";
 
 const memory = new ZepMemory({
@@ -16,6 +16,7 @@ const model = new ChatOpenAI({
 });
 
 const chain = new ConversationChain({ llm: model, memory });
+console.log("Memory Keys:", memory.memoryKeys);
 
 const res1 = await chain.call({ input: "Hi! I'm Jim." });
 console.log({ res1 });
@@ -37,3 +38,5 @@ console.log({ res2 });
   }
 }
 */
+console.log("Session ID: ", sessionId);
+console.log("Memory: ", await memory.loadMemoryVariables({}));

--- a/langchain/src/memory/zep.ts
+++ b/langchain/src/memory/zep.ts
@@ -67,7 +67,9 @@ export class ZepMemory extends BaseChatMemory implements ZepMemoryInput {
     } catch (error) {
       // eslint-disable-next-line no-instanceof/no-instanceof
       if (error instanceof NotFoundError) {
-        const result = this.returnMessages ? { [this.memoryKey]: [] } : { [this.memoryKey]: "" };
+        const result = this.returnMessages
+          ? { [this.memoryKey]: [] }
+          : { [this.memoryKey]: "" };
         return result;
       } else {
         throw error;

--- a/langchain/src/memory/zep.ts
+++ b/langchain/src/memory/zep.ts
@@ -67,7 +67,7 @@ export class ZepMemory extends BaseChatMemory implements ZepMemoryInput {
     } catch (error) {
       // eslint-disable-next-line no-instanceof/no-instanceof
       if (error instanceof NotFoundError) {
-        return { [this.memoryKey]: [] };
+        return this.returnMessages ? { [this.memoryKey]: [] } : { [this.memoryKey]: "" };
       } else {
         throw error;
       }
@@ -150,3 +150,4 @@ export class ZepMemory extends BaseChatMemory implements ZepMemoryInput {
     await super.clear();
   }
 }
+1

--- a/langchain/src/memory/zep.ts
+++ b/langchain/src/memory/zep.ts
@@ -67,7 +67,8 @@ export class ZepMemory extends BaseChatMemory implements ZepMemoryInput {
     } catch (error) {
       // eslint-disable-next-line no-instanceof/no-instanceof
       if (error instanceof NotFoundError) {
-        return this.returnMessages ? { [this.memoryKey]: [] } : { [this.memoryKey]: "" };
+        const result = this.returnMessages ? { [this.memoryKey]: [] } : { [this.memoryKey]: "" };
+        return result;
       } else {
         throw error;
       }
@@ -150,4 +151,3 @@ export class ZepMemory extends BaseChatMemory implements ZepMemoryInput {
     await super.clear();
   }
 }
-1

--- a/langchain/src/memory/zep.ts
+++ b/langchain/src/memory/zep.ts
@@ -67,8 +67,7 @@ export class ZepMemory extends BaseChatMemory implements ZepMemoryInput {
     } catch (error) {
       // eslint-disable-next-line no-instanceof/no-instanceof
       if (error instanceof NotFoundError) {
-        if (this.returnMessages) return { [this.memoryKey]: [] };
-        return [];
+        return { [this.memoryKey]: [] };
       } else {
         throw error;
       }


### PR DESCRIPTION
If memory not found, loadMemoryVariables returns [], instead needs to return memorykey:[]
