### PR TITLE
typesense: add vector_distance as score

### DIFF
--- a/langchain/src/vectorstores/tests/typesense.test.ts
+++ b/langchain/src/vectorstores/tests/typesense.test.ts
@@ -75,38 +75,50 @@ test("typesenseRecordsToDocuments should return the correct langchain documents"
 
   const typesenseRecords = [
     {
-      text: "hello world",
-      foo: "fooo",
-      bar: "barr",
-      baz: "bazz",
-      vec: await embeddings.embedQuery("hello world"),
+      document: {
+        text: "hello world",
+        foo: "fooo",
+        bar: "barr",
+        baz: "bazz",
+        vec: await embeddings.embedQuery("hello world"),
+      },
+      vector_distance: 0.2342145,
     },
     {
-      text: "hello world 2",
-      foo: "foooo",
-      bar: "barrr",
-      baz: "bazzz",
-      vec: await embeddings.embedQuery("hello world 2"),
+      document: {
+        text: "hello world 2",
+        foo: "foooo",
+        bar: "barrr",
+        baz: "bazzz",
+        vec: await embeddings.embedQuery("hello world 2"),
+      },
+      vector_distance: 0.4521355,
     },
   ];
 
   const expected = [
-    {
-      metadata: {
-        foo: "fooo",
-        bar: "barr",
-        baz: "bazz",
+    [
+      {
+        metadata: {
+          foo: "fooo",
+          bar: "barr",
+          baz: "bazz",
+        },
+        pageContent: "hello world",
       },
-      pageContent: "hello world",
-    },
-    {
-      metadata: {
-        foo: "foooo",
-        bar: "barrr",
-        baz: "bazzz",
+      0.2342145,
+    ],
+    [
+      {
+        metadata: {
+          foo: "foooo",
+          bar: "barrr",
+          baz: "bazzz",
+        },
+        pageContent: "hello world 2",
       },
-      pageContent: "hello world 2",
-    },
+      0.4521355,
+    ],
   ];
 
   expect(vectorstore._typesenseRecordsToDocuments(typesenseRecords)).toEqual(


### PR DESCRIPTION
Typesense vector search provides the vector_distance in the search result:

https://typesense.org/docs/0.24.1/api/vector-search.html#nearest-neighbor-vector-search
