### PR TITLE
Overrode JSONLoader.load to accept JSON already in memory.

### DIFF
--- a/langchain/src/document_loaders/tests/json.test.ts
+++ b/langchain/src/document_loaders/tests/json.test.ts
@@ -21,7 +21,33 @@ test("Test JSON loader", async () => {
   );
 });
 
-test("Test JSON  loader for complex json without keys", async () => {
+test("Test JSON loader from inmemory JSON", async() => {
+    const json = [
+      "<i>Corruption discovered at the core of the Banking Clan!</i>",
+      "<i>Reunited, Rush Clovis and Senator Amidala</i>",
+      "<i>discover the full extent of the deception.</i>",
+      "<i>Anakin Skywalker is sent to the rescue!</i>",
+      "<i>He refuses to trust Clovis and asks Padm not to work with him.</i>",
+      "<i>Determined to save the banks, she refuses her husband's request,</i>",
+      "<i>throwing their relationship into turmoil.</i>",
+      "<i>Voted for by both the Separatists and the Republic,</i>",
+      "<i>Rush Clovis is elected new leader of the Galactic Banking Clan.</i>",
+      "<i>Now, all attention is focused on Scipio</i>",
+      "<i>as the important transfer of power begins.</i>"
+  ];
+  const loader = new JSONLoader("");
+  const docs = await loader.load(json);
+  expect(docs.length).toBe(11);
+  expect(docs[0]).toEqual(
+    new Document({
+      metadata: { source: "json", line: 1 },
+      pageContent:
+        "<i>Corruption discovered at the core of the Banking Clan!</i>",
+    })
+  );
+});
+
+test("Test JSON loader for complex json without keys", async () => {
   const filePath = path.resolve(
     path.dirname(url.fileURLToPath(import.meta.url)),
     "./example_data/complex.json"


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

This request adds functionality to the JSONLoader by overriding the load method so that you can provide it with JSON already held in memory. Often large JSON datasets can be returned from document databases or from REST requests. In these cases no filesystem JSON exists.