### PR TITLE
Refactor how the Google Vertex AI PaLM Codey  code- models are implemented

### DIFF
--- a/docs/docs/modules/models/llms/integrations.mdx
+++ b/docs/docs/modules/models/llms/integrations.mdx
@@ -69,9 +69,8 @@ import GoogleVertexAIExample from "@examples/llms/googlevertexai.ts";
 <CodeBlock language="typescript">{GoogleVertexAIExample}</CodeBlock>
 
 Google also has separate models for their "Codey" code generation models.
-For various reasons, these use a different class.
 
-The "code-gecko" model is the default and is useful for code completion:
+The "code-gecko" model is useful for code completion:
 
 import GoogleVertexAICodeGeckoExample from "@examples/llms/googlevertexai-code-gecko.ts";
 

--- a/examples/src/llms/googlevertexai-code-bison.ts
+++ b/examples/src/llms/googlevertexai-code-bison.ts
@@ -1,4 +1,4 @@
-import { GoogleVertexAICode } from "langchain/llms/googlevertexai";
+import { GoogleVertexAI } from "langchain/llms/googlevertexai";
 
 /*
  * Before running this, you should make sure you have created a
@@ -13,7 +13,7 @@ import { GoogleVertexAICode } from "langchain/llms/googlevertexai";
  *   path of a credentials file for a service account permitted to the project.
  */
 
-const model = new GoogleVertexAICode({
+const model = new GoogleVertexAI({
   model: "code-bison",
   maxOutputTokens: 2048,
 });

--- a/examples/src/llms/googlevertexai-code-gecko.ts
+++ b/examples/src/llms/googlevertexai-code-gecko.ts
@@ -1,4 +1,4 @@
-import { GoogleVertexAICode } from "langchain/llms/googlevertexai";
+import { GoogleVertexAI } from "langchain/llms/googlevertexai";
 
 /*
  * Before running this, you should make sure you have created a
@@ -13,6 +13,8 @@ import { GoogleVertexAICode } from "langchain/llms/googlevertexai";
  *   path of a credentials file for a service account permitted to the project.
  */
 
-const model = new GoogleVertexAICode();
+const model = new GoogleVertexAI({
+  model: "code-gecko",
+});
 const res = await model.call("for (let co=0;");
 console.log({ res });

--- a/langchain/src/llms/tests/googlevertexai.int.test.ts
+++ b/langchain/src/llms/tests/googlevertexai.int.test.ts
@@ -1,25 +1,25 @@
 import { expect, test } from "@jest/globals";
-import { GoogleVertexAI, GoogleVertexAICode } from "../googlevertexai.js";
+import { GoogleVertexAI } from "../googlevertexai.js";
 
-test.skip("Test Google Vertex", async () => {
+test("Test Google Vertex", async () => {
   const model = new GoogleVertexAI({ maxOutputTokens: 50 });
   const res = await model.call("1 + 1 = ");
   console.log({ res });
 });
 
-test.skip("Test Google Vertex generation", async () => {
+test("Test Google Vertex generation", async () => {
   const model = new GoogleVertexAI({ maxOutputTokens: 50 });
   const res = await model.generate(["1 + 1 = "]);
   console.log(JSON.stringify(res, null, 2));
 });
 
-test.skip("Test Google Vertex generation", async () => {
+test("Test Google Vertex generation", async () => {
   const model = new GoogleVertexAI({ maxOutputTokens: 50 });
   const res = await model.generate(["Print hello world."]);
   console.log(JSON.stringify(res, null, 2));
 });
 
-test.skip("Test Google Vertex generation", async () => {
+test("Test Google Vertex generation", async () => {
   const model = new GoogleVertexAI({ maxOutputTokens: 50 });
   const res = await model.generate([
     `Translate "I love programming" into Korean.`,
@@ -27,16 +27,18 @@ test.skip("Test Google Vertex generation", async () => {
   console.log(JSON.stringify(res, null, 2));
 });
 
-test.skip("Test Google Vertex Codey gecko model", async () => {
-  const model = new GoogleVertexAICode();
+test("Test Google Vertex Codey gecko model", async () => {
+  const model = new GoogleVertexAI({ model: "code-gecko" });
   expect(model.model).toEqual("code-gecko");
+  expect(model.temperature).toEqual(0.2);
+  expect(model.maxOutputTokens).toEqual(256);
 
   const res = await model.call("for( let co = 0");
   console.log(res);
 });
 
-test.skip("Test Google Vertex Codey bison model", async () => {
-  const model = new GoogleVertexAICode({
+test("Test Google Vertex Codey bison model", async () => {
+  const model = new GoogleVertexAI({
     model: "code-bison",
     maxOutputTokens: 2048,
   });


### PR DESCRIPTION
Related to #1575 
Refactoring how the GoogleVertexAI llm support is implemented and removes the GoogleVertexAICode class (which is a breaking change, but one I think folks are unlikely to run into).