### PR TITLE
Downgrade decamelize for browser compatibility

### DIFF
--- a/langchain/package.json
+++ b/langchain/package.json
@@ -718,7 +718,7 @@
     "ansi-styles": "^5.0.0",
     "binary-extensions": "^2.2.0",
     "camelcase": "6",
-    "decamelize": "^3.2.0",
+    "decamelize": "^1.2.0",
     "expr-eval": "^2.0.2",
     "flat": "^5.0.2",
     "js-tiktoken": "^1.0.7",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -718,7 +718,7 @@
     "ansi-styles": "^5.0.0",
     "binary-extensions": "^2.2.0",
     "camelcase": "6",
-    "decamelize": "3",
+    "decamelize": "^3.2.0",
     "expr-eval": "^2.0.2",
     "flat": "^5.0.2",
     "js-tiktoken": "^1.0.7",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -718,7 +718,7 @@
     "ansi-styles": "^5.0.0",
     "binary-extensions": "^2.2.0",
     "camelcase": "6",
-    "decamelize": "5",
+    "decamelize": "3",
     "expr-eval": "^2.0.2",
     "flat": "^5.0.2",
     "js-tiktoken": "^1.0.7",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -462,6 +462,7 @@
     "@tigrisdata/vector": "^1.1.0",
     "@tsconfig/recommended": "^1.0.2",
     "@types/d3-dsv": "^2",
+    "@types/decamelize": "^1.2.0",
     "@types/flat": "^5.0.2",
     "@types/html-to-text": "^9",
     "@types/object-hash": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,6 +7915,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/decamelize@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@types/decamelize@npm:1.2.0"
+  checksum: cff4e926bf771f8ad6423ab8c5119d6b8679c09aaf9f0b26a4a1dbcf324c0b1df183c2bfe688b90b6f880d8e864684a2806a22529b4ee404fd9160f9c123853d
+  languageName: node
+  linkType: hard
+
 "@types/eslint-scope@npm:^3.7.3":
   version: 3.7.4
   resolution: "@types/eslint-scope@npm:3.7.4"
@@ -18615,6 +18622,7 @@ __metadata:
     "@tigrisdata/vector": ^1.1.0
     "@tsconfig/recommended": ^1.0.2
     "@types/d3-dsv": ^2
+    "@types/decamelize": ^1.2.0
     "@types/flat": ^5.0.2
     "@types/html-to-text": ^9
     "@types/object-hash": ^3.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -12166,10 +12166,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:5":
-  version: 5.0.1
-  resolution: "decamelize@npm:5.0.1"
-  checksum: 7c3b1ed4b3e60e7fbc00a35fb248298527c1cdfe603e41dfcf05e6c4a8cb9efbee60630deb677ed428908fb4e74e322966c687a094d1478ddc9c3a74e9dc7140
+"decamelize@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "decamelize@npm:1.2.0"
+  checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
   languageName: node
   linkType: hard
 
@@ -18634,7 +18634,7 @@ __metadata:
     chromadb: ^1.5.2
     cohere-ai: ^5.0.2
     d3-dsv: ^2.0.0
-    decamelize: 5
+    decamelize: ^1.2.0
     dotenv: ^16.0.3
     dpdm: ^3.12.0
     epub2: ^3.0.1


### PR DESCRIPTION
<!--
Downgrade dependency decamelize to v3.2.0

Decamelize is used here: https://github.com/hwchase17/langchainjs/blob/main/langchain/src/load/map_keys.ts#L1
See decamelize's release history here: https://github.com/sindresorhus/decamelize/releases

-->

<!-- Remove if not applicable -->

Fixes #1761 