### PR TITLE
qdrant.ts: add support for QDRANT_API_KEY 

### DIFF
--- a/langchain/src/vectorstores/qdrant.ts
+++ b/langchain/src/vectorstores/qdrant.ts
@@ -10,6 +10,7 @@ import { getEnvironmentVariable } from "../util/env.js";
 export interface QdrantLibArgs {
   client?: QdrantClient;
   url?: string;
+  apiKey?: string;
   collectionName?: string;
   collectionConfig?: QdrantSchemas["CreateCollection"];
 }
@@ -32,6 +33,7 @@ export class QdrantVectorStore extends VectorStore {
     super(embeddings, args);
 
     const url = args.url ?? getEnvironmentVariable("QDRANT_URL");
+    const apiKey = args.apiKey ?? getEnvironmentVariable("QDRANT_API_KEY")
 
     if (!args.client && !url) {
       throw new Error("Qdrant client or url address must be set.");
@@ -41,6 +43,7 @@ export class QdrantVectorStore extends VectorStore {
       args.client ||
       new QdrantClient({
         url,
+        apiKey,
       });
 
     this.collectionName = args.collectionName ?? "documents";

--- a/langchain/src/vectorstores/qdrant.ts
+++ b/langchain/src/vectorstores/qdrant.ts
@@ -33,7 +33,7 @@ export class QdrantVectorStore extends VectorStore {
     super(embeddings, args);
 
     const url = args.url ?? getEnvironmentVariable("QDRANT_URL");
-    const apiKey = args.apiKey ?? getEnvironmentVariable("QDRANT_API_KEY")
+    const apiKey = args.apiKey ?? getEnvironmentVariable("QDRANT_API_KEY");
 
     if (!args.client && !url) {
       throw new Error("Qdrant client or url address must be set.");


### PR DESCRIPTION
Adds support for `apiKey`

From the official [Qdrant JS Client docs](https://github.com/qdrant/qdrant-js): 

```javascript
import {QdrantClient} from '@qdrant/js-client-rest';

// TO connect to Qdrant running locally
const client = new QdrantClient({url: 'http://127.0.0.1:6333'});

// or connect to Qdrant Cloud
const client = new QdrantClient({
    url: 'https://xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.us-east-0-1.aws.cloud.qdrant.io',
    apiKey: '<your-api-key>',
});
```