### PR TITLE
Ensure that run managers are returned from handleLLMStart/handleChatModelStart always in the same order as the prompts passed in

### DIFF
--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -348,9 +348,7 @@ export class CallbackManager
     _parentRunId: string | undefined = undefined,
     extraParams: Record<string, unknown> | undefined = undefined
   ): Promise<CallbackManagerForLLMRun[]> {
-    const managers: CallbackManagerForLLMRun[] = [];
-
-    await Promise.all(
+    return Promise.all(
       prompts.map(async (prompt) => {
         const runId = uuidv4();
 
@@ -377,20 +375,16 @@ export class CallbackManager
           )
         );
 
-        managers.push(
-          new CallbackManagerForLLMRun(
-            runId,
-            this.handlers,
-            this.inheritableHandlers,
-            this.tags,
-            this.inheritableTags,
-            this._parentRunId
-          )
+        return new CallbackManagerForLLMRun(
+          runId,
+          this.handlers,
+          this.inheritableHandlers,
+          this.tags,
+          this.inheritableTags,
+          this._parentRunId
         );
       })
     );
-
-    return managers;
   }
 
   async handleChatModelStart(
@@ -400,9 +394,7 @@ export class CallbackManager
     _parentRunId: string | undefined = undefined,
     extraParams: Record<string, unknown> | undefined = undefined
   ): Promise<CallbackManagerForLLMRun[]> {
-    const managers: CallbackManagerForLLMRun[] = [];
-
-    await Promise.all(
+    return Promise.all(
       messages.map(async (messageGroup) => {
         const runId = uuidv4();
 
@@ -441,20 +433,16 @@ export class CallbackManager
           )
         );
 
-        managers.push(
-          new CallbackManagerForLLMRun(
-            runId,
-            this.handlers,
-            this.inheritableHandlers,
-            this.tags,
-            this.inheritableTags,
-            this._parentRunId
-          )
+        return new CallbackManagerForLLMRun(
+          runId,
+          this.handlers,
+          this.inheritableHandlers,
+          this.tags,
+          this.inheritableTags,
+          this._parentRunId
         );
       })
     );
-
-    return managers;
   }
 
   async handleChainStart(


### PR DESCRIPTION


What was happening was that the runManager was only added to the managers array after the callback handlers finished executing, so eg if the callback handlers for the second run finished first the runManager for prompt #2 would actually be in position #1 of the returned array.

<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)