### PR TITLE
Add oauth access token support to Zapier

### DIFF
--- a/langchain/src/tools/zapier.ts
+++ b/langchain/src/tools/zapier.ts
@@ -23,6 +23,7 @@ export type ZapierValues = Record<string, any>;
 
 export interface ZapierNLAWrapperParams extends AsyncCallerParams {
   apiKey?: string;
+  oauthAccessToken?: string;
 }
 
 export class ZapierNLAWrapper extends Serializable {
@@ -34,7 +35,9 @@ export class ZapierNLAWrapper extends Serializable {
     };
   }
 
-  zapierNlaApiKey: string;
+  zapierNlaApiKey?: string;
+
+  zapierNlaOAuthAccessToken?: string;
 
   zapierNlaApiBase = "https://nla.zapier.com/api/v1/";
 
@@ -43,24 +46,49 @@ export class ZapierNLAWrapper extends Serializable {
   constructor(params?: ZapierNLAWrapperParams) {
     super(params);
 
+    const zapierNlaOAuthAccessToken = params?.oauthAccessToken;
     const zapierNlaApiKey = params?.apiKey;
+
+    const oauthAccessToken =
+      zapierNlaOAuthAccessToken ??
+      getEnvironmentVariable("ZAPIER_NLA_OAUTH_ACCESS_TOKEN");
     const apiKey =
       zapierNlaApiKey ?? getEnvironmentVariable("ZAPIER_NLA_API_KEY");
-    if (!apiKey) {
-      throw new Error("ZAPIER_NLA_API_KEY not set");
+    if (!apiKey && !oauthAccessToken) {
+      throw new Error(
+        "Neither ZAPIER_NLA_OAUTH_ACCESS_TOKEN or ZAPIER_NLA_API_KEY are set"
+      );
     }
-    this.zapierNlaApiKey = apiKey;
+
+    if (oauthAccessToken) {
+      this.zapierNlaOAuthAccessToken = oauthAccessToken;
+    } else {
+      this.zapierNlaApiKey = apiKey;
+    }
+
     this.caller = new AsyncCaller(
       typeof params === "string" ? {} : params ?? {}
     );
   }
 
   protected _getHeaders(): Record<string, string> {
-    return {
+    const headers: {
+      "Content-Type": string;
+      Accept: string;
+      Authorization?: string;
+      "x-api-key"?: string;
+    } = {
       "Content-Type": "application/json",
       Accept: "application/json",
-      "x-api-key": this.zapierNlaApiKey,
     };
+
+    if (this.zapierNlaOAuthAccessToken) {
+      headers.Authorization = `Bearer ${this.zapierNlaOAuthAccessToken}`;
+    } else {
+      headers["x-api-key"] = this.zapierNlaApiKey;
+    }
+
+    return headers;
   }
 
   protected async _getActionRequest(


### PR DESCRIPTION
Description: This copies over OAuth access token support from the Zapier wrapper in langchain and mirroring the capability for langchainjs.

I ran these unit tests for this PR:

OAuth
```
ZAPIER_NLA_OAUTH_ACCESS_TOKEN=<redacted> yarn test:single langchain/src/agents/tests/zapier_toolkit.int.test.ts

PASS  src/agents/tests/zapier_toolkit.int.test.ts (10.339 s)
  ZapierNLAWrapper
    ✓ loads ZapierToolKit (1029 ms)
    ✓ Zapier NLA has connected actions (269 ms)
    Giphy action
      ✓ returns a GIF (4428 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        10.39 s, estimated 13 s
```

API Key
```
ZAPIER_NLA_API_KEY=<redacted> yarn test:single langchain/src/agents/tests/zapier_toolkit.int.test.ts

PASS  src/agents/tests/zapier_toolkit.int.test.ts (9.458 s)
  ZapierNLAWrapper
    ✓ loads ZapierToolKit (722 ms)
    ✓ Zapier NLA has connected actions (134 ms)
    Giphy action
      ✓ returns a GIF (4905 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        9.503 s, estimated 11 s
```

I confirmed both of these tests fail when I either don't supply a key, or supply the wrong key.