### PR TITLE
Update Zapier agent docs

### DIFF
--- a/docs/docs/modules/agents/tools/zapier_agent.mdx
+++ b/docs/docs/modules/agents/tools/zapier_agent.mdx
@@ -16,7 +16,7 @@ Server-side (API Key): for quickly getting started, testing, and production scen
 
 User-facing (Oauth): for production scenarios where you are deploying an end-user facing application and LangChain needs access to end-user's exposed actions and connected accounts on Zapier.com
 
-Attach NLA credentials via either an environment variable (`ZAPIER_NLA_OAUTH_ACCESS_TOKEN` or `ZAPIER_NLA_API_KEY`) or refer to the params argument in the API reference for `ZapierNLAWrapper`. 
+Attach NLA credentials via either an environment variable (`ZAPIER_NLA_OAUTH_ACCESS_TOKEN` or `ZAPIER_NLA_API_KEY`) or refer to the params argument in the API reference for `ZapierNLAWrapper`.
 
 Review [auth docs](https://nla.zapier.com/docs/authentication/) for more details.
 

--- a/docs/docs/modules/agents/tools/zapier_agent.mdx
+++ b/docs/docs/modules/agents/tools/zapier_agent.mdx
@@ -2,7 +2,7 @@ import CodeBlock from "@theme/CodeBlock";
 
 # Agent with Zapier NLA Integration
 
-Full docs here: https://nla.zapier.com/api/v1/dynamic/docs
+Full docs here: https://nla.zapier.com/start/
 
 **Zapier Natural Language Actions** gives you access to the 5k+ apps and 20k+ actions on Zapier's platform through a natural language API interface.
 
@@ -16,7 +16,9 @@ Server-side (API Key): for quickly getting started, testing, and production scen
 
 User-facing (Oauth): for production scenarios where you are deploying an end-user facing application and LangChain needs access to end-user's exposed actions and connected accounts on Zapier.com
 
-This quick start will focus on the server-side use case for brevity. Review full docs or reach out to nla@zapier.com for user-facing oauth developer support.
+Attach NLA credentials via either an environment variable (`ZAPIER_NLA_OAUTH_ACCESS_TOKEN` or `ZAPIER_NLA_API_KEY`) or refer to the params argument in the API reference for `ZapierNLAWrapper`. 
+
+Review [auth docs](https://nla.zapier.com/docs/authentication/) for more details.
 
 The example below demonstrates how to use the Zapier integration as an Agent:
 

--- a/langchain/src/tools/zapier.ts
+++ b/langchain/src/tools/zapier.ts
@@ -22,7 +22,15 @@ const zapierNLABaseDescription: string =
 export type ZapierValues = Record<string, any>;
 
 export interface ZapierNLAWrapperParams extends AsyncCallerParams {
+  /**
+   * NLA API Key. Found in the NLA documentation https://nla.zapier.com/docs/authentication/#api-key
+   * Can also be set via the environment variable `ZAPIER_NLA_API_KEY`
+   */
   apiKey?: string;
+  /**
+   * NLA OAuth Access Token. Found in the NLA documentation https://nla.zapier.com/docs/authentication/#oauth-credentials
+   * Can also be set via the environment variable `ZAPIER_NLA_OAUTH_ACCESS_TOKEN`
+   */
   oauthAccessToken?: string;
 }
 


### PR DESCRIPTION
Updating docs to call out how to attach Zapier NLA auth.  Also removed email address as developers can now self serve.

Question: 

With this PR https://github.com/hwchase17/langchainjs/pull/1798 I updated the Wrapper class params, yet documentation doesn't reflect that change currently https://js.langchain.com/docs/api/tools/classes/ZapierNLAWrapper.  I tried running `yarn docs` but it did not generate any updated documentation.  How do I get this MD file updated?

I should get the class updated to call out params can be set via `params` or the equivalent env var.