### PR TITLE
fix: make the api error message more clear

### DIFF
--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -202,7 +202,7 @@ export class ChatOpenAI
       getEnvironmentVariable("AZURE_OPENAI_API_KEY");
 
     if (!this.azureOpenAIApiKey && !this.openAIApiKey) {
-      throw new Error("(Azure) OpenAI API key not found");
+      throw new Error("OpenAI or Azure OpenAI API key not found");
     }
 
     this.azureOpenAIApiInstanceName =

--- a/langchain/src/embeddings/openai.ts
+++ b/langchain/src/embeddings/openai.ts
@@ -74,7 +74,7 @@ export class OpenAIEmbeddings
       fields?.azureOpenAIApiKey ??
       getEnvironmentVariable("AZURE_OPENAI_API_KEY");
     if (!azureApiKey && !apiKey) {
-      throw new Error("(Azure) OpenAI API key not found");
+      throw new Error("OpenAI or Azure OpenAI API key not found");
     }
 
     const azureApiInstanceName =

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -137,7 +137,7 @@ export class OpenAIChat
       getEnvironmentVariable("AZURE_OPENAI_API_KEY");
 
     if (!this.azureOpenAIApiKey && !this.openAIApiKey) {
-      throw new Error("(Azure) OpenAI API key not found");
+      throw new Error("OpenAI or Azure OpenAI API key not found");
     }
 
     this.azureOpenAIApiInstanceName =

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -145,7 +145,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput, AzureOpenAIInput {
       getEnvironmentVariable("AZURE_OPENAI_API_KEY");
 
     if (!this.azureOpenAIApiKey && !this.openAIApiKey) {
-      throw new Error("(Azure) OpenAI API key not found");
+      throw new Error("OpenAI or Azure OpenAI API key not found");
     }
 
     this.azureOpenAIApiInstanceName =


### PR DESCRIPTION
The way it's written now it's not clear that this an "or" check. It sounds like
the package may be configured to use the azure version of openai instead of standard
openai. I think this wording makes it a bit more clear that langchain checked for both API
keys and didn't find any.
