### PR TITLE
docs: note about complex schema

### DIFF
--- a/docs/docs/modules/prompts/output_parsers/index.mdx
+++ b/docs/docs/modules/prompts/output_parsers/index.mdx
@@ -26,7 +26,7 @@ Below we go over some examples of output parsers.
 
 ## Structured Output Parser
 
-This output parser can be used when you want to return multiple fields.
+This output parser can be used when you want to return multiple fields. If you want complex schema returned (i.e. a JSON object with arrays of strings), use the Zod Schema detailed below.
 
 import Structured from "@examples/prompts/structured_parser.ts";
 


### PR DESCRIPTION
it was unclear to me that the basic schema parser did not support things like arrays of strings. This makes it a bit more clear.
