### PR TITLE
Adds FunctionCallStructuredOutputParser

### DIFF
--- a/langchain/src/chains/llm_chain.ts
+++ b/langchain/src/chains/llm_chain.ts
@@ -71,7 +71,6 @@ export class LLMChain<
     super(fields);
     this.prompt = fields.prompt;
     this.llm = fields.llm;
-    this.llmKwargs = fields.llmKwargs;
     this.outputKey = fields.outputKey ?? this.outputKey;
     this.outputParser =
       fields.outputParser ?? (new NoOpOutputParser() as BaseOutputParser<T>);
@@ -81,6 +80,7 @@ export class LLMChain<
       }
       this.outputParser = this.prompt.outputParser as BaseOutputParser<T>;
     }
+    this.llmKwargs = { ...this.outputParser.llmKwargs, ...fields.llmKwargs };
   }
 
   /** @ignore */

--- a/langchain/src/output_parsers/index.ts
+++ b/langchain/src/output_parsers/index.ts
@@ -16,3 +16,4 @@ export {
   JsonOutputFunctionsParser,
   JsonKeyOutputFunctionsParser,
 } from "../output_parsers/openai_functions.js";
+export { FunctionCallStructuredOutputParser } from "../output_parsers/openai_function_call_structured.js";

--- a/langchain/src/output_parsers/openai_function_call_structured.ts
+++ b/langchain/src/output_parsers/openai_function_call_structured.ts
@@ -5,7 +5,7 @@ import { JsonSchema7Type } from "zod-to-json-schema/src/parseDef.js";
 
 import { StructuredOutputParser } from "./structured.js";
 import { OutputParserException } from "../schema/output_parser.js";
-import { JsonOutputFunctionsParser } from "./openai_functions.js";
+import { OutputFunctionsParser } from "./openai_functions.js";
 import { Generation, ChatGeneration } from "../schema/index.js";
 
 export class FunctionCallStructuredOutputParser<
@@ -17,7 +17,7 @@ export class FunctionCallStructuredOutputParser<
 
   public jsonSchema: JsonSchema7Type;
 
-  protected functionOutputParser = new JsonOutputFunctionsParser();
+  protected functionOutputParser = new OutputFunctionsParser();
 
   constructor(schema: T) {
     super(schema);
@@ -42,12 +42,15 @@ export class FunctionCallStructuredOutputParser<
   }
 
   async parseResult(generations: Generation[] | ChatGeneration[]) {
-    return this.functionOutputParser.parseResult(generations);
+    const initialParseResult = await this.functionOutputParser.parseResult(
+      generations
+    );
+    return this.parse(initialParseResult);
   }
 
   async parse(text: string): Promise<z.infer<T>> {
     try {
-      return this.schema.parseAsync(JSON.parse(text).arguments);
+      return this.schema.parseAsync(JSON.parse(text));
     } catch (e) {
       throw new OutputParserException(
         `Failed to parse. Text: "${text}". Error: ${e}`,

--- a/langchain/src/output_parsers/openai_function_call_structured.ts
+++ b/langchain/src/output_parsers/openai_function_call_structured.ts
@@ -1,0 +1,62 @@
+import { ChatCompletionFunctions } from "openai";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { JsonSchema7Type } from "zod-to-json-schema/src/parseDef.js";
+
+import { StructuredOutputParser } from "./structured.js";
+import { OutputParserException } from "../schema/output_parser.js";
+import { JsonOutputFunctionsParser } from "./openai_functions.js";
+import { Generation, ChatGeneration } from "../schema/index.js";
+
+export class FunctionCallStructuredOutputParser<
+  T extends z.ZodTypeAny
+> extends StructuredOutputParser<T> {
+  public outputFunctionName = "__lc_output__";
+
+  public outputFunctionDescription = `Output formatter. Should always be used to format your response to the user.`;
+
+  public jsonSchema: JsonSchema7Type;
+
+  protected functionOutputParser = new JsonOutputFunctionsParser();
+
+  constructor(schema: T) {
+    super(schema);
+    this.jsonSchema = zodToJsonSchema(schema);
+  }
+
+  get openAiFunctionSchema(): ChatCompletionFunctions {
+    return {
+      name: this.outputFunctionName,
+      description: this.outputFunctionDescription,
+      parameters: this.jsonSchema,
+    };
+  }
+
+  get llmKwargs() {
+    return {
+      functions: [this.openAiFunctionSchema],
+      function_call: {
+        name: this.outputFunctionName,
+      },
+    };
+  }
+
+  async parseResult(generations: Generation[] | ChatGeneration[]) {
+    return this.functionOutputParser.parseResult(generations);
+  }
+
+  async parse(text: string): Promise<z.infer<T>> {
+    try {
+      return this.schema.parseAsync(JSON.parse(text).arguments);
+    } catch (e) {
+      throw new OutputParserException(
+        `Failed to parse. Text: "${text}". Error: ${e}`,
+        text
+      );
+    }
+  }
+
+  getFormatInstructions(): string {
+    return `You must use the provided function when responding, making sure to format your response to match the function's schema.`;
+  }
+}

--- a/langchain/src/output_parsers/tests/openai_function_call_structured.int.test.ts
+++ b/langchain/src/output_parsers/tests/openai_function_call_structured.int.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "@jest/globals";
+import { z } from "zod";
+
+import { FunctionCallStructuredOutputParser } from "../openai_function_call_structured.js";
+import { ChatOpenAI } from "../../chat_models/openai.js";
+import { LLMChain } from "../../chains/index.js";
+import {
+  ChatPromptTemplate,
+  HumanMessagePromptTemplate,
+  SystemMessagePromptTemplate,
+} from "../../prompts/index.js";
+
+test("FunctionCallStructuredOutputParser deals special chars in prompt with chat model", async () => {
+  const model = new ChatOpenAI({
+    modelName: "gpt-3.5-turbo-0613",
+    temperature: 0,
+  });
+
+  const parser = FunctionCallStructuredOutputParser.fromNamesAndDescriptions({
+    question1: "a very on-topic question",
+    question2: "a super weird question",
+    question3: "an on-topic, but slightly creative",
+  });
+
+  const prompt = new ChatPromptTemplate({
+    promptMessages: [
+      SystemMessagePromptTemplate.fromTemplate("context:\n{context}\n---"),
+    ],
+    inputVariables: ["context"],
+  });
+
+  const chain = new LLMChain({
+    llm: model,
+    prompt,
+    outputParser: parser,
+    outputKey: "questions",
+  });
+
+  const result = await chain.call({
+    context: `The U2 ur-myth begins in 1976, when drummer Larry Mullen wanted to form a band.
+        He picked four school friends from Mount Temple Comprehensive School in Dublin.
+        “Larry formed U2,” says Paul McGuinness, U2’s manager from the beginning. “He
+        auditioned the other three and he chose them. The first name of U2 was the Larry
+        Mullen band,” McGuinness laughs. “And he never lets us forget it.” `,
+  });
+
+  console.log("response", result);
+
+  expect(result.questions).toHaveProperty("question1");
+  expect(result.questions).toHaveProperty("question2");
+  expect(result.questions).toHaveProperty("question3");
+});
+
+test("FunctionCallStructuredOutputParser handles a longer and more complex schema", async () => {
+  const parser = FunctionCallStructuredOutputParser.fromZodSchema(
+    z.object({
+      name: z.string().describe("Human name"),
+      surname: z.string().describe("Human surname"),
+      age: z.number().describe("Human age"),
+      appearance: z.string().describe("Human appearance description"),
+      shortBio: z.string().describe("Short bio secription"),
+      university: z.string().optional().describe("University name if attended"),
+      gender: z.string().describe("Gender of the human"),
+      interests: z
+        .array(z.string())
+        .describe("json array of strings human interests"),
+    })
+  );
+
+  const prompt = new ChatPromptTemplate({
+    promptMessages: [
+      SystemMessagePromptTemplate.fromTemplate(
+        "Generate details of a hypothetical person."
+      ),
+      HumanMessagePromptTemplate.fromTemplate(
+        "Person description: {inputText}"
+      ),
+    ],
+    inputVariables: ["inputText"],
+  });
+
+  const model = new ChatOpenAI({
+    temperature: 0.5,
+    modelName: "gpt-3.5-turbo-0613",
+  });
+
+  const chain = new LLMChain({
+    llm: model,
+    prompt,
+    outputKey: "person",
+    outputParser: parser,
+  });
+
+  const response = await chain.call({ inputText: "A man, living in Poland." });
+  console.log("response", response);
+
+  expect(response.person).toHaveProperty("name");
+  expect(response.person).toHaveProperty("surname");
+  expect(response.person).toHaveProperty("age");
+  expect(response.person).toHaveProperty("appearance");
+  expect(response.person).toHaveProperty("shortBio");
+  expect(response.person).toHaveProperty("age");
+  expect(response.person).toHaveProperty("gender");
+  expect(response.person).toHaveProperty("interests");
+  expect(response.person.interests.length).toBeGreaterThan(0);
+});

--- a/langchain/src/schema/output_parser.ts
+++ b/langchain/src/schema/output_parser.ts
@@ -8,6 +8,14 @@ import { Serializable } from "../load/serializable.js";
 export interface FormatInstructionsOptions {}
 
 export abstract class BaseLLMOutputParser<T = unknown> extends Serializable {
+  /**
+   * Input kwargs required for the LLM to produce an output parseable by the parser.
+   * For example, "functions" and "function_call" for OpenAI functions models.
+   */
+  get llmKwargs() {
+    return {};
+  }
+
   abstract parseResult(
     generations: Generation[] | ChatGeneration[],
     callbacks?: Callbacks


### PR DESCRIPTION
Adds a new type of output parser that leverages OpenAI functions to structure output rather than stuffing format instructions into the prompt. Should help with reliability for more complex schemas.

Followup would be making it work with the output fixing parser, but theoretically it shouldn't require as many second passes.