### PR TITLE
fix(openapi.ts): filter out empty params before passing them to the request method

### DIFF
--- a/langchain/src/chains/openai_functions/openapi.ts
+++ b/langchain/src/chains/openai_functions/openapi.ts
@@ -352,7 +352,14 @@ class SimpleRequestChain extends BaseChain {
   ): Promise<ChainValues> {
     const inputKeyValue = values[this.inputKey];
     const methodName = inputKeyValue.name;
-    const args = inputKeyValue.arguments;
+    let { params } = inputKeyValue.arguments;
+    params = Object.keys(params).reduce((acc, key) => {
+      if (Object.keys(params[key]).length !== 0) {
+        acc[key] = params[key];
+      }
+      return acc;
+    }, {} as Record<string, string>);
+    const args = { ...inputKeyValue.arguments, params };
     const response = await this.requestMethod(methodName, args);
     let output;
     if (response.status < 200 || response.status > 299) {


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Partially addresses #1870 

It's better to design APIs to only require parameters that are actually used, so this should not really create issues. Some API, as highlighted in my issue, will try to consume a provided query if it's empty, and will throw a 400 status code if the param is not an expected value