### PR TITLE
docs: add a simple playwright example, fix bad imports

### DIFF
--- a/docs/docs/modules/indexes/document_loaders/examples/web_loaders/web_playwright.md
+++ b/docs/docs/modules/indexes/document_loaders/examples/web_loaders/web_playwright.md
@@ -60,7 +60,20 @@ By passing these options to the `PlaywrightWebBaseLoader` constructor, you can c
 Here is a basic example to do it:
 
 ```typescript
-import { PlaywrightWebBaseLoader } from "langchain/document_loaders/web/playwright";
+import { PlaywrightWebBaseLoader, Page, Browser } from "langchain/document_loaders/web/playwright";
+
+const url = "https://www.tabnews.com.br/"
+const loader = new PlaywrightWebBaseLoader(url)
+const docs = await loader.load()
+
+// raw HTML page content
+const extractedContents = docs[0].pageContent
+```
+
+And a more advanced example:
+
+```typescript
+import { PlaywrightWebBaseLoader, Page, Browser } from "langchain/document_loaders/web/playwright";
 
 const loader = new PlaywrightWebBaseLoader("https://www.tabnews.com.br/", {
   launchOptions: {


### PR DESCRIPTION
fwiw I wasn't able to get `waitForResponse` working for me and it's not clear from the docs why you need it in the evaluate block.
The default evaluate function does not use it.
