### PR TITLE
Fix the batchSize parameter of OpenAIEmbeddings

### DIFF
--- a/langchain/src/embeddings/openai.ts
+++ b/langchain/src/embeddings/openai.ts
@@ -99,7 +99,7 @@ export class OpenAIEmbeddings
       getEnvironmentVariable("AZURE_OPENAI_BASE_PATH");
 
     this.modelName = fields?.modelName ?? this.modelName;
-    this.batchSize = fields?.batchSize ?? azureApiKey ? 1 : this.batchSize;
+    this.batchSize = fields?.batchSize ?? (azureApiKey ? 1 : this.batchSize);
     this.stripNewLines = fields?.stripNewLines ?? this.stripNewLines;
     this.timeout = fields?.timeout;
 


### PR DESCRIPTION
According to the operator precedence in JavaScript, the nullish coalescing operator `(??)` has a lower precedence than the conditional operator `(? :)`. Therefore, the expression is actually evaluated as
```
this.batchSize = (fields?.batchSize ?? azureApiKey) ? 1 : this.batchSize
```
 so the `batchSize` parameter will not work