### PR TITLE
docs: make it clear that chunks are characters and not tokens

### DIFF
--- a/docs/docs/modules/indexes/text_splitters/index.mdx
+++ b/docs/docs/modules/indexes/text_splitters/index.mdx
@@ -19,8 +19,8 @@ Using a Text Splitter can also help improve the results from vector store search
 
 ## Parameters
 
-- `chunkSize?: number = 1000`: The maximum number of characters in each chunk. The default value is 1000 tokens.
-- `chunkOverlap?: number = 200`: The number of overlapping characters between adjacent chunks. The default value is 200 tokens.
+- `chunkSize?: number = 1000`: The maximum number of characters (not tokens) in each chunk. The default value is 1000 characters.
+- `chunkOverlap?: number = 200`: The number of overlapping characters between adjacent chunks. The default value is 200 characters.
 
 ```typescript
 type TextSplitterChunkHeaderOptions = {

--- a/examples/src/agents/vectorstore.ts
+++ b/examples/src/agents/vectorstore.ts
@@ -12,7 +12,7 @@ import {
 const model = new OpenAI({ temperature: 0 });
 /* Load in the file we want to do question answering over */
 const text = fs.readFileSync("state_of_the_union.txt", "utf8");
-/* Split the text into chunks */
+/* Split the text into chunks using character, not token, size */
 const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
 const docs = await textSplitter.createDocuments([text]);
 /* Create the vectorstore */


### PR DESCRIPTION
tokens and characters are mentioned in the same line, this makes it clear that splitters work off of characters (being able to split based on token count would be way better imho).
