### PR TITLE
Avoid retries and surface better error message for OpenAI quota cutoff errors

### DIFF
--- a/langchain/src/util/async_caller.ts
+++ b/langchain/src/util/async_caller.ts
@@ -93,6 +93,12 @@ export class AsyncCaller {
               if (status && STATUS_NO_RETRY.includes(+status)) {
                 throw error;
               }
+              const data = (error as any)?.response?.data;
+              if (data?.error?.code === "insufficient_quota") {
+                const error = new Error(data?.error?.message);
+                error.name = "InsufficientQuotaError";
+                throw error;
+              }
             },
             retries: this.maxRetries,
             randomize: true,


### PR DESCRIPTION
Fixes #1929. 

Previously, such errors would be mistaken for retryable rate limit errors and retried with an exponential backoff, causing apps to confusingly hang.