### PR TITLE
Add custom lengthFunction for textSplitters

### DIFF
--- a/langchain/src/text_splitter.ts
+++ b/langchain/src/text_splitter.ts
@@ -7,6 +7,7 @@ export interface TextSplitterParams {
   chunkSize: number;
   chunkOverlap: number;
   keepSeparator: boolean;
+  lengthFunction?: (text: string) => number;
 }
 
 export type TextSplitterChunkHeaderOptions = {
@@ -27,11 +28,14 @@ export abstract class TextSplitter
 
   keepSeparator = false;
 
+  lengthFunction: (text: string) => number = (text: string) => text.length;
+
   constructor(fields?: Partial<TextSplitterParams>) {
     super(fields);
     this.chunkSize = fields?.chunkSize ?? this.chunkSize;
     this.chunkOverlap = fields?.chunkOverlap ?? this.chunkOverlap;
     this.keepSeparator = fields?.keepSeparator ?? this.keepSeparator;
+    this.lengthFunction = fields?.lengthFunction ?? ((text) => text.length);
     if (this.chunkOverlap >= this.chunkSize) {
       throw new Error("Cannot have chunkOverlap >= chunkSize");
     }
@@ -90,7 +94,7 @@ export abstract class TextSplitter
         let numberOfIntermediateNewLines = 0;
         if (prevChunk) {
           const indexChunk = text.indexOf(chunk);
-          const indexEndPrevChunk = text.indexOf(prevChunk) + prevChunk.length;
+          const indexEndPrevChunk = text.indexOf(prevChunk) + this.lengthFunction(prevChunk);
           const removedNewlinesFromSplittingText = text.slice(
             indexEndPrevChunk,
             indexChunk
@@ -154,7 +158,7 @@ export abstract class TextSplitter
     const currentDoc: string[] = [];
     let total = 0;
     for (const d of splits) {
-      const _len = d.length;
+      const _len = this.lengthFunction(d);
       if (
         total + _len + (currentDoc.length > 0 ? separator.length : 0) >
         this.chunkSize
@@ -177,7 +181,7 @@ which is longer than the specified ${this.chunkSize}`
             total > this.chunkOverlap ||
             (total + _len > this.chunkSize && total > 0)
           ) {
-            total -= currentDoc[0].length;
+            total -= this.lengthFunction( currentDoc[0]);
             currentDoc.shift();
           }
         }
@@ -280,7 +284,7 @@ export class RecursiveCharacterTextSplitter
     let goodSplits: string[] = [];
     const _separator = this.keepSeparator ? "" : separator;
     for (const s of splits) {
-      if (s.length < this.chunkSize) {
+      if (this.lengthFunction(s) < this.chunkSize) {
         goodSplits.push(s);
       } else {
         if (goodSplits.length) {


### PR DESCRIPTION
Needs testing.

- Added a lengthFunction for textSplitter class in an attempt to bring parity to how langchain python allows for a length_function to be passed in. This allows chunking using the RecursiveTextSplitter or CharacterTextSplitter, but uses a custom length function that will allow you to pass in a tiktoken length function or similar.

Fixes https://github.com/hwchase17/langchainjs/issues/1951