### PR TITLE
Feature: Add handleLLMNewFunctionCall callback

### DIFF
--- a/langchain/src/callbacks/base.ts
+++ b/langchain/src/callbacks/base.ts
@@ -63,7 +63,7 @@ abstract class BaseCallbackHandlerMethodsClass {
    * Called when an LLM/ChatModel in `streaming` mode produces a new function call
    */
   handleLLMNewFunctionCall?(
-    function_call: { name?: string; arguments?: string },
+    functionCall: { name?: string; arguments?: string },
     idx: NewTokenIndices,
     runId: string,
     parentRunId?: string,

--- a/langchain/src/callbacks/base.ts
+++ b/langchain/src/callbacks/base.ts
@@ -60,6 +60,17 @@ abstract class BaseCallbackHandlerMethodsClass {
   ): Promise<void> | void;
 
   /**
+   * Called when an LLM/ChatModel in `streaming` mode produces a new function call
+   */
+  handleLLMNewFunctionCall?(
+    function_call: { name?: string; arguments?: string },
+    idx: NewTokenIndices,
+    runId: string,
+    parentRunId?: string,
+    tags?: string[]
+  ): Promise<void> | void;
+
+  /**
    * Called if an LLM/ChatModel run encounters an error
    */
   handleLLMError?(

--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -149,6 +149,33 @@ export class CallbackManagerForLLMRun
     );
   }
 
+  async handleLLMNewFunctionCall(
+    function_call: { name?: string; arguments?: string },
+    idx: NewTokenIndices = { prompt: 0, completion: 0 }
+  ) {
+    await Promise.all(
+      this.handlers.map((handler) =>
+        consumeCallback(async () => {
+          if (!handler.ignoreLLM) {
+            try {
+              await handler.handleLLMNewFunctionCall?.(
+                function_call,
+                idx,
+                this.runId,
+                this._parentRunId,
+                this.tags
+              );
+            } catch (err) {
+              console.error(
+                `Error in handler ${handler.constructor.name}, handleLLMNewFunctionCall: ${err}`
+              );
+            }
+          }
+        }, handler.awaitHandlers)
+      )
+    );
+  }
+
   async handleLLMError(err: Error | unknown): Promise<void> {
     await Promise.all(
       this.handlers.map((handler) =>

--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -150,7 +150,7 @@ export class CallbackManagerForLLMRun
   }
 
   async handleLLMNewFunctionCall(
-    function_call: { name?: string; arguments?: string },
+    functionCall: { name?: string; arguments?: string },
     idx: NewTokenIndices = { prompt: 0, completion: 0 }
   ) {
     await Promise.all(
@@ -159,7 +159,7 @@ export class CallbackManagerForLLMRun
           if (!handler.ignoreLLM) {
             try {
               await handler.handleLLMNewFunctionCall?.(
-                function_call,
+                functionCall,
                 idx,
                 this.runId,
                 this._parentRunId,

--- a/langchain/src/callbacks/tests/callbacks.test.ts
+++ b/langchain/src/callbacks/tests/callbacks.test.ts
@@ -33,6 +33,8 @@ class FakeCallbackHandler extends BaseCallbackHandler {
 
   llmStreams = 0;
 
+  llmFunctionCalls = 0;
+
   toolStarts = 0;
 
   toolEnds = 0;
@@ -57,6 +59,10 @@ class FakeCallbackHandler extends BaseCallbackHandler {
 
   async handleLLMNewToken(_token: string): Promise<void> {
     this.llmStreams += 1;
+  }
+
+  async handleLLMNewFunctionCall(_function_call: object): Promise<void> {
+    this.llmFunctionCalls += 1;
   }
 
   async handleLLMError(_err: Error): Promise<void> {
@@ -159,6 +165,7 @@ test("CallbackManager", async () => {
     llmCbs.map(async (llmCb) => {
       await llmCb.handleLLMEnd({ generations: [] });
       await llmCb.handleLLMNewToken("test");
+      await llmCb.handleLLMNewFunctionCall({});
       await llmCb.handleLLMError(new Error("test"));
     })
   );
@@ -183,6 +190,7 @@ test("CallbackManager", async () => {
     expect(handler.llmStarts).toBe(1);
     expect(handler.llmEnds).toBe(1);
     expect(handler.llmStreams).toBe(1);
+    expect(handler.llmFunctionCalls).toBe(1);
     expect(handler.chainStarts).toBe(1);
     expect(handler.chainEnds).toBe(1);
     expect(handler.toolStarts).toBe(2);

--- a/langchain/src/callbacks/tests/callbacks.test.ts
+++ b/langchain/src/callbacks/tests/callbacks.test.ts
@@ -61,7 +61,7 @@ class FakeCallbackHandler extends BaseCallbackHandler {
     this.llmStreams += 1;
   }
 
-  async handleLLMNewFunctionCall(_function_call: object): Promise<void> {
+  async handleLLMNewFunctionCall(_functionCall: object): Promise<void> {
     this.llmFunctionCalls += 1;
   }
 

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -419,6 +419,14 @@ export class ChatOpenAI
                           part.delta?.function_call?.name ?? "";
                         choice.message.function_call.arguments +=
                           part.delta?.function_call?.arguments ?? "";
+
+                        void runManager?.handleLLMNewFunctionCall(
+                          choice.message.function_call,
+                          {
+                            prompt: options.promptIndex ?? 0,
+                            completion: part.index,
+                          }
+                        );
                       }
                       // eslint-disable-next-line no-void
                       void runManager?.handleLLMNewToken(
@@ -428,8 +436,6 @@ export class ChatOpenAI
                           completion: part.index,
                         }
                       );
-                      // TODO we don't currently have a callback method for
-                      // sending the function call arguments
                     }
                   }
 


### PR DESCRIPTION
Right now when we are using a function call, the `handleLLMNewToken` callback returns nothing. The `handleLLMNewFunctionCall` callback allows us to receive a streamed response.