### PR TITLE
Use default export from Anthropic SDK instead of named

### DIFF
--- a/langchain/src/chat_models/anthropic.ts
+++ b/langchain/src/chat_models/anthropic.ts
@@ -1,7 +1,4 @@
-import AnthropicApi, {
-  AI_PROMPT,
-  HUMAN_PROMPT,
-} from "@anthropic-ai/sdk";
+import * as AnthropicApi from "@anthropic-ai/sdk";
 import type { CompletionCreateParams } from "@anthropic-ai/sdk/resources/completions";
 
 import { BaseLanguageModelCallOptions } from "../base_language/index.js";
@@ -19,9 +16,9 @@ import { BaseChatModel, BaseChatModelParams } from "./base.js";
 function getAnthropicPromptFromMessage(type: MessageType): string {
   switch (type) {
     case "ai":
-      return AI_PROMPT;
+      return AnthropicApi.AI_PROMPT;
     case "human":
-      return HUMAN_PROMPT;
+      return AnthropicApi.HUMAN_PROMPT;
     case "system":
       return "";
     default:
@@ -29,7 +26,7 @@ function getAnthropicPromptFromMessage(type: MessageType): string {
   }
 }
 
-const DEFAULT_STOP_SEQUENCES = [HUMAN_PROMPT];
+const DEFAULT_STOP_SEQUENCES = [AnthropicApi.HUMAN_PROMPT];
 
 /**
  * Input to AnthropicChat class.
@@ -140,10 +137,10 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
   streaming = false;
 
   // Used for non-streaming requests
-  private batchClient: AnthropicApi;
+  private batchClient: AnthropicApi.Anthropic;
 
   // Used for streaming requests
-  private streamingClient: AnthropicApi;
+  private streamingClient: AnthropicApi.Anthropic;
 
   constructor(fields?: Partial<AnthropicInput> & BaseChatModelParams) {
     super(fields ?? {});
@@ -218,7 +215,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
           );
           return `${messagePrompt} ${message.content}`;
         })
-        .join("") + AI_PROMPT
+        .join("") + AnthropicApi.AI_PROMPT
     );
   }
 
@@ -245,7 +242,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     );
 
     const generations: ChatGeneration[] = response.completion
-      .split(AI_PROMPT)
+      .split(AnthropicApi.AI_PROMPT)
       .map((message) => ({
         text: message,
         message: new AIMessage(message),
@@ -261,17 +258,17 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     request: CompletionCreateParams & Kwargs,
     options: { signal?: AbortSignal },
     runManager?: CallbackManagerForLLMRun
-  ): Promise<AnthropicApi.Completions.Completion> {
+  ): Promise<AnthropicApi.Anthropic.Completions.Completion> {
     if (!this.anthropicApiKey) {
       throw new Error("Missing Anthropic API key.");
     }
-    let makeCompletionRequest: () => Promise<AnthropicApi.Completions.Completion>;
+    let makeCompletionRequest: () => Promise<AnthropicApi.Anthropic.Completions.Completion>;
 
     let asyncCallerOptions = {};
     if (request.stream) {
       if (!this.streamingClient) {
         const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
-        this.streamingClient = new AnthropicApi({
+        this.streamingClient = new AnthropicApi.Anthropic({
           ...options,
           apiKey: this.anthropicApiKey,
         });
@@ -281,7 +278,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
           ...request,
         });
 
-        const completion: AnthropicApi.Completion = {
+        const completion: AnthropicApi.Anthropic.Completion = {
           completion: "",
           model: "",
           stop_reason: "",
@@ -312,7 +309,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     } else {
       if (!this.batchClient) {
         const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
-        this.batchClient = new AnthropicApi({
+        this.batchClient = new AnthropicApi.Anthropic({
           ...options,
           apiKey: this.anthropicApiKey,
         });

--- a/langchain/src/chat_models/anthropic.ts
+++ b/langchain/src/chat_models/anthropic.ts
@@ -1,4 +1,8 @@
-import * as AnthropicApi from "@anthropic-ai/sdk";
+import AnthropicApi, {
+  AI_PROMPT,
+  HUMAN_PROMPT,
+  Anthropic,
+} from "@anthropic-ai/sdk";
 import type { CompletionCreateParams } from "@anthropic-ai/sdk/resources/completions";
 
 import { BaseLanguageModelCallOptions } from "../base_language/index.js";
@@ -16,9 +20,9 @@ import { BaseChatModel, BaseChatModelParams } from "./base.js";
 function getAnthropicPromptFromMessage(type: MessageType): string {
   switch (type) {
     case "ai":
-      return AnthropicApi.AI_PROMPT;
+      return AI_PROMPT;
     case "human":
-      return AnthropicApi.HUMAN_PROMPT;
+      return HUMAN_PROMPT;
     case "system":
       return "";
     default:
@@ -26,7 +30,7 @@ function getAnthropicPromptFromMessage(type: MessageType): string {
   }
 }
 
-const DEFAULT_STOP_SEQUENCES = [AnthropicApi.HUMAN_PROMPT];
+const DEFAULT_STOP_SEQUENCES = [HUMAN_PROMPT];
 
 /**
  * Input to AnthropicChat class.
@@ -137,10 +141,10 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
   streaming = false;
 
   // Used for non-streaming requests
-  private batchClient: AnthropicApi.Anthropic;
+  private batchClient: AnthropicApi;
 
   // Used for streaming requests
-  private streamingClient: AnthropicApi.Anthropic;
+  private streamingClient: AnthropicApi;
 
   constructor(fields?: Partial<AnthropicInput> & BaseChatModelParams) {
     super(fields ?? {});
@@ -215,7 +219,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
           );
           return `${messagePrompt} ${message.content}`;
         })
-        .join("") + AnthropicApi.AI_PROMPT
+        .join("") + AI_PROMPT
     );
   }
 
@@ -242,7 +246,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     );
 
     const generations: ChatGeneration[] = response.completion
-      .split(AnthropicApi.AI_PROMPT)
+      .split(AI_PROMPT)
       .map((message) => ({
         text: message,
         message: new AIMessage(message),
@@ -258,17 +262,17 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     request: CompletionCreateParams & Kwargs,
     options: { signal?: AbortSignal },
     runManager?: CallbackManagerForLLMRun
-  ): Promise<AnthropicApi.Anthropic.Completions.Completion> {
+  ): Promise<Anthropic.Completions.Completion> {
     if (!this.anthropicApiKey) {
       throw new Error("Missing Anthropic API key.");
     }
-    let makeCompletionRequest: () => Promise<AnthropicApi.Anthropic.Completions.Completion>;
+    let makeCompletionRequest: () => Promise<Anthropic.Completions.Completion>;
 
     let asyncCallerOptions = {};
     if (request.stream) {
       if (!this.streamingClient) {
         const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
-        this.streamingClient = new AnthropicApi.Anthropic({
+        this.streamingClient = new AnthropicApi({
           ...options,
           apiKey: this.anthropicApiKey,
         });
@@ -278,7 +282,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
           ...request,
         });
 
-        const completion: AnthropicApi.Anthropic.Completion = {
+        const completion: Anthropic.Completion = {
           completion: "",
           model: "",
           stop_reason: "",
@@ -309,7 +313,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     } else {
       if (!this.batchClient) {
         const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
-        this.batchClient = new AnthropicApi.Anthropic({
+        this.batchClient = new AnthropicApi({
           ...options,
           apiKey: this.anthropicApiKey,
         });

--- a/langchain/src/chat_models/anthropic.ts
+++ b/langchain/src/chat_models/anthropic.ts
@@ -1,6 +1,5 @@
-import {
+import AnthropicApi, {
   AI_PROMPT,
-  Anthropic as AnthropicApi,
   HUMAN_PROMPT,
 } from "@anthropic-ai/sdk";
 import type { CompletionCreateParams } from "@anthropic-ai/sdk/resources/completions";

--- a/langchain/src/chat_models/anthropic.ts
+++ b/langchain/src/chat_models/anthropic.ts
@@ -13,6 +13,11 @@ import {
 import { getEnvironmentVariable } from "../util/env.js";
 import { BaseChatModel, BaseChatModelParams } from "./base.js";
 
+// Anthropic's 0.5.3 SDK currently has a collision with the default exported class
+// and an exported namespace that causes issues when transpiling to CommonJS
+const AnthropicClientConstructor =
+  AnthropicApi.Anthropic ?? AnthropicApi.default;
+
 function getAnthropicPromptFromMessage(type: MessageType): string {
   switch (type) {
     case "ai":
@@ -268,7 +273,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     if (request.stream) {
       if (!this.streamingClient) {
         const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
-        this.streamingClient = new AnthropicApi.Anthropic({
+        this.streamingClient = new AnthropicClientConstructor({
           ...options,
           apiKey: this.anthropicApiKey,
         });
@@ -309,7 +314,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     } else {
       if (!this.batchClient) {
         const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
-        this.batchClient = new AnthropicApi.Anthropic({
+        this.batchClient = new AnthropicClientConstructor({
           ...options,
           apiKey: this.anthropicApiKey,
         });

--- a/langchain/src/chat_models/anthropic.ts
+++ b/langchain/src/chat_models/anthropic.ts
@@ -1,8 +1,4 @@
-import AnthropicApi, {
-  AI_PROMPT,
-  HUMAN_PROMPT,
-  Anthropic,
-} from "@anthropic-ai/sdk";
+import * as AnthropicApi from "@anthropic-ai/sdk";
 import type { CompletionCreateParams } from "@anthropic-ai/sdk/resources/completions";
 
 import { BaseLanguageModelCallOptions } from "../base_language/index.js";
@@ -20,9 +16,9 @@ import { BaseChatModel, BaseChatModelParams } from "./base.js";
 function getAnthropicPromptFromMessage(type: MessageType): string {
   switch (type) {
     case "ai":
-      return AI_PROMPT;
+      return AnthropicApi.AI_PROMPT;
     case "human":
-      return HUMAN_PROMPT;
+      return AnthropicApi.HUMAN_PROMPT;
     case "system":
       return "";
     default:
@@ -30,7 +26,7 @@ function getAnthropicPromptFromMessage(type: MessageType): string {
   }
 }
 
-const DEFAULT_STOP_SEQUENCES = [HUMAN_PROMPT];
+const DEFAULT_STOP_SEQUENCES = [AnthropicApi.HUMAN_PROMPT];
 
 /**
  * Input to AnthropicChat class.
@@ -141,10 +137,10 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
   streaming = false;
 
   // Used for non-streaming requests
-  private batchClient: AnthropicApi;
+  private batchClient: AnthropicApi.Anthropic;
 
   // Used for streaming requests
-  private streamingClient: AnthropicApi;
+  private streamingClient: AnthropicApi.Anthropic;
 
   constructor(fields?: Partial<AnthropicInput> & BaseChatModelParams) {
     super(fields ?? {});
@@ -219,7 +215,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
           );
           return `${messagePrompt} ${message.content}`;
         })
-        .join("") + AI_PROMPT
+        .join("") + AnthropicApi.AI_PROMPT
     );
   }
 
@@ -246,7 +242,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     );
 
     const generations: ChatGeneration[] = response.completion
-      .split(AI_PROMPT)
+      .split(AnthropicApi.AI_PROMPT)
       .map((message) => ({
         text: message,
         message: new AIMessage(message),
@@ -262,17 +258,17 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     request: CompletionCreateParams & Kwargs,
     options: { signal?: AbortSignal },
     runManager?: CallbackManagerForLLMRun
-  ): Promise<Anthropic.Completions.Completion> {
+  ): Promise<AnthropicApi.Anthropic.Completions.Completion> {
     if (!this.anthropicApiKey) {
       throw new Error("Missing Anthropic API key.");
     }
-    let makeCompletionRequest: () => Promise<Anthropic.Completions.Completion>;
+    let makeCompletionRequest: () => Promise<AnthropicApi.Anthropic.Completions.Completion>;
 
     let asyncCallerOptions = {};
     if (request.stream) {
       if (!this.streamingClient) {
         const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
-        this.streamingClient = new AnthropicApi({
+        this.streamingClient = new AnthropicApi.Anthropic({
           ...options,
           apiKey: this.anthropicApiKey,
         });
@@ -282,7 +278,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
           ...request,
         });
 
-        const completion: Anthropic.Completion = {
+        const completion: AnthropicApi.Anthropic.Completion = {
           completion: "",
           model: "",
           stop_reason: "",
@@ -313,7 +309,7 @@ export class ChatAnthropic extends BaseChatModel implements AnthropicInput {
     } else {
       if (!this.batchClient) {
         const options = this.apiUrl ? { apiUrl: this.apiUrl } : undefined;
-        this.batchClient = new AnthropicApi({
+        this.batchClient = new AnthropicApi.Anthropic({
           ...options,
           apiKey: this.anthropicApiKey,
         });


### PR DESCRIPTION
Fixes #1958

The CJS version of langchain resolved the anthropic SDK like so:
```
const sdk_1 = require("@anthropic-ai/sdk");
[...code here...]
this.streamingClient = new sdk_1.Anthropic({
    ...options,
    apiKey: this.anthropicApiKey,
});
```

The above code appears to has issues when the CJS version of langchain was consumed. I think the issue is that `sdk_1.Anthropic` from the package `@anthropic-ai/sdk` resolves to a namespace and/or has a collision since the Anthropic client and a namespace are both exported under `Anthropic` in the anthropic package.

The change raised here uses the explicit default export from `@anthropic-ai/sdk`. This results in the following CJS code in the langchain build:
```
const sdk_1 = __importStar(require("@anthropic-ai/sdk"));
[...code here...]
this.streamingClient = new sdk_1.default({
    ...options,
    apiKey: this.anthropicApiKey,
});
```

This solves the found issue since `sdk_1.default` resolves to the correct Anthropic SDK client and doesn't collide.