### PR TITLE
A quick way to create a fake, but consistent, pseudo-embeddings

### DIFF
--- a/langchain/src/embeddings/fake.ts
+++ b/langchain/src/embeddings/fake.ts
@@ -15,11 +15,13 @@ export class FakeEmbeddings extends Embeddings {
 }
 
 interface SyntheticEmbeddingsParams extends EmbeddingsParams {
-  vectorSize: number
+  vectorSize: number;
 }
 
-export class SyntheticEmbeddings extends Embeddings implements SyntheticEmbeddingsParams {
-
+export class SyntheticEmbeddings
+  extends Embeddings
+  implements SyntheticEmbeddingsParams
+{
   vectorSize: number;
 
   constructor(params?: SyntheticEmbeddingsParams) {
@@ -28,46 +30,45 @@ export class SyntheticEmbeddings extends Embeddings implements SyntheticEmbeddin
   }
 
   async embedDocuments(documents: string[]): Promise<number[][]> {
-    return Promise.all(documents.map(doc => this.embedQuery(doc)));
+    return Promise.all(documents.map((doc) => this.embedQuery(doc)));
   }
 
   async embedQuery(document: string): Promise<number[]> {
     let doc = document;
 
     // Only use the letters (and space) from the document, and make them lower case
-    doc = doc.toLowerCase().replaceAll(/[^a-z ]/g, '');
+    doc = doc.toLowerCase().replaceAll(/[^a-z ]/g, "");
     // console.log(doc.length);
 
     // Pad the document to make sure it has a divisible number of chunks
     const padMod = doc.length % this.vectorSize;
     const padGapSize = padMod === 0 ? 0 : this.vectorSize - padMod;
     const padSize = doc.length + padGapSize;
-    doc = doc.padEnd(padSize,' ');
+    doc = doc.padEnd(padSize, " ");
     // console.log(padGapSize, padSize, doc);
 
     // Break it into chunks
     const chunkSize = doc.length / this.vectorSize;
     const docChunk = [];
-    for (let co=0; co<doc.length; co += chunkSize) {
-      docChunk.push(doc.slice(co, co+chunkSize));
+    for (let co = 0; co < doc.length; co += chunkSize) {
+      docChunk.push(doc.slice(co, co + chunkSize));
     }
     // console.log(chunkSize, docChunk);
 
     // Turn each chunk into a number
-    const ret: number[] = docChunk.map( s => {
+    const ret: number[] = docChunk.map((s) => {
       let sum = 0;
       // Get a total value by adding the value of each character in the string
-      for (let co=0; co<s.length; co+=1) {
-        sum += s ===  ' ' ? 0 : s.charCodeAt(co);
+      for (let co = 0; co < s.length; co += 1) {
+        sum += s === " " ? 0 : s.charCodeAt(co);
       }
       // Reduce this to a number between 0 and 25 inclusive
       // Then get the fractional number by dividing it by 26
-      const ret =  (sum % 26) / 26;
+      const ret = (sum % 26) / 26;
       // console.log(s, sum, sum % 26, ret);
       return ret;
-    })
+    });
 
     return ret;
   }
-
 }

--- a/langchain/src/embeddings/fake.ts
+++ b/langchain/src/embeddings/fake.ts
@@ -38,14 +38,12 @@ export class SyntheticEmbeddings
 
     // Only use the letters (and space) from the document, and make them lower case
     doc = doc.toLowerCase().replaceAll(/[^a-z ]/g, "");
-    // console.log(doc.length);
 
     // Pad the document to make sure it has a divisible number of chunks
     const padMod = doc.length % this.vectorSize;
     const padGapSize = padMod === 0 ? 0 : this.vectorSize - padMod;
     const padSize = doc.length + padGapSize;
     doc = doc.padEnd(padSize, " ");
-    // console.log(padGapSize, padSize, doc);
 
     // Break it into chunks
     const chunkSize = doc.length / this.vectorSize;
@@ -53,7 +51,6 @@ export class SyntheticEmbeddings
     for (let co = 0; co < doc.length; co += chunkSize) {
       docChunk.push(doc.slice(co, co + chunkSize));
     }
-    // console.log(chunkSize, docChunk);
 
     // Turn each chunk into a number
     const ret: number[] = docChunk.map((s) => {
@@ -65,7 +62,6 @@ export class SyntheticEmbeddings
       // Reduce this to a number between 0 and 25 inclusive
       // Then get the fractional number by dividing it by 26
       const ret = (sum % 26) / 26;
-      // console.log(s, sum, sum % 26, ret);
       return ret;
     });
 

--- a/langchain/src/embeddings/fake.ts
+++ b/langchain/src/embeddings/fake.ts
@@ -13,3 +13,61 @@ export class FakeEmbeddings extends Embeddings {
     return Promise.resolve([0.1, 0.2, 0.3, 0.4]);
   }
 }
+
+interface SyntheticEmbeddingsParams extends EmbeddingsParams {
+  vectorSize: number
+}
+
+export class SyntheticEmbeddings extends Embeddings implements SyntheticEmbeddingsParams {
+
+  vectorSize: number;
+
+  constructor(params?: SyntheticEmbeddingsParams) {
+    super(params ?? {});
+    this.vectorSize = params?.vectorSize ?? 4;
+  }
+
+  async embedDocuments(documents: string[]): Promise<number[][]> {
+    return Promise.all(documents.map(doc => this.embedQuery(doc)));
+  }
+
+  async embedQuery(document: string): Promise<number[]> {
+    let doc = document;
+
+    // Only use the letters (and space) from the document, and make them lower case
+    doc = doc.toLowerCase().replaceAll(/[^a-z ]/g, '');
+    // console.log(doc.length);
+
+    // Pad the document to make sure it has a divisible number of chunks
+    const padMod = doc.length % this.vectorSize;
+    const padGapSize = padMod === 0 ? 0 : this.vectorSize - padMod;
+    const padSize = doc.length + padGapSize;
+    doc = doc.padEnd(padSize,' ');
+    // console.log(padGapSize, padSize, doc);
+
+    // Break it into chunks
+    const chunkSize = doc.length / this.vectorSize;
+    const docChunk = [];
+    for (let co=0; co<doc.length; co += chunkSize) {
+      docChunk.push(doc.slice(co, co+chunkSize));
+    }
+    // console.log(chunkSize, docChunk);
+
+    // Turn each chunk into a number
+    const ret: number[] = docChunk.map( s => {
+      let sum = 0;
+      // Get a total value by adding the value of each character in the string
+      for (let co=0; co<s.length; co+=1) {
+        sum += s ===  ' ' ? 0 : s.charCodeAt(co);
+      }
+      // Reduce this to a number between 0 and 25 inclusive
+      // Then get the fractional number by dividing it by 26
+      const ret =  (sum % 26) / 26;
+      // console.log(s, sum, sum % 26, ret);
+      return ret;
+    })
+
+    return ret;
+  }
+
+}

--- a/langchain/src/embeddings/tests/fake.test.ts
+++ b/langchain/src/embeddings/tests/fake.test.ts
@@ -1,36 +1,36 @@
 import { test, expect } from "@jest/globals";
 import { SyntheticEmbeddings } from "../fake.js";
 
-test('Synthetic basic', async () => {
-  const embed = new SyntheticEmbeddings({vectorSize: 5});
-  const vector = await embed.embedQuery('aaaaaaaaaa');
+test("Synthetic basic", async () => {
+  const embed = new SyntheticEmbeddings({ vectorSize: 5 });
+  const vector = await embed.embedQuery("aaaaaaaaaa");
   expect(vector).toHaveLength(5);
   expect(vector[0]).toEqual(0.46153846153846156);
   expect(vector[4]).toEqual(0.46153846153846156);
 });
 
-test('Synthetic Padding', async () => {
-  const embed = new SyntheticEmbeddings({vectorSize: 5});
-  const vector = await embed.embedQuery('aaaaaaaaa');
+test("Synthetic Padding", async () => {
+  const embed = new SyntheticEmbeddings({ vectorSize: 5 });
+  const vector = await embed.embedQuery("aaaaaaaaa");
   expect(vector).toHaveLength(5);
   expect(vector[0]).toEqual(0.46153846153846156);
   expect(vector[4]).toEqual(0.9615384615384616);
 });
 
-test('Synthetic extreme padding', async () => {
-  const embed = new SyntheticEmbeddings({vectorSize: 768});
-  const vector = await embed.embedQuery('aa');
+test("Synthetic extreme padding", async () => {
+  const embed = new SyntheticEmbeddings({ vectorSize: 768 });
+  const vector = await embed.embedQuery("aa");
   expect(vector).toHaveLength(768);
   expect(vector[0]).toEqual(0.7307692307692307);
   expect(vector[1]).toEqual(0.7307692307692307);
   expect(vector[2]).toEqual(0);
-})
+});
 
-test('Synthetic similarity', async () => {
-  const embed = new SyntheticEmbeddings({vectorSize: 2});
-  const v1 = await embed.embedQuery('this');
-  const v2 = await embed.embedQuery('that');
-  console.log(v1,v2);
+test("Synthetic similarity", async () => {
+  const embed = new SyntheticEmbeddings({ vectorSize: 2 });
+  const v1 = await embed.embedQuery("this");
+  const v2 = await embed.embedQuery("that");
+  console.log(v1, v2);
   expect(v1).toHaveLength(2);
   expect(v2).toHaveLength(2);
   expect(v1[0]).toEqual(v2[0]);

--- a/langchain/src/embeddings/tests/fake.test.ts
+++ b/langchain/src/embeddings/tests/fake.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "@jest/globals";
+import { SyntheticEmbeddings } from "../fake.js";
+
+test('Synthetic basic', async () => {
+  const embed = new SyntheticEmbeddings({vectorSize: 5});
+  const vector = await embed.embedQuery('aaaaaaaaaa');
+  expect(vector).toHaveLength(5);
+  expect(vector[0]).toEqual(0.46153846153846156);
+  expect(vector[4]).toEqual(0.46153846153846156);
+});
+
+test('Synthetic Padding', async () => {
+  const embed = new SyntheticEmbeddings({vectorSize: 5});
+  const vector = await embed.embedQuery('aaaaaaaaa');
+  expect(vector).toHaveLength(5);
+  expect(vector[0]).toEqual(0.46153846153846156);
+  expect(vector[4]).toEqual(0.9615384615384616);
+});
+
+test('Synthetic extreme padding', async () => {
+  const embed = new SyntheticEmbeddings({vectorSize: 768});
+  const vector = await embed.embedQuery('aa');
+  expect(vector).toHaveLength(768);
+  expect(vector[0]).toEqual(0.7307692307692307);
+  expect(vector[1]).toEqual(0.7307692307692307);
+  expect(vector[2]).toEqual(0);
+})
+
+test('Synthetic similarity', async () => {
+  const embed = new SyntheticEmbeddings({vectorSize: 2});
+  const v1 = await embed.embedQuery('this');
+  const v2 = await embed.embedQuery('that');
+  console.log(v1,v2);
+  expect(v1).toHaveLength(2);
+  expect(v2).toHaveLength(2);
+  expect(v1[0]).toEqual(v2[0]);
+  expect(v1[1]).not.toEqual(v2[1]);
+});


### PR DESCRIPTION
This provides a SyntheticEmbeddings class which is created with a specified vector size. It then creates a vector of this size based on the input.
* Identical inputs should yield the same output for the same vector size. ("this" will always have the same vector)
* Similar inputs of the same size should yield nearby vectors, depending (very roughly) how similar. ("this" and "that" should have nearby vectors, but it depends on the vector size)
* Inputs of different sizes may give similar vectors, depending in the input sizes and vector size. In some cases. ("this" and "thing" may have nearby vectors, but it depends largely on the vector size. If the vector size is 10, for example, the first three components in the vector should be the same.)

This class is meant to be used for testing in cases where it is advantageous to have several consistent, but not always identical to each other, vectors without needing to install a real embeddings engine.