### PR TITLE
fix: type modelName

### DIFF
--- a/langchain/src/base_language/count_tokens.ts
+++ b/langchain/src/base_language/count_tokens.ts
@@ -78,6 +78,7 @@ export const calculateMaxTokens = async ({
     );
 
     // fallback to approximate calculation if tiktoken is not available
+    // each token is ~4 characters: https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them#
     numTokens = Math.ceil(prompt.length / 4);
   }
 

--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -16,6 +16,7 @@ import {
   AzureOpenAIInput,
   OpenAICallOptions,
   OpenAIChatInput,
+  TiktokenModel,
 } from "../types/openai-types.js";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
 import type { StreamingAxiosConfiguration } from "../util/axios-types.js";
@@ -158,7 +159,7 @@ export class ChatOpenAI
 
   logitBias?: Record<string, number>;
 
-  modelName = "gpt-3.5-turbo";
+  modelName: TiktokenModel = "gpt-3.5-turbo";
 
   modelKwargs?: OpenAIChatInput["modelKwargs"];
 

--- a/langchain/src/embeddings/openai.ts
+++ b/langchain/src/embeddings/openai.ts
@@ -6,7 +6,7 @@ import {
 } from "openai";
 import type { AxiosRequestConfig } from "axios";
 import { getEnvironmentVariable, isNode } from "../util/env.js";
-import { AzureOpenAIInput } from "../types/openai-types.js";
+import { AzureOpenAIInput, TiktokenModel } from "../types/openai-types.js";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
 import { chunkArray } from "../util/chunk.js";
 import { Embeddings, EmbeddingsParams } from "./base.js";
@@ -14,7 +14,7 @@ import { getEndpoint, OpenAIEndpointConfig } from "../util/azure.js";
 
 export interface OpenAIEmbeddingsParams extends EmbeddingsParams {
   /** Model name to use */
-  modelName: string;
+  modelName: TiktokenModel;
 
   /**
    * Timeout to use when making requests to OpenAI.
@@ -38,7 +38,7 @@ export class OpenAIEmbeddings
   extends Embeddings
   implements OpenAIEmbeddingsParams, AzureOpenAIInput
 {
-  modelName = "text-embedding-ada-002";
+  modelName: TiktokenModel = "text-embedding-ada-002";
 
   batchSize = 512;
 

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -12,6 +12,7 @@ import {
   AzureOpenAIInput,
   OpenAICallOptions,
   OpenAIChatInput,
+  TiktokenModel,
 } from "../types/openai-types.js";
 import type { StreamingAxiosConfiguration } from "../util/axios-types.js";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
@@ -97,7 +98,7 @@ export class OpenAIChat
 
   maxTokens?: number;
 
-  modelName = "gpt-3.5-turbo";
+  modelName: TiktokenModel = "gpt-3.5-turbo";
 
   prefixMessages?: ChatCompletionRequestMessage[];
 

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -1,4 +1,3 @@
-import type { TiktokenModel } from "js-tiktoken/lite";
 import {
   Configuration,
   ConfigurationParameters,
@@ -12,6 +11,7 @@ import {
   AzureOpenAIInput,
   OpenAICallOptions,
   OpenAIInput,
+  TiktokenModel,
 } from "../types/openai-types.js";
 import type { StreamingAxiosConfiguration } from "../util/axios-types.js";
 import fetchAdapter from "../util/axios-fetch-adapter.js";
@@ -93,7 +93,7 @@ export class OpenAI extends BaseLLM implements OpenAIInput, AzureOpenAIInput {
 
   logitBias?: Record<string, number>;
 
-  modelName = "text-davinci-003";
+  modelName: TiktokenModel = "text-davinci-003";
 
   modelKwargs?: OpenAIInput["modelKwargs"];
 

--- a/langchain/src/types/openai-types.ts
+++ b/langchain/src/types/openai-types.ts
@@ -1,7 +1,12 @@
 import { AxiosRequestConfig } from "axios";
 import { ChatCompletionRequestMessage } from "openai";
 
+import { TiktokenModel } from "js-tiktoken/lite";
 import { BaseLanguageModelCallOptions } from "../base_language/index.js";
+
+// reexport this type from the included package so we can easily override and extend it if needed in the future
+// also makes it easier for folks to import this type without digging around into the dependent packages
+export type {TiktokenModel}
 
 export declare interface OpenAIBaseInput {
   /** Sampling temperature to use */
@@ -32,7 +37,7 @@ export declare interface OpenAIBaseInput {
   streaming: boolean;
 
   /** Model name to use */
-  modelName: string;
+  modelName: TiktokenModel;
 
   /** Holds any additional parameters that are valid to pass to {@link
    * https://platform.openai.com/docs/api-reference/completions/create |

--- a/langchain/src/types/openai-types.ts
+++ b/langchain/src/types/openai-types.ts
@@ -6,7 +6,7 @@ import { BaseLanguageModelCallOptions } from "../base_language/index.js";
 
 // reexport this type from the included package so we can easily override and extend it if needed in the future
 // also makes it easier for folks to import this type without digging around into the dependent packages
-export type {TiktokenModel}
+export type { TiktokenModel };
 
 export declare interface OpenAIBaseInput {
   /** Sampling temperature to use */


### PR DESCRIPTION
This has some great side effects:

* errors when a typo is made
* avoid ts errors when using `model.modelName` in downstream code

here's why it's useful:

```javascript
const model = new OpenAI({
	temperature: 0,
	maxTokens: -1,
	modelName: "gpt-3.5-turbo-16k",
	openAIApiKey: openAIAPIKey,
})

const modelTokenLimit = await calculateMaxTokens({
	prompt: renderedEmptyPrompt,
	modelName: model.modelName,
})
```
