### PR TITLE
docs: Mendable: Fixes pretty sources not working

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/preset-classic": "2.4.0",
     "@docusaurus/remark-plugin-npm2yarn": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
-    "@mendable/search": "^0.0.122",
+    "@mendable/search": "^0.0.125",
     "clsx": "^1.2.1",
     "json-loader": "^0.5.7",
     "process": "^0.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6152,15 +6152,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mendable/search@npm:^0.0.122":
-  version: 0.0.122
-  resolution: "@mendable/search@npm:0.0.122"
+"@mendable/search@npm:^0.0.125":
+  version: 0.0.125
+  resolution: "@mendable/search@npm:0.0.125"
   dependencies:
     posthog-js: ^1.45.1
   peerDependencies:
     react: ^17.x || ^18.x
     react-dom: ^17.x || ^18.x
-  checksum: afda6ac7b066b160044580a7e15183d7e64f2eaa1afaa2a8f1aca877c57060039e5de1f47a8633b89ea66b7e616a9f7b4a13e0250a14367a3b2a8f8798217976
+  checksum: 9884a2de1c1909c9b59abe6523d17033ffcecea0a16189476c2ed009df57665ab6eb0a05419237a367b9fe2d1aa02efdea0aa76063cef461f4119062b64c8a04
   languageName: node
   linkType: hard
 
@@ -11834,7 +11834,7 @@ __metadata:
     "@docusaurus/preset-classic": 2.4.0
     "@docusaurus/remark-plugin-npm2yarn": ^2.4.0
     "@mdx-js/react": ^1.6.22
-    "@mendable/search": ^0.0.122
+    "@mendable/search": ^0.0.125
     "@swc/core": ^1.3.62
     clsx: ^1.2.1
     docusaurus-plugin-typedoc: next


### PR DESCRIPTION
This new version fixes the"Verified Sources" display that got broken. Instead of displaying the full URL in the source item, it shows the title of the page the source is from.