### PR TITLE
Update Anthropic SDK to 0.5.7

### DIFF
--- a/langchain/package.json
+++ b/langchain/package.json
@@ -829,7 +829,7 @@
     }
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.5.3",
+    "@anthropic-ai/sdk": "^0.5.7",
     "ansi-styles": "^5.0.0",
     "binary-extensions": "^2.2.0",
     "camelcase": "6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,21 +15,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/sdk@npm:^0.5.3":
-  version: 0.5.4
-  resolution: "@anthropic-ai/sdk@npm:0.5.4"
+"@anthropic-ai/sdk@npm:^0.5.7":
+  version: 0.5.7
+  resolution: "@anthropic-ai/sdk@npm:0.5.7"
   dependencies:
     "@types/node": ^18.11.18
     "@types/node-fetch": ^2.6.4
-    "@types/qs": ^6.9.7
     abort-controller: ^3.0.0
     agentkeepalive: ^4.2.1
     digest-fetch: ^1.3.0
     form-data-encoder: 1.7.2
     formdata-node: ^4.3.2
     node-fetch: ^2.6.7
-    qs: ^6.10.3
-  checksum: 2baee795eebd852d13368c67f857d039901f362ac740cd97dc748c8170e0aa19ccccefd57356c2c7b134ace2fb22ff7d95a2d43b6957524056f0803a6610fac8
+  checksum: b4c55d8c962438516a035e8d08c4e6bc1f34f93df6254dc0e12db3d21cf265df3416cbfe976e9fad9ecc22f15aa1f58048465f9a298f80b71efcb6c872a35583
   languageName: node
   linkType: hard
 
@@ -6114,7 +6112,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/qs@npm:*, @types/qs@npm:^6.9.7":
+"@types/qs@npm:*":
   version: 6.9.7
   resolution: "@types/qs@npm:6.9.7"
   checksum: 7fd6f9c25053e9b5bb6bc9f9f76c1d89e6c04f7707a7ba0e44cc01f17ef5284adb82f230f542c2d5557d69407c9a40f0f3515e8319afd14e1e16b5543ac6cdba
@@ -12947,7 +12945,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "langchain@workspace:langchain"
   dependencies:
-    "@anthropic-ai/sdk": ^0.5.3
+    "@anthropic-ai/sdk": ^0.5.7
     "@aws-sdk/client-dynamodb": ^3.310.0
     "@aws-sdk/client-kendra": ^3.352.0
     "@aws-sdk/client-lambda": ^3.310.0
@@ -16043,15 +16041,6 @@ __metadata:
   version: 6.0.0
   resolution: "pure-rand@npm:6.0.0"
   checksum: ad1378d0a4859482d053a5264b2b485b445ece4bbc56f8959c233ea678b81ac2d613737925d496ded134eff5f29cc5546bf7492b6bce319ee27bebbad8a0c612
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.10.3":
-  version: 6.11.2
-  resolution: "qs@npm:6.11.2"
-  dependencies:
-    side-channel: ^1.0.4
-  checksum: e812f3c590b2262548647d62f1637b6989cc56656dc960b893fe2098d96e1bd633f36576f4cd7564dfbff9db42e17775884db96d846bebe4f37420d073ecdc0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Addresses the following issues: 
- crash when importing Anthropic SDK to non-NextJS Edge Functions
- Inconsistencies with CJS and ESM version of Anthropic SDK (we can remove the previous workaround)