### PR TITLE
fix: broken OpenAIModerationChain example

### DIFF
--- a/examples/src/chains/openai_moderation.ts
+++ b/examples/src/chains/openai_moderation.ts
@@ -13,7 +13,7 @@ try {
 
   // Send the user's input to the moderation chain and wait for the result
   const { output: badResult } = await moderation.call({
-    input: badString
+    input: badString,
   });
 
   // If the moderation chain does not detect violating content, it will return the original input and you can proceed to use the result in another chain.

--- a/examples/src/chains/openai_moderation.ts
+++ b/examples/src/chains/openai_moderation.ts
@@ -7,12 +7,13 @@ const badString = "Bad naughty words from user";
 
 try {
   // Create a new instance of the OpenAIModerationChain
-  const moderation = new OpenAIModerationChain();
+  const moderation = new OpenAIModerationChain({
+    throwError: true, // If set to true, the call will throw an error when the moderation chain detects violating content. If set to false, violating content will return "Text was found that violates OpenAI's content policy.".
+  });
 
   // Send the user's input to the moderation chain and wait for the result
   const { output: badResult } = await moderation.call({
-    input: badString,
-    throwError: true, // If set to true, the call will throw an error when the moderation chain detects violating content. If set to false, violating content will return "Text was found that violates OpenAI's content policy.".
+    input: badString
   });
 
   // If the moderation chain does not detect violating content, it will return the original input and you can proceed to use the result in another chain.


### PR DESCRIPTION
This example didn't align with how the code is actually structured. 
It is expected on instantiation of the moderation chain [here](https://github.com/hwchase17/langchainjs/blob/c09f8310a3a2197e98e188167ee39f04dbe18a1d/langchain/src/chains/openai_moderation.ts#L51), but this example is setting it on the call which doesn't do anything.