### PR TITLE
fix(StructuredOutputParser): Do not obscure OutputParserException

### DIFF
--- a/langchain/src/output_parsers/structured.ts
+++ b/langchain/src/output_parsers/structured.ts
@@ -76,7 +76,7 @@ ${JSON.stringify(zodToJsonSchema(this.schema))}
       const json = text.includes("```")
         ? text.trim().split(/```(?:json)?/)[1]
         : text.trim();
-      return this.schema.parseAsync(JSON.parse(json));
+      return await this.schema.parseAsync(JSON.parse(json));
     } catch (e) {
       throw new OutputParserException(
         `Failed to parse. Text: "${text}". Error: ${e}`,

--- a/langchain/src/output_parsers/tests/structured.test.ts
+++ b/langchain/src/output_parsers/tests/structured.test.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { expect, test } from "@jest/globals";
 
+import { OutputParserException } from "../../schema/output_parser.js";
 import { StructuredOutputParser } from "../structured.js";
 
 test("StructuredOutputParser.fromNamesAndDescriptions", async () => {
@@ -64,6 +65,16 @@ Here is the JSON Schema instance your output must adhere to. Include the enclosi
 \`\`\`
 "
 `);
+});
+
+test("StructuredOutputParser.fromZodSchema", async () => {
+  const parser = StructuredOutputParser.fromZodSchema(
+    z.object({ answer: z.enum(["yes", "no"]).describe("yes or no") })
+  );
+
+  await expect(parser.parse('```\n{"answer": "YES"}```')).rejects.toThrow(
+    OutputParserException
+  );
 });
 
 test("StructuredOutputParser.fromZodSchema", async () => {


### PR DESCRIPTION
Hello, first of all, thanks for this great project and for helping AI get closer to Javascript.

There's an error with `StructuredOutputParser` which makes it unable to work with `OutputFixingParser`.

Currently, `StructuredOutputParser` was not "awaiting" the schema check, so the try-catch clause did not run when the schema check failed. Because of this, the error that surfaced was a "ZodError" (in my case using zod).

Because `OutputFixingParser` (rightfully so) expect that the error received to be `OutputParserException` it will not properly try to fix these errors and just bail.

This fix just introduced the "await" so the try-catch clause work and also a regression test to validate.