### PR TITLE
Fix mistake in ChatOpenAI docs

### DIFF
--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -106,7 +106,7 @@ export interface ChatOpenAICallOptions extends OpenAICallOptions {
  * @remarks
  * Any parameters that are valid to be passed to {@link
  * https://platform.openai.com/docs/api-reference/chat/create |
- * `openai.createCompletion`} can be passed through {@link modelKwargs}, even
+ * `openai.createChatCompletion`} can be passed through {@link modelKwargs}, even
  * if not explicitly available on this class.
  */
 export class ChatOpenAI


### PR DESCRIPTION
This is a mistake in the documentation.

Specifically, the docs here link out to OpenAI's /chat/completions endpoint, but the link itself contains the following text:

```
openai.createCompletion
```

This is the wrong function for the /chat/completions endpoint. The correct function (which you can see clearly in the [README for the OpenAI Node module](https://github.com/openai/openai-node#usage)) is:

```
openai.createChatCompletion
```