### PR TITLE
Adds temporary shim for convo retrieval qa chain legacy users

### DIFF
--- a/docs/snippets/modules/chains/popular/chat_vector_db.mdx
+++ b/docs/snippets/modules/chains/popular/chat_vector_db.mdx
@@ -53,7 +53,7 @@ import ConvoQAStreamingExample from "@examples/chains/conversational_qa_streamin
 ## Externally-Managed Memory
 
 For this chain, if you'd like to format the chat history in a custom way (or pass in chat messages directly for convenience), you can also pass the chat history in explicitly by omitting the `memory` option and supplying
-a `chat_history` string or array of [HumanMessages](/docs/api/schema/classes/HumanMessage) and [AIMessages(/docs/api/schema/classes/AIMessage) directly into the `chain.call` method:
+a `chat_history` string or array of [HumanMessages](/docs/api/schema/classes/HumanMessage) and [AIMessages](/docs/api/schema/classes/AIMessage) directly into the `chain.call` method:
 
 import ConvoQAExternalMemoryExample from "@examples/chains/conversational_qa_external_memory.ts";
 

--- a/examples/src/chains/conversational_qa_external_memory.ts
+++ b/examples/src/chains/conversational_qa_external_memory.ts
@@ -5,31 +5,29 @@ import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
 import * as fs from "fs";
 
-export const run = async () => {
-  /* Initialize the LLM to use to answer the question */
-  const model = new OpenAI({});
-  /* Load in the file we want to do question answering over */
-  const text = fs.readFileSync("state_of_the_union.txt", "utf8");
-  /* Split the text into chunks */
-  const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
-  const docs = await textSplitter.createDocuments([text]);
-  /* Create the vectorstore */
-  const vectorStore = await HNSWLib.fromDocuments(docs, new OpenAIEmbeddings());
-  /* Create the chain */
-  const chain = ConversationalRetrievalQAChain.fromLLM(
-    model,
-    vectorStore.asRetriever()
-  );
-  /* Ask it a question */
-  const question = "What did the president say about Justice Breyer?";
-  /* Can be a string or an array of chat messages */
-  const res = await chain.call({ question, chat_history: "" });
-  console.log(res);
-  /* Ask it a follow up question */
-  const chatHistory = `${question}\n${res.text}`;
-  const followUpRes = await chain.call({
-    question: "Was that nice?",
-    chat_history: chatHistory,
-  });
-  console.log(followUpRes);
-};
+/* Initialize the LLM to use to answer the question */
+const model = new OpenAI({});
+/* Load in the file we want to do question answering over */
+const text = fs.readFileSync("state_of_the_union.txt", "utf8");
+/* Split the text into chunks */
+const textSplitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000 });
+const docs = await textSplitter.createDocuments([text]);
+/* Create the vectorstore */
+const vectorStore = await HNSWLib.fromDocuments(docs, new OpenAIEmbeddings());
+/* Create the chain */
+const chain = ConversationalRetrievalQAChain.fromLLM(
+  model,
+  vectorStore.asRetriever()
+);
+/* Ask it a question */
+const question = "What did the president say about Justice Breyer?";
+/* Can be a string or an array of chat messages */
+const res = await chain.call({ question, chat_history: "" });
+console.log(res);
+/* Ask it a follow up question */
+const chatHistory = `${question}\n${res.text}`;
+const followUpRes = await chain.call({
+  question: "Was that nice?",
+  chat_history: chatHistory,
+});
+console.log(followUpRes);

--- a/langchain/src/chains/tests/conversational_retrieval_chain.int.test.ts
+++ b/langchain/src/chains/tests/conversational_retrieval_chain.int.test.ts
@@ -330,3 +330,39 @@ test("Test ConversationalRetrievalQAChain from LLM with a chat model and memory"
 
   console.log({ res2 });
 });
+
+test("Test ConversationalRetrievalQAChain from LLM with deprecated history syntax", async () => {
+  const model = new OpenAI({
+    temperature: 0,
+  });
+  const vectorStore = await HNSWLib.fromTexts(
+    [
+      "Mitochondria are the powerhouse of the cell",
+      "Foo is red",
+      "Bar is red",
+      "Buildings are made out of brick",
+      "Mitochondria are made of lipids",
+    ],
+    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    new OpenAIEmbeddings()
+  );
+
+  const chain = ConversationalRetrievalQAChain.fromLLM(
+    model,
+    vectorStore.asRetriever()
+  );
+  const question = "What is the powerhouse of the cell?";
+  const res = await chain.call({
+    question,
+    chat_history: [],
+  });
+
+  console.log({ res });
+
+  const res2 = await chain.call({
+    question: "What are they made out of?",
+    chat_history: [[question, res.text]],
+  });
+
+  console.log({ res2 });
+});


### PR DESCRIPTION
Some popular examples in the wild have been using an unexpected format for external memory for the ConversationalRetrievalQAChain. This PR fixes the chain for those users, and logs a warning pointing them to the updated docs.

Fixes #2029 and likely others.