### PR TITLE
Feature: Enable to change the fields name in Milvus 

### DIFF
--- a/langchain/src/vectorstores/milvus.ts
+++ b/langchain/src/vectorstores/milvus.ts
@@ -400,6 +400,9 @@ export class Milvus extends VectorStore {
       ssl: dbConfig?.ssl,
       username: dbConfig?.username,
       password: dbConfig?.password,
+      textField: dbConfig?.textField,
+      primaryField: dbConfig?.primaryField,
+      vectorField: dbConfig?.vectorField,
     };
     const instance = new this(embeddings, args);
     await instance.addDocuments(docs);


### PR DESCRIPTION
With this PR we can change the fields name in Milvus DB, for example instead of name: "langchain_primaryid", the developer can change to: "some_primaryid". 
The constructor contains already these fields:  args.textField, args.primaryField and args.vectorField