### PR TITLE
feat: Allow alias usage for Qdrant database

### DIFF
--- a/langchain/src/vectorstores/qdrant.ts
+++ b/langchain/src/vectorstores/qdrant.ts
@@ -128,13 +128,18 @@ export class QdrantVectorStore extends VectorStore {
   }
 
   async ensureCollection() {
-    const response = await this.client.getCollections();
+    const collectionsResponse = await this.client.getCollections();
+    const aliasesResponse = await this.client.getAliases();
 
-    const collectionNames = response.collections.map(
+    const collectionNames = collectionsResponse.collections.map(
       (collection) => collection.name
     );
 
-    if (!collectionNames.includes(this.collectionName)) {
+    const aliasesNames = aliasesResponse.aliases.map(
+      (alias) => alias.alias_name
+    );
+
+    if (!collectionNames.includes(this.collectionName) && !aliasesNames.includes(this.collectionName)) {
       await this.client.createCollection(
         this.collectionName,
         this.collectionConfig


### PR DESCRIPTION
The change allows aliases usage for Qdrant vector database.

Qdrant allows the usage of aliases to identify collections, it's important for a data update process, Qdrant developers recommend to use the alias name to switch a collection [Qdrant Docs](https://qdrant.tech/documentation/concepts/collections/)

The actual implementation tries to create a database when an alias name is used, resulting in the following error:
status: 400, statusText: "Bad Request", data: { status: { error: "Wrong input: Can't create collection with name alias_name. Alias with the same name already exists", }