### PR TITLE
fix: duplicates in Max Marginal Relevance output

### DIFF
--- a/langchain/src/util/math_utils.ts
+++ b/langchain/src/util/math_utils.ts
@@ -80,7 +80,7 @@ export function maximalMarginalRelevance(
     );
 
     similarityToQuery.forEach((queryScore, queryScoreIndex) => {
-      if (queryScoreIndex in selectedEmbeddingsIndexes) {
+      if (selectedEmbeddingsIndexes.includes(queryScoreIndex)) {
         return;
       }
       const maxSimilarityToSelected = Math.max(

--- a/langchain/src/util/tests/math_utils.test.ts
+++ b/langchain/src/util/tests/math_utils.test.ts
@@ -129,3 +129,17 @@ test("Test maximal marginal relevance query dim", async () => {
 
   expect(first).toEqual(second);
 });
+
+test("Test maximal marginal relevance has no duplicates", async () => {
+  const queryEmbedding = Matrix.rand(1, 1536).to1DArray();
+  const embeddingList = Matrix.rand(200, 1536).to2DArray();
+
+  const actual = maximalMarginalRelevance(
+    queryEmbedding,
+    embeddingList,
+    0.5,
+    200
+  );
+  const expected = new Set(actual).size;
+  expect(actual).toHaveLength(expected);
+});


### PR DESCRIPTION
Fixed a bad "in" check for already selected embeddings, added a test for duplicates check