### PR TITLE
fix non saving chroma loc

### DIFF
--- a/langchain/src/vectorstores/chroma.ts
+++ b/langchain/src/vectorstores/chroma.ts
@@ -111,13 +111,11 @@ export class Chroma extends VectorStore {
     await collection.upsert({
       ids: documentIds,
       embeddings: vectors,
-      metadatas: documents.map(({ metadata }) => {
-        return {
-          ...metadata,
-          locFrom:metadata.loc.lines.from,
-          locTo: metadata.loc.lines.to,
-        }
-      }),
+      metadatas: documents.map(({ metadata }) => ({
+        ...metadata,
+        locFrom: metadata.loc.lines.from,
+        locTo: metadata.loc.lines.to,
+      })),
       documents: documents.map(({ pageContent }) => pageContent),
     });
     return documentIds;
@@ -168,28 +166,28 @@ export class Chroma extends VectorStore {
 
     const results: [Document, number][] = [];
     for (let i = 0; i < firstIds.length; i += 1) {
-      let metadata = {} as any
-      let storedMetadata = firstMetadatas?.[i]
+      let metadata: Document["metadata"] = {};
+      const storedMetadata = firstMetadatas?.[i];
 
-      if (storedMetadata && storedMetadata.locFrom && storedMetadata.locTo ) {
+      if (storedMetadata && storedMetadata.locFrom && storedMetadata.locTo) {
         metadata = {
           ...firstMetadatas[i],
           loc: {
             lines: {
               from: storedMetadata.locFrom,
-              to: storedMetadata.locTo
-            }
-          }
-        }
-        
-        delete metadata.locFrom
-        delete metadata.locTo
+              to: storedMetadata.locTo,
+            },
+          },
+        };
+
+        delete metadata.locFrom;
+        delete metadata.locTo;
       }
 
       results.push([
         new Document({
           pageContent: firstDocuments?.[i] ?? "",
-          metadata: metadata,
+          metadata,
         }),
         firstDistances[i],
       ]);

--- a/langchain/src/vectorstores/chroma.ts
+++ b/langchain/src/vectorstores/chroma.ts
@@ -109,22 +109,25 @@ export class Chroma extends VectorStore {
       options?.ids ?? Array.from({ length: vectors.length }, () => uuid.v1());
     const collection = await this.ensureCollection();
 
-    let mappedMetadatas = documents.map(({ metadata }) => {
-      let locFrom = undefined;
-      let locTo = undefined;
+    const mappedMetadatas = documents.map(({ metadata }) => {
+      let locFrom;
+      let locTo;
 
       if (metadata?.loc) {
         if (metadata.loc.lines?.from !== undefined)
           locFrom = metadata.loc.lines.from;
         if (metadata.loc.lines?.to !== undefined) locTo = metadata.loc.lines.to;
-        delete metadata.loc;
       }
 
-      return {
+      const newMetadata: Document["metadata"] = {
         ...metadata,
         ...(locFrom !== undefined && { locFrom }),
         ...(locTo !== undefined && { locTo }),
       };
+
+      if (newMetadata.loc) delete newMetadata.loc;
+
+      return newMetadata;
     });
 
     await collection.upsert({

--- a/langchain/src/vectorstores/chroma.ts
+++ b/langchain/src/vectorstores/chroma.ts
@@ -113,8 +113,12 @@ export class Chroma extends VectorStore {
       embeddings: vectors,
       metadatas: documents.map(({ metadata }) => ({
         ...metadata,
-        locFrom: metadata.loc.lines.from,
-        locTo: metadata.loc.lines.to,
+        ...(metadata?.loc?.lines?.from && {
+          locFrom: metadata.loc.lines.from,
+        }),
+        ...(metadata?.loc?.lines?.to && {
+          locTo: metadata.loc.lines.to,
+        }),
       })),
       documents: documents.map(({ pageContent }) => pageContent),
     });

--- a/langchain/src/vectorstores/tests/chroma.test.ts
+++ b/langchain/src/vectorstores/tests/chroma.test.ts
@@ -56,7 +56,7 @@ describe("Chroma", () => {
     );
     expect(mockCollection.upsert).toHaveBeenCalled();
 
-    const metadatas = mockCollection.upsert.mock.calls[0][0].metadatas;
+    const { metadatas } = mockCollection.upsert.mock.calls[0][0];
     expect(metadatas).toEqual([{}, {}]);
   });
 
@@ -74,7 +74,7 @@ describe("Chroma", () => {
     const chroma = new Chroma(embeddings, args);
     await chroma.addDocuments(documents as any);
 
-    const metadatas = mockCollection.upsert.mock.calls[0][0].metadatas;
+    const { metadatas } = mockCollection.upsert.mock.calls[0][0];
 
     expect(metadatas[0]).toEqual({
       source: "source.html",

--- a/langchain/src/vectorstores/tests/chroma.test.ts
+++ b/langchain/src/vectorstores/tests/chroma.test.ts
@@ -39,6 +39,7 @@ describe("Chroma", () => {
 
     expect(chromaStore).toBeDefined();
   });
+
   test("should add vectors to the collection", async () => {
     const expectedPageContents = ["Document 1", "Document 2"];
     const embeddings = new FakeEmbeddings();
@@ -54,6 +55,32 @@ describe("Chroma", () => {
       expectedPageContents
     );
     expect(mockCollection.upsert).toHaveBeenCalled();
+
+    const metadatas = mockCollection.upsert.mock.calls[0][0].metadatas;
+    expect(metadatas).toEqual([{}, {}]);
+  });
+
+  test("should override loc.lines with locFrom/locTo", async () => {
+    const expectedPageContents = ["Document 1"];
+    const embeddings = new FakeEmbeddings();
+    jest.spyOn(embeddings, "embedDocuments");
+
+    const args = { collectionName: "testCollection", index: mockClient };
+    const documents = expectedPageContents.map((pc) => ({
+      pageContent: pc,
+      metadata: { source: "source.html", loc: { lines: { from: 0, to: 4 } } },
+    }));
+
+    const chroma = new Chroma(embeddings, args);
+    await chroma.addDocuments(documents as any);
+
+    const metadatas = mockCollection.upsert.mock.calls[0][0].metadatas;
+
+    expect(metadatas[0]).toEqual({
+      source: "source.html",
+      locFrom: 0,
+      locTo: 4,
+    });
   });
 
   test("should throw an error for mismatched vector lengths", async () => {


### PR DESCRIPTION
Chroma doesn't save multi level objects. Seemingly since 0.4.0. See chroma [types.ts](https://github.com/chroma-core/chroma/blob/77c1675c49a1aeab5a1b0c81b4aacc1afdf877b5/clients/js/src/types.ts#L12), which doesn't include object as an allowed value.

The storing succeeds, but the loc object is empty.

If you store the object as a single property (`locFrom`, `locTo`), it works.

This PR maps the langchain `loc` when storing and the new `locFrom` when reading.