### PR TITLE
Enhance PlaywrightWebBaseLoader with HTTP response handling

### DIFF
--- a/docs/extras/modules/data_connection/document_loaders/integrations/web_loaders/web_playwright.md
+++ b/docs/extras/modules/data_connection/document_loaders/integrations/web_loaders/web_playwright.md
@@ -53,7 +53,7 @@ type PlaywrightWebBaseLoaderOptions = {
 
 2. `gotoOptions`: an optional object that specifies additional options to pass to the page.goto() method. This can include options such as the timeout option to specify the maximum navigation time in milliseconds, or the waitUntil option to specify when to consider the navigation as successful.
 
-3. `evaluate`: an optional function that can be used to evaluate JavaScript code on the page using a custom evaluation function. This can be useful for extracting data from the page or interacting with page elements. The function should return a Promise that resolves to a string containing the result of the evaluation.
+3. `evaluate`: an optional function that can be used to evaluate JavaScript code on the page using a custom evaluation function. This can be useful for extracting data from the page, interacting with page elements, or handling specific HTTP responses. The function should return a Promise that resolves to a string containing the result of the evaluation.
 
 By passing these options to the `PlaywrightWebBaseLoader` constructor, you can customize the behavior of the loader and use Playwright's powerful features to scrape and interact with web pages.
 
@@ -91,7 +91,7 @@ const loader = new PlaywrightWebBaseLoader("https://www.tabnews.com.br/", {
     waitUntil: "domcontentloaded",
   },
   /** Pass custom evaluate, in this case you get page and browser instances */
-  async evaluate(page: Page, browser: Browser) {
+  async evaluate(page: Page, browser: Browser, response: Response | null) {
     await page.waitForResponse("https://www.tabnews.com.br/va/view");
 
     const result = await page.evaluate(() => document.body.innerHTML);

--- a/langchain/src/document_loaders/web/playwright.ts
+++ b/langchain/src/document_loaders/web/playwright.ts
@@ -1,10 +1,10 @@
-import type { LaunchOptions, Page, Browser } from "playwright";
+import type { LaunchOptions, Page, Browser, Response } from "playwright";
 
 import { Document } from "../../document.js";
 import { BaseDocumentLoader } from "../base.js";
 import type { DocumentLoader } from "../base.js";
 
-export { Page, Browser };
+export { Page, Browser, Response };
 
 export type PlaywrightGotoOptions = {
   referer?: string;
@@ -14,7 +14,8 @@ export type PlaywrightGotoOptions = {
 
 export type PlaywrightEvaluate = (
   page: Page,
-  browser: Browser
+  browser: Browser,
+  response: Response | null
 ) => Promise<string>;
 
 export type PlaywrightWebBaseLoaderOptions = {
@@ -49,13 +50,13 @@ export class PlaywrightWebBaseLoader
     });
     const page = await browser.newPage();
 
-    await page.goto(url, {
+    const response = await page.goto(url, {
       timeout: 180000,
       waitUntil: "domcontentloaded",
       ...options?.gotoOptions,
     });
     const bodyHTML = options?.evaluate
-      ? await options?.evaluate(page, browser)
+      ? await options?.evaluate(page, browser, response)
       : await page.content();
 
     await browser.close();


### PR DESCRIPTION
This PR introduces an enhancement to the PlaywrightWebBaseLoader in LangChain, a feature update that gives you more control over the HTTP responses when loading web pages using the Playwright library.

The original implementation of PlaywrightWebBaseLoader doesn't deal with the Response object returned by Playwright's page navigation function. With this PR, PlaywrightWebBaseLoader is adjusted to capture and use this Response object, enabling additional processing based on the HTTP response.

Here's a snippet of how to use this enhanced functionality:

```typescript
import {
  PlaywrightWebBaseLoader,
  Page,
  Browser,
  Response,
} from "langchain/document_loaders/web/playwright";

const loader = new PlaywrightWebBaseLoader("https://your-web-url", {
  async evaluate(page: Page, browser: Browser, response: Response | null) {
    let contentType = 'text/html';
    if (response != null) {
      contentType = response.headers()['content-type'];
    }
    if (contentType.includes('text/html')) {
      // Do something specific for HTML content
    }
    // Do something else for non-HTML content
  },
});
...
```

By providing more control over the handling of HTTP responses, this enhancement broadens LangChain's web scraping capabilities to cater a wider range of use cases.