### PR TITLE
Update refine_prompts.ts

### DIFF
--- a/langchain/src/chains/question_answering/refine_prompts.ts
+++ b/langchain/src/chains/question_answering/refine_prompts.ts
@@ -19,7 +19,7 @@ We have the opportunity to refine the existing answer
 {context}
 ------------
 Given the new context, refine the original answer to better answer the question. 
-If the context isn't useful, return the original answer.`;
+You must provide a response, either original answer or refined answer.`;
 export const DEFAULT_REFINE_PROMPT = /*#__PURE__*/ new PromptTemplate({
   inputVariables: ["question", "existing_answer", "context"],
   template: DEFAULT_REFINE_PROMPT_TMPL,
@@ -33,7 +33,7 @@ We have the opportunity to refine the existing answer
 {context}
 ------------
 Given the new context, refine the original answer to better answer the question. 
-If the context isn't useful, return the original answer.`;
+You must provide a response, either original answer or refined answer.`;
 
 const messages = [
   /*#__PURE__*/ HumanMessagePromptTemplate.fromTemplate("{question}"),


### PR DESCRIPTION
Came across a bug with `gpt-3.5-turbo-16k` and with other LLMs:

`QARefineChain` overwrites a good answer previously found with a useless message about no further refinement needed.
After a bit of debugging, I've realised that the bot seems to ignore this line `If the context isn't useful, return the original answer.` 

Reproduction:
a. https://platform.openai.com/playground/p/bjJa9sc7rb6z1Y9dFpsi4uvH
b. same prompt with local LLMs

Suggested solution:
Improve the problematic line with `you must` words.

Demo:
a. https://platform.openai.com/playground/p/756t4wSvzDJiUHLlkWiUnZDY
b. try yourself with another LLM, for instance LLaMA
    