### PR TITLE
Feat: make projectId configurable for vertex ai

### DIFF
--- a/langchain/src/types/googlevertexai-types.ts
+++ b/langchain/src/types/googlevertexai-types.ts
@@ -1,11 +1,11 @@
 import { BaseLLMParams } from "../llms/index.js";
+import { GoogleAuthOptions } from "google-auth-library";
 
 export interface GoogleVertexAIConnectionParams {
   /** Hostname for the API call */
   endpoint?: string;
 
-  /** Project where Vertex AI is enabled */
-  projectId?: string;
+  authOptions?: GoogleAuthOptions;
 
   /** Region where the LLM is stored */
   location?: string;

--- a/langchain/src/types/googlevertexai-types.ts
+++ b/langchain/src/types/googlevertexai-types.ts
@@ -1,5 +1,5 @@
-import { BaseLLMParams } from "../llms/index.js";
 import { GoogleAuthOptions } from "google-auth-library";
+import { BaseLLMParams } from "../llms/index.js";
 
 export interface GoogleVertexAIConnectionParams {
   /** Hostname for the API call */

--- a/langchain/src/types/googlevertexai-types.ts
+++ b/langchain/src/types/googlevertexai-types.ts
@@ -4,6 +4,9 @@ export interface GoogleVertexAIConnectionParams {
   /** Hostname for the API call */
   endpoint?: string;
 
+  /** Project where Vertex AI is enabled */
+  projectId?: string;
+
   /** Region where the LLM is stored */
   location?: string;
 

--- a/langchain/src/util/googlevertexai-connection.ts
+++ b/langchain/src/util/googlevertexai-connection.ts
@@ -36,6 +36,7 @@ export class GoogleVertexAIConnection<
 
     this.auth = new GoogleAuth({
       scopes: "https://www.googleapis.com/auth/cloud-platform",
+      projectId: fields?.projectId,
     });
   }
 

--- a/langchain/src/util/googlevertexai-connection.ts
+++ b/langchain/src/util/googlevertexai-connection.ts
@@ -36,7 +36,7 @@ export class GoogleVertexAIConnection<
 
     this.auth = new GoogleAuth({
       scopes: "https://www.googleapis.com/auth/cloud-platform",
-      projectId: fields?.projectId,
+      projectId: fields?.projectId ?? null,
     });
   }
 

--- a/langchain/src/util/googlevertexai-connection.ts
+++ b/langchain/src/util/googlevertexai-connection.ts
@@ -36,7 +36,7 @@ export class GoogleVertexAIConnection<
 
     this.auth = new GoogleAuth({
       scopes: "https://www.googleapis.com/auth/cloud-platform",
-      projectId: fields?.projectId ?? null,
+      projectId: fields?.projectId,
     });
   }
 

--- a/langchain/src/util/googlevertexai-connection.ts
+++ b/langchain/src/util/googlevertexai-connection.ts
@@ -35,8 +35,8 @@ export class GoogleVertexAIConnection<
     this.model = fields?.model ?? this.model;
 
     this.auth = new GoogleAuth({
-      ...fields?.authOptions,
       scopes: "https://www.googleapis.com/auth/cloud-platform",
+      ...fields?.authOptions,
     });
   }
 

--- a/langchain/src/util/googlevertexai-connection.ts
+++ b/langchain/src/util/googlevertexai-connection.ts
@@ -35,8 +35,8 @@ export class GoogleVertexAIConnection<
     this.model = fields?.model ?? this.model;
 
     this.auth = new GoogleAuth({
+      ...fields?.authOptions,
       scopes: "https://www.googleapis.com/auth/cloud-platform",
-      projectId: fields?.projectId,
     });
   }
 


### PR DESCRIPTION
This PR allows overwriting the auth options for Vertex AI that differ from the variables from environment such as `GOOGLE_APPLICATION_CREDENTIALS`. 

ref: https://github.com/googleapis/google-auth-library-nodejs/blob/main/src/auth/googleauth.ts#L85