### PR TITLE
Added missing property declaration

### DIFF
--- a/examples/src/agents/structured_chat.ts
+++ b/examples/src/agents/structured_chat.ts
@@ -17,6 +17,7 @@ export const run = async () => {
       }),
       func: async ({ low, high }) =>
         (Math.random() * (high - low) + low).toString(), // Outputs still must be strings
+      returnDirect: false, // This is an option that allows the tool to return the output directly 
     }),
   ];
 

--- a/examples/src/agents/structured_chat.ts
+++ b/examples/src/agents/structured_chat.ts
@@ -17,7 +17,7 @@ export const run = async () => {
       }),
       func: async ({ low, high }) =>
         (Math.random() * (high - low) + low).toString(), // Outputs still must be strings
-      returnDirect: false, // This is an option that allows the tool to return the output directly 
+      returnDirect: false, // This is an option that allows the tool to return the output directly
     }),
   ];
 


### PR DESCRIPTION
Dynamic structured tool has a property called returnDirect that allows the tool to return the output directly. I have added this missing declaration to the documentation.


Fixes #2109 


twitter_handle: @SkenosP