### PR TITLE
Feature - add filter type for Milvus DB

### DIFF
--- a/langchain/src/vectorstores/base.ts
+++ b/langchain/src/vectorstores/base.ts
@@ -62,7 +62,7 @@ export class VectorStoreRetriever<
 }
 
 export abstract class VectorStore extends Serializable {
-  declare FilterType: object;
+  declare FilterType: object | string;
 
   lc_namespace = ["langchain", "vectorstores", this._vectorstoreType()];
 

--- a/langchain/src/vectorstores/milvus.ts
+++ b/langchain/src/vectorstores/milvus.ts
@@ -23,6 +23,10 @@ export interface MilvusLibArgs {
   password?: string;
 }
 
+export interface MilvusFilterType {
+  filterStr: string;
+}
+
 type IndexType =
   | "IVF_FLAT"
   | "IVF_SQ8"
@@ -55,6 +59,8 @@ export class Milvus extends VectorStore {
       password: "MILVUS_PASSWORD",
     };
   }
+
+  declare FilterType: MilvusFilterType;
 
   collectionName: string;
 
@@ -184,7 +190,8 @@ export class Milvus extends VectorStore {
 
   async similaritySearchVectorWithScore(
     query: number[],
-    k: number
+    k: number,
+    filter?: MilvusFilterType
   ): Promise<[Document, number][]> {
     const hasColResp = await this.client.hasCollection({
       collection_name: this.collectionName,
@@ -197,6 +204,8 @@ export class Milvus extends VectorStore {
         `Collection not found: ${this.collectionName}, please create collection before search.`
       );
     }
+
+    const filterStr = filter ? filter.filterStr : "";
 
     await this.grabCollectionFields();
 
@@ -223,6 +232,7 @@ export class Milvus extends VectorStore {
       output_fields: outputFields,
       vector_type: DataType.FloatVector,
       vectors: [query],
+      filter: filterStr,
     });
     if (searchResp.status.error_code !== ErrorCode.SUCCESS) {
       throw new Error(`Error searching data: ${JSON.stringify(searchResp)}`);

--- a/langchain/src/vectorstores/milvus.ts
+++ b/langchain/src/vectorstores/milvus.ts
@@ -23,10 +23,6 @@ export interface MilvusLibArgs {
   password?: string;
 }
 
-export interface MilvusFilterType {
-  filterStr: string;
-}
-
 type IndexType =
   | "IVF_FLAT"
   | "IVF_SQ8"
@@ -60,7 +56,7 @@ export class Milvus extends VectorStore {
     };
   }
 
-  declare FilterType: MilvusFilterType;
+  declare FilterType: string;
 
   collectionName: string;
 
@@ -191,7 +187,7 @@ export class Milvus extends VectorStore {
   async similaritySearchVectorWithScore(
     query: number[],
     k: number,
-    filter?: MilvusFilterType
+    filter?: string
   ): Promise<[Document, number][]> {
     const hasColResp = await this.client.hasCollection({
       collection_name: this.collectionName,
@@ -205,7 +201,7 @@ export class Milvus extends VectorStore {
       );
     }
 
-    const filterStr = filter ? filter.filterStr : "";
+    const filterStr = filter ?? "";
 
     await this.grabCollectionFields();
 

--- a/langchain/src/vectorstores/tests/milvus.int.test.ts
+++ b/langchain/src/vectorstores/tests/milvus.int.test.ts
@@ -50,9 +50,7 @@ Harmonic Labyrinth of the dreaded Majotaur?`,
     { id: 5, other: objA },
   ]);
 
-  const resultThree = await milvus.similaritySearch(query, 1, {
-    filterStr: "id == 1",
-  });
+  const resultThree = await milvus.similaritySearch(query, 1, "id == 1");
   const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
   expect(resultThreeMetadatas).toEqual([{ id: 1, other: objB }]);
 });
@@ -75,9 +73,7 @@ test.skip("Test Milvus.fromExistingCollection", async () => {
   expect(resultTwoMetadatas[1].id).toEqual(4);
   expect(resultTwoMetadatas[2].id).toEqual(5);
 
-  const resultThree = await milvus.similaritySearch(query, 1, {
-    filterStr: "id == 1",
-  });
+  const resultThree = await milvus.similaritySearch(query, 1, "id == 1");
   const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
   expect(resultThreeMetadatas.length).toBe(1);
   expect(resultThreeMetadatas[0].id).toEqual(1);

--- a/langchain/src/vectorstores/tests/milvus.int.test.ts
+++ b/langchain/src/vectorstores/tests/milvus.int.test.ts
@@ -49,6 +49,12 @@ Harmonic Labyrinth of the dreaded Majotaur?`,
     { id: 4, other: objB },
     { id: 5, other: objA },
   ]);
+
+  const resultThree = await milvus.similaritySearch(query, 1, {
+    filterStr: "id == 1",
+  });
+  const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
+  expect(resultThreeMetadatas).toEqual([{ id: 1, other: objB }]);
 });
 
 test.skip("Test Milvus.fromExistingCollection", async () => {
@@ -68,6 +74,13 @@ test.skip("Test Milvus.fromExistingCollection", async () => {
   expect(resultTwoMetadatas[0].id).toEqual(1);
   expect(resultTwoMetadatas[1].id).toEqual(4);
   expect(resultTwoMetadatas[2].id).toEqual(5);
+
+  const resultThree = await milvus.similaritySearch(query, 1, {
+    filterStr: "id == 1",
+  });
+  const resultThreeMetadatas = resultThree.map(({ metadata }) => metadata);
+  expect(resultThreeMetadatas.length).toBe(1);
+  expect(resultThreeMetadatas[0].id).toEqual(1);
 });
 
 afterAll(async () => {


### PR DESCRIPTION
A filter type has been added to Milvus DB, so we can pass filter object with a property called `filterStr`