### PR TITLE
Add support for Xata as a vector store

### DIFF
--- a/docs/extras/modules/data_connection/vectorstores/integrations/xata.mdx
+++ b/docs/extras/modules/data_connection/vectorstores/integrations/xata.mdx
@@ -2,7 +2,7 @@
 
 [Xata](https://xata.io) is a serverless data platform, based on PostgreSQL. It provides a type-safe TypeScript/JavaScript SDK for interacting with your database, and a UI for managing your data.
 
-Xata has a native vector type, which can be added to any table, and supports similarity search. LangChain inserts vectors directly to Xata, and queries Weaviate for the nearest neighbors of a given vector, so that you can use all the LangChain Embeddings integrations with Xata.
+Xata has a native vector type, which can be added to any table, and supports similarity search. LangChain inserts vectors directly to Xata, and queries it for the nearest neighbors of a given vector, so that you can use all the LangChain Embeddings integrations with Xata.
 
 ## Setup
 

--- a/docs/extras/modules/data_connection/vectorstores/integrations/xata.mdx
+++ b/docs/extras/modules/data_connection/vectorstores/integrations/xata.mdx
@@ -1,0 +1,52 @@
+# Xata
+
+[Xata](https://xata.io) is a serverless data platform, based on PostgreSQL. It provides a type-safe TypeScript/JavaScript SDK for interacting with your database, and a UI for managing your data.
+
+Xata has a native vector type, which can be added to any table, and supports similarity search. LangChain inserts vectors directly to Xata, and queries Weaviate for the nearest neighbors of a given vector, so that you can use all the LangChain Embeddings integrations with Xata.
+
+## Setup
+
+### Install the Xata CLI
+
+```bash
+npm install @xata.io/cli -g
+```
+
+### Create a database to be used as a vector store
+
+In the [Xata UI](https://app.xata.io) create a new database. You can name it whatever you want, but for this example we'll use `langchain`.
+Create a table, again you can name it anything, but we will use `vectors`. Add the following columns via the UI:
+
+* `content` of type "Long text". This is used to store the `Document.pageContent` values.
+* `embedding` of type "Vector". Use the dimension used by the model you plan to use (1536 for OpenAI).
+* any other columns you want to use as metadata. They are populated from the `Document.metadata` object. For example, if in the `Document.metadata` object you have a `title` property, you can create a `title` column in the table and it will be populated.
+
+### Initialize the project
+
+In your project, run:
+
+```bash
+xata init
+```
+
+and then choose the database you created above. This will also generate a `xata.ts` or `xata.js` file that defines the client you can use to interact with the database. See the [Xata getting started docs](https://xata.io/docs/getting-started/installation) for more details on using the Xata JavaScript/TypeScript SDK.
+
+## Usage
+
+import CodeBlock from "@theme/CodeBlock";
+
+### Example: Q&A chatbot using OpenAI and Xata as vector store
+
+This example uses the `VectorDBQAChain` to search the documents stored in Xata and then pass them as context to the OpenAI model, in order to answer the question asked by the user.
+
+import FromDocs from "@examples/indexes/vector_stores/xata.ts";
+
+<CodeBlock language="typescript">{FromDocs}</CodeBlock>
+
+### Example: Similarity search with a metadata filter
+
+This example shows how to implement semantic search using LangChain.js and Xata. Before running it, make sure to add an `author` column of type String to the `vectors` table in Xata.
+
+import SimSearch from "@examples/indexes/vector_stores/xata_metadata.ts";
+
+<CodeBlock language="typescript">{SimSearch}</CodeBlock>

--- a/examples/package.json
+++ b/examples/package.json
@@ -35,6 +35,7 @@
     "@tensorflow/tfjs-backend-cpu": "^4.4.0",
     "@tigrisdata/vector": "^1.1.0",
     "@upstash/redis": "^1.20.6",
+    "@xata.io/client": "^0.25.1",
     "@zilliz/milvus2-sdk-node": "^2.2.7",
     "axios": "^0.26.0",
     "chromadb": "^1.4.0",

--- a/examples/src/indexes/vector_stores/xata.ts
+++ b/examples/src/indexes/vector_stores/xata.ts
@@ -1,0 +1,3 @@
+import { XataClientArgs, XataVectorSearch } from "langchain/vectorstores/xata";
+
+export async function run() {}

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -199,6 +199,9 @@ vectorstores/tigris.d.ts
 vectorstores/vectara.cjs
 vectorstores/vectara.js
 vectorstores/vectara.d.ts
+vectorstores/xata.cjs
+vectorstores/xata.js
+vectorstores/xata.d.ts
 text_splitter.cjs
 text_splitter.js
 text_splitter.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -211,6 +211,9 @@
     "vectorstores/vectara.cjs",
     "vectorstores/vectara.js",
     "vectorstores/vectara.d.ts",
+    "vectorstores/xata.cjs",
+    "vectorstores/xata.js",
+    "vectorstores/xata.d.ts",
     "text_splitter.cjs",
     "text_splitter.js",
     "text_splitter.d.ts",
@@ -1242,6 +1245,11 @@
       "types": "./vectorstores/vectara.d.ts",
       "import": "./vectorstores/vectara.js",
       "require": "./vectorstores/vectara.cjs"
+    },
+    "./vectorstores/xata": {
+      "types": "./vectorstores/xata.d.ts",
+      "import": "./vectorstores/xata.js",
+      "require": "./vectorstores/xata.cjs"
     },
     "./text_splitter": {
       "types": "./text_splitter.d.ts",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -561,6 +561,7 @@
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.58.0",
     "@upstash/redis": "^1.20.6",
+    "@xata.io/client": "^0.25.1",
     "@zilliz/milvus2-sdk-node": ">=2.2.7",
     "apify-client": "^2.7.1",
     "axios": "^0.26.0",
@@ -641,6 +642,7 @@
     "@tensorflow/tfjs-core": "*",
     "@tigrisdata/vector": "^1.1.0",
     "@upstash/redis": "^1.20.6",
+    "@xata.io/client": "^0.25.1",
     "@zilliz/milvus2-sdk-node": ">=2.2.7",
     "apify-client": "^2.7.1",
     "axios": "*",
@@ -755,6 +757,9 @@
     "@upstash/redis": {
       "optional": true
     },
+    "@xata.io/client": {
+      "optional": true
+    },
     "@zilliz/milvus2-sdk-node": {
       "optional": true
     },
@@ -860,7 +865,6 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.5.7",
-    "@xata.io/client": "latest",
     "ansi-styles": "^5.0.0",
     "binary-extensions": "^2.2.0",
     "camelcase": "6",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -857,6 +857,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.5.7",
+    "@xata.io/client": "latest",
     "ansi-styles": "^5.0.0",
     "binary-extensions": "^2.2.0",
     "camelcase": "6",

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -83,6 +83,7 @@ const entrypoints = {
   "vectorstores/singlestore": "vectorstores/singlestore",
   "vectorstores/tigris": "vectorstores/tigris",
   "vectorstores/vectara": "vectorstores/vectara",
+  "vectorstores/xata": "vectorstores/xata",
   // text_splitter
   text_splitter: "text_splitter",
   // memory
@@ -191,7 +192,8 @@ const entrypoints = {
   "experimental/babyagi": "experimental/babyagi/index",
   "experimental/generative_agents": "experimental/generative_agents/index",
   "experimental/plan_and_execute": "experimental/plan_and_execute/index",
-  "experimental/multimodal_embeddings/googlevertexai": "experimental/multimodal_embeddings/googlevertexai",
+  "experimental/multimodal_embeddings/googlevertexai":
+    "experimental/multimodal_embeddings/googlevertexai",
   // evaluation
   evaluation: "evaluation/index",
 };

--- a/langchain/src/load/import_map.ts
+++ b/langchain/src/load/import_map.ts
@@ -18,6 +18,7 @@ export * as vectorstores__base from "../vectorstores/base.js";
 export * as vectorstores__memory from "../vectorstores/memory.js";
 export * as vectorstores__prisma from "../vectorstores/prisma.js";
 export * as vectorstores__vectara from "../vectorstores/vectara.js";
+export * as vectorstores__xata from "../vectorstores/xata.js";
 export * as text_splitter from "../text_splitter.js";
 export * as memory from "../memory/index.js";
 export * as document from "../document.js";

--- a/langchain/src/vectorstores/tests/xata.int.test.ts
+++ b/langchain/src/vectorstores/tests/xata.int.test.ts
@@ -6,7 +6,7 @@ import { XataVectorSearch } from "../xata.js";
 import { OpenAIEmbeddings } from "../../embeddings/openai.js";
 import { Document } from "../../document.js";
 
-test("XataVectorSearch integration", async () => {
+test.skip("XataVectorSearch integration", async () => {
   if (!process.env.XATA_API_KEY) {
     throw new Error("XATA_API_KEY not set");
   }
@@ -98,7 +98,7 @@ test("XataVectorSearch integration", async () => {
   expect(results5).toHaveLength(0);
 });
 
-test("Search a XataVectorSearch using a metadata filter", async () => {
+test.skip("Search a XataVectorSearch using a metadata filter", async () => {
   if (!process.env.XATA_API_KEY) {
     throw new Error("XATA_API_KEY not set");
   }

--- a/langchain/src/vectorstores/tests/xata.int.test.ts
+++ b/langchain/src/vectorstores/tests/xata.int.test.ts
@@ -1,0 +1,161 @@
+/* eslint-disable no-process-env */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { BaseClient } from "@xata.io/client";
+
+import { XataVectorSearch } from "../xata.js";
+import { OpenAIEmbeddings } from "../../embeddings/openai.js";
+import { Document } from "../../document.js";
+
+test("XataVectorSearch integration", async () => {
+  if (!process.env.XATA_API_KEY) {
+    throw new Error("XATA_API_KEY not set");
+  }
+
+  if (!process.env.XATA_DB_URL) {
+    throw new Error("XATA_DB_URL not set");
+  }
+  const xata = new BaseClient({
+    databaseURL: process.env.XATA_DB_URL,
+    apiKey: process.env.XATA_API_KEY,
+    branch: process.env.XATA_BRANCH || "main",
+  });
+
+  const table = "docs";
+  const embeddings = new OpenAIEmbeddings();
+
+  const store = new XataVectorSearch(embeddings, { client: xata, table });
+  expect(store).toBeDefined();
+
+  const createdAt = new Date().getTime();
+
+  const ids1 = await store.addDocuments([
+    { pageContent: "hello", metadata: { a: createdAt + 1 } },
+    { pageContent: "car", metadata: { a: createdAt } },
+    { pageContent: "adjective", metadata: { a: createdAt } },
+    { pageContent: "hi", metadata: { a: createdAt } },
+  ]);
+
+  let results1 = await store.similaritySearch("hello!", 1);
+
+  // search store is eventually consistent so we need to retry if nothing is
+  // returned
+  for (let i = 0; i < 5 && results1.length === 0; i += 1) {
+    results1 = await store.similaritySearch("hello!", 1);
+    // eslint-disable-next-line no-promise-executor-return
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  expect(results1).toHaveLength(1);
+  expect(results1).toEqual([
+    new Document({ metadata: { a: createdAt + 1 }, pageContent: "hello" }),
+  ]);
+
+  const results2 = await store.similaritySearchWithScore("testing!", 6, {
+    a: createdAt,
+  });
+  expect(results2).toHaveLength(3);
+
+  const ids2 = await store.addDocuments(
+    [
+      { pageContent: "hello upserted", metadata: { a: createdAt + 1 } },
+      { pageContent: "car upserted", metadata: { a: createdAt } },
+      { pageContent: "adjective upserted", metadata: { a: createdAt } },
+      { pageContent: "hi upserted", metadata: { a: createdAt } },
+    ],
+    { ids: ids1 }
+  );
+
+  expect(ids1).toEqual(ids2);
+
+  const results3 = await store.similaritySearchWithScore("testing!", 6, {
+    a: createdAt,
+  });
+
+  expect(results3).toHaveLength(3);
+
+  await store.delete({ ids: ids1.slice(2) });
+
+  let results4 = await store.similaritySearchWithScore("testing!", 3, {
+    a: createdAt,
+  });
+  for (let i = 0; i < 5 && results4.length > 1; i += 1) {
+    results4 = await store.similaritySearchWithScore("testing!", 3, {
+      a: createdAt,
+    });
+    // eslint-disable-next-line no-promise-executor-return
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  expect(results4).toHaveLength(1);
+
+  await store.delete({ ids: ids1 });
+  let results5 = await store.similaritySearch("hello!", 1);
+  for (let i = 0; i < 5 && results1.length > 0; i += 1) {
+    results5 = await store.similaritySearch("hello!", 1);
+    // eslint-disable-next-line no-promise-executor-return
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  expect(results5).toHaveLength(0);
+});
+
+test("Search a XataVectorSearch using a metadata filter", async () => {
+  if (!process.env.XATA_API_KEY) {
+    throw new Error("XATA_API_KEY not set");
+  }
+
+  if (!process.env.XATA_DB_URL) {
+    throw new Error("XATA_DB_URL not set");
+  }
+  const xata = new BaseClient({
+    databaseURL: process.env.XATA_DB_URL,
+    apiKey: process.env.XATA_API_KEY,
+    branch: process.env.XATA_BRANCH || "main",
+  });
+
+  const table = "docs";
+  const embeddings = new OpenAIEmbeddings();
+
+  const store = new XataVectorSearch(embeddings, { client: xata, table });
+  expect(store).toBeDefined();
+
+  const createdAt = new Date().getTime();
+
+  const ids = await store.addDocuments([
+    { pageContent: "hello 0", metadata: { a: createdAt } },
+    { pageContent: "hello 1", metadata: { a: createdAt + 1 } },
+    { pageContent: "hello 2", metadata: { a: createdAt + 2 } },
+    { pageContent: "hello 3", metadata: { a: createdAt + 3 } },
+  ]);
+
+  // search store is eventually consistent so we need to retry if nothing is
+  // returned
+  let results1 = await store.similaritySearch("hello!", 1);
+  for (let i = 0; i < 5 && results1.length < 4; i += 1) {
+    results1 = await store.similaritySearch("hello", 6);
+    // eslint-disable-next-line no-promise-executor-return
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  expect(results1).toHaveLength(4);
+
+  const results = await store.similaritySearch("hello", 1, {
+    a: createdAt + 2,
+  });
+  expect(results).toHaveLength(1);
+
+  expect(results).toEqual([
+    new Document({
+      metadata: { a: createdAt + 2 },
+      pageContent: "hello 2",
+    }),
+  ]);
+
+  await store.delete({ ids });
+  let results5 = await store.similaritySearch("hello!", 1);
+  for (let i = 0; i < 5 && results1.length > 0; i += 1) {
+    results5 = await store.similaritySearch("hello", 1);
+    // eslint-disable-next-line no-promise-executor-return
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  expect(results5).toHaveLength(0);
+});

--- a/langchain/src/vectorstores/xata.ts
+++ b/langchain/src/vectorstores/xata.ts
@@ -1,18 +1,19 @@
+import { BaseClient } from "@xata.io/client";
 import { VectorStore } from "./base.js";
 import { Embeddings } from "../embeddings/base.js";
 import { Document } from "../document.js";
 
-export interface XataClientArgs {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly client: any;
+export interface XataClientArgs<XataClient> {
+  readonly client: XataClient;
   readonly table: string;
 }
 
 type XataFilter = object;
 
-export class XataVectorSearch extends VectorStore {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private readonly client: any;
+export class XataVectorSearch<
+  XataClient extends BaseClient
+> extends VectorStore {
+  private readonly client: XataClient;
 
   private readonly table: string;
 
@@ -20,7 +21,7 @@ export class XataVectorSearch extends VectorStore {
     return "xata";
   }
 
-  constructor(embeddings: Embeddings, args: XataClientArgs) {
+  constructor(embeddings: Embeddings, args: XataClientArgs<XataClient>) {
     super(embeddings, args);
 
     this.client = args.client;
@@ -55,7 +56,8 @@ export class XataVectorSearch extends VectorStore {
       });
 
     const res = await this.client.db[this.table].createOrReplace(rows);
-    // XXX: clean this up
+    // Since we have an untyped BaseClient, it doesn't know the
+    // actual return type of the overload.
     const results = res as unknown as { id: string }[];
     const returnedIds = results.map((row) => row.id);
     return returnedIds;

--- a/langchain/src/vectorstores/xata.ts
+++ b/langchain/src/vectorstores/xata.ts
@@ -13,6 +13,8 @@ type XataFilter = object;
 export class XataVectorSearch<
   XataClient extends BaseClient
 > extends VectorStore {
+  declare FilterType: XataFilter;
+
   private readonly client: XataClient;
 
   private readonly table: string;

--- a/langchain/src/vectorstores/xata.ts
+++ b/langchain/src/vectorstores/xata.ts
@@ -1,0 +1,99 @@
+import type { BaseClient } from "@xata.io/client";
+import { VectorStore } from "./base.js";
+import { Embeddings } from "../embeddings/base.js";
+import { Document } from "../document.js";
+
+export interface XataClientArgs {
+  readonly client: BaseClient;
+  readonly table: string;
+}
+
+type XataFilter = object;
+
+export class XataVectorSearch extends VectorStore {
+  private readonly client: BaseClient;
+
+  private readonly table: string;
+
+  _vectorstoreType(): string {
+    return "xata";
+  }
+
+  constructor(embeddings: Embeddings, args: XataClientArgs) {
+    super(embeddings, args);
+
+    this.client = args.client;
+    this.table = args.table;
+  }
+
+  async addDocuments(documents: Document[], options?: { ids?: string[] }) {
+    const texts = documents.map(({ pageContent }) => pageContent);
+    return this.addVectors(
+      await this.embeddings.embedDocuments(texts),
+      documents,
+      options
+    );
+  }
+
+  async addVectors(
+    vectors: number[][],
+    documents: Document[],
+    options?: { ids?: string[] }
+  ) {
+    const rows = vectors
+      .map((embedding, idx) => ({
+        content: documents[idx].pageContent,
+        embedding,
+        ...documents[idx].metadata,
+      }))
+      .map((row, idx) => {
+        if (options?.ids) {
+          return { id: options.ids[idx], ...row };
+        }
+        return row;
+      });
+
+    const res = await this.client.db[this.table].createOrReplace(rows);
+    // XXX: clean this up
+    const results = res as unknown as { id: string }[];
+    const returnedIds = results.map((row) => row.id);
+    return returnedIds;
+  }
+
+  async delete(params: { ids: string[] }): Promise<void> {
+    const { ids } = params;
+    await this.client.db[this.table].delete(ids);
+  }
+
+  async similaritySearchVectorWithScore(
+    query: number[],
+    k: number,
+    filter?: XataFilter | undefined
+  ): Promise<[Document, number][]> {
+    const records = await this.client.db[this.table].vectorSearch(
+      "embedding",
+      query,
+      {
+        size: k,
+        filter,
+      }
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return records.map((record: any) => [
+      new Document({
+        pageContent: record.content,
+        metadata: Object.fromEntries(
+          Object.entries(record).filter(
+            ([key]) =>
+              key !== "content" &&
+              key !== "embedding" &&
+              key !== "xata" &&
+              key !== "id"
+          )
+        ),
+      }),
+      record.xata.score,
+    ]);
+  }
+}

--- a/langchain/src/vectorstores/xata.ts
+++ b/langchain/src/vectorstores/xata.ts
@@ -1,17 +1,18 @@
-import type { BaseClient } from "@xata.io/client";
 import { VectorStore } from "./base.js";
 import { Embeddings } from "../embeddings/base.js";
 import { Document } from "../document.js";
 
 export interface XataClientArgs {
-  readonly client: BaseClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly client: any;
   readonly table: string;
 }
 
 type XataFilter = object;
 
 export class XataVectorSearch extends VectorStore {
-  private readonly client: BaseClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly client: any;
 
   private readonly table: string;
 

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -96,6 +96,7 @@
       "src/vectorstores/singlestore.ts",
       "src/vectorstores/tigris.ts",
       "src/vectorstores/vectara.ts",
+      "src/vectorstores/xata.ts",
       "src/text_splitter.ts",
       "src/memory/index.ts",
       "src/memory/zep.ts",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@xata.io/client": "latest",
     "turbo": "latest"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@xata.io/client": "latest",
+    "@xata.io/client": "^0.25.1",
     "turbo": "latest"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@xata.io/client": "^0.25.1",
     "turbo": "latest"
   },
   "resolutions": {

--- a/test-exports-cf/src/entrypoints.js
+++ b/test-exports-cf/src/entrypoints.js
@@ -17,6 +17,7 @@ export * from "langchain/vectorstores/base";
 export * from "langchain/vectorstores/memory";
 export * from "langchain/vectorstores/prisma";
 export * from "langchain/vectorstores/vectara";
+export * from "langchain/vectorstores/xata";
 export * from "langchain/text_splitter";
 export * from "langchain/memory";
 export * from "langchain/document";

--- a/test-exports-cjs/src/entrypoints.js
+++ b/test-exports-cjs/src/entrypoints.js
@@ -17,6 +17,7 @@ const vectorstores_base = require("langchain/vectorstores/base");
 const vectorstores_memory = require("langchain/vectorstores/memory");
 const vectorstores_prisma = require("langchain/vectorstores/prisma");
 const vectorstores_vectara = require("langchain/vectorstores/vectara");
+const vectorstores_xata = require("langchain/vectorstores/xata");
 const text_splitter = require("langchain/text_splitter");
 const memory = require("langchain/memory");
 const document = require("langchain/document");

--- a/test-exports-esbuild/src/entrypoints.js
+++ b/test-exports-esbuild/src/entrypoints.js
@@ -17,6 +17,7 @@ import * as vectorstores_base from "langchain/vectorstores/base";
 import * as vectorstores_memory from "langchain/vectorstores/memory";
 import * as vectorstores_prisma from "langchain/vectorstores/prisma";
 import * as vectorstores_vectara from "langchain/vectorstores/vectara";
+import * as vectorstores_xata from "langchain/vectorstores/xata";
 import * as text_splitter from "langchain/text_splitter";
 import * as memory from "langchain/memory";
 import * as document from "langchain/document";

--- a/test-exports-esm/src/entrypoints.js
+++ b/test-exports-esm/src/entrypoints.js
@@ -17,6 +17,7 @@ import * as vectorstores_base from "langchain/vectorstores/base";
 import * as vectorstores_memory from "langchain/vectorstores/memory";
 import * as vectorstores_prisma from "langchain/vectorstores/prisma";
 import * as vectorstores_vectara from "langchain/vectorstores/vectara";
+import * as vectorstores_xata from "langchain/vectorstores/xata";
 import * as text_splitter from "langchain/text_splitter";
 import * as memory from "langchain/memory";
 import * as document from "langchain/document";

--- a/test-exports-vercel/src/entrypoints.js
+++ b/test-exports-vercel/src/entrypoints.js
@@ -17,6 +17,7 @@ export * from "langchain/vectorstores/base";
 export * from "langchain/vectorstores/memory";
 export * from "langchain/vectorstores/prisma";
 export * from "langchain/vectorstores/vectara";
+export * from "langchain/vectorstores/xata";
 export * from "langchain/text_splitter";
 export * from "langchain/memory";
 export * from "langchain/document";

--- a/test-exports-vite/src/entrypoints.js
+++ b/test-exports-vite/src/entrypoints.js
@@ -17,6 +17,7 @@ export * from "langchain/vectorstores/base";
 export * from "langchain/vectorstores/memory";
 export * from "langchain/vectorstores/prisma";
 export * from "langchain/vectorstores/vectara";
+export * from "langchain/vectorstores/xata";
 export * from "langchain/text_splitter";
 export * from "langchain/memory";
 export * from "langchain/document";

--- a/yarn.lock
+++ b/yarn.lock
@@ -6663,6 +6663,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xata.io/client@npm:^0.25.1":
+  version: 0.25.1
+  resolution: "@xata.io/client@npm:0.25.1"
+  peerDependencies:
+    typescript: ">=4.5"
+  checksum: 041988667b19e84a4af27b8abb6c3ca79904df595a687e4a8cd19ce0c1e3d180781fb2e54ba55de2217893f76b05048cffa99d171034f9a4229d694904d43bcd
+  languageName: node
+  linkType: hard
+
 "@xata.io/client@npm:latest":
   version: 0.24.3
   resolution: "@xata.io/client@npm:0.24.3"
@@ -9939,6 +9948,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.51.0
     "@typescript-eslint/parser": ^5.51.0
     "@upstash/redis": ^1.20.6
+    "@xata.io/client": ^0.25.1
     "@zilliz/milvus2-sdk-node": ^2.2.7
     axios: ^0.26.0
     chromadb: ^1.4.0
@@ -13279,7 +13289,7 @@ __metadata:
   dependencies:
     "@tsconfig/recommended": ^1.0.2
     "@types/jest": ^29.5.3
-    "@xata.io/client": latest
+    "@xata.io/client": ^0.25.1
     dotenv: ^16.0.3
     husky: ^8.0.0
     lint-staged: ^13.1.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -6663,6 +6663,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xata.io/client@npm:latest":
+  version: 0.24.3
+  resolution: "@xata.io/client@npm:0.24.3"
+  peerDependencies:
+    typescript: ">=4.5"
+  checksum: 5750dc6f0d81891878212238280d6d037d12a1f56e18ae5ba108524ab833f6fd19dbb76a7f57d473e130e95776063d0fa529b7cbbd3fc13e175a36f0c512320c
+  languageName: node
+  linkType: hard
+
 "@zilliz/milvus2-sdk-node@npm:>=2.2.7, @zilliz/milvus2-sdk-node@npm:^2.2.7":
   version: 2.2.10
   resolution: "@zilliz/milvus2-sdk-node@npm:2.2.10"
@@ -13006,6 +13015,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.58.0
     "@typescript-eslint/parser": ^5.58.0
     "@upstash/redis": ^1.20.6
+    "@xata.io/client": latest
     "@zilliz/milvus2-sdk-node": ">=2.2.7"
     ansi-styles: ^5.0.0
     apify-client: ^2.7.1
@@ -13269,6 +13279,7 @@ __metadata:
   dependencies:
     "@tsconfig/recommended": ^1.0.2
     "@types/jest": ^29.5.3
+    "@xata.io/client": latest
     dotenv: ^16.0.3
     husky: ^8.0.0
     lint-staged: ^13.1.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -6672,15 +6672,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xata.io/client@npm:latest":
-  version: 0.24.3
-  resolution: "@xata.io/client@npm:0.24.3"
-  peerDependencies:
-    typescript: ">=4.5"
-  checksum: 5750dc6f0d81891878212238280d6d037d12a1f56e18ae5ba108524ab833f6fd19dbb76a7f57d473e130e95776063d0fa529b7cbbd3fc13e175a36f0c512320c
-  languageName: node
-  linkType: hard
-
 "@zilliz/milvus2-sdk-node@npm:>=2.2.7, @zilliz/milvus2-sdk-node@npm:^2.2.7":
   version: 2.2.10
   resolution: "@zilliz/milvus2-sdk-node@npm:2.2.10"
@@ -13025,7 +13016,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.58.0
     "@typescript-eslint/parser": ^5.58.0
     "@upstash/redis": ^1.20.6
-    "@xata.io/client": latest
+    "@xata.io/client": ^0.25.1
     "@zilliz/milvus2-sdk-node": ">=2.2.7"
     ansi-styles: ^5.0.0
     apify-client: ^2.7.1
@@ -13125,6 +13116,7 @@ __metadata:
     "@tensorflow/tfjs-core": "*"
     "@tigrisdata/vector": ^1.1.0
     "@upstash/redis": ^1.20.6
+    "@xata.io/client": ^0.25.1
     "@zilliz/milvus2-sdk-node": ">=2.2.7"
     apify-client: ^2.7.1
     axios: "*"
@@ -13211,6 +13203,8 @@ __metadata:
     "@tigrisdata/vector":
       optional: true
     "@upstash/redis":
+      optional: true
+    "@xata.io/client":
       optional: true
     "@zilliz/milvus2-sdk-node":
       optional: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -13283,7 +13283,6 @@ __metadata:
   dependencies:
     "@tsconfig/recommended": ^1.0.2
     "@types/jest": ^29.5.3
-    "@xata.io/client": ^0.25.1
     dotenv: ^16.0.3
     husky: ^8.0.0
     lint-staged: ^13.1.1


### PR DESCRIPTION
This adds supports for [Xata](https://xata.io) (serverless data platform based on Postgres) as a vector store. There were a [couple](https://github.com/hwchase17/langchainjs/pull/967) of [attempts](https://github.com/hwchase17/langchainjs/pull/543) from the community to add Xata as a vector store, but they stopped short of adding sample code and docs. This PR includes sample code and docs and it's coming from us at Xata so we'll make sure to keep it maintained.

Opening in draft mode for now because I'd like a colleague (@SferaDev) to have a look at the types used. But the PR is otherwise functional and any feedback would be appreciated already.

### To run the integration tests

You will need to create a DB in xata (see the docs), then run something like:

```
OPENAI_API_KEY=sk-... XATA_API_KEY=xau_...  XATA_DB_URL='https://...'  yarn test:single './langchain/src/vectorstores/tests/xata.int.test.ts'
```

### To run the examples:

Follow the docs instructions, and run:

```
OPENAI_API_KEY=sk-... XATA_API_KEY=xau_...  XATA_DB_URL='https://...'  yarn example ./examples/src/indexes/vector_stores/xata.ts
```

```
OPENAI_API_KEY=sk-... XATA_API_KEY=xau_...  XATA_DB_URL='https://...'  yarn example ./examples/src/indexes/vector_stores/xata_metadata.ts
```


