### PR TITLE
Broader Runnable support, compositional pieces

### DIFF
--- a/docs/extras/guides/_category_.yml
+++ b/docs/extras/guides/_category_.yml
@@ -1,0 +1,2 @@
+label: 'Guides'
+position: 3

--- a/docs/extras/guides/expression_language/_category_.yml
+++ b/docs/extras/guides/expression_language/_category_.yml
@@ -1,0 +1,2 @@
+label: 'LangChain Expression Language'
+position: 1

--- a/docs/extras/guides/expression_language/cookbook.mdx
+++ b/docs/extras/guides/expression_language/cookbook.mdx
@@ -1,0 +1,63 @@
+import CodeBlock from "@theme/CodeBlock";
+
+# Cookbook
+
+In this guide, we'll take a look at a few common types of sequences you can create.
+
+## PromptTemplate + LLM
+
+A PromptTemplate -> LLM is a core chain that is used in most other larger chains/systems.
+
+import BasicExample from "@examples/guides/expression_language/cookbook_basic.ts";
+
+<CodeBlock language="typescript">{BasicExample}</CodeBlock>
+
+## PromptTemplate + LLM + OutputParser
+
+We can also add in an output parser to easily trasform the raw LLM/ChatModel output into a consistent string format:
+
+import OutputParserExample from "@examples/guides/expression_language/cookbook_output_parser.ts";
+
+<CodeBlock language="typescript">{OutputParserExample}</CodeBlock>
+
+## Passthroughs
+
+Often times when constructing a chain you may want to pass along original input variables to future steps in the chain. How exactly you do this depends on what exactly the input is:
+
+- If the original input was a string, then you likely just want to pass along the string. This can be done with `RunnablePassthrough`. For an example of this, see `LLMChain + Retriever`
+- If the original input was an object, then you likely want to pass along specific keys. For this, you can use an arrow function that takes the object as input and extracts the desired key. For an example of this see the `Mapping multiple input keys` example below
+
+## LLMChain + Retriever
+
+Let's now look at adding in a retrieval step, which adds up to a "retrieval-augmented generation" chain:
+
+import RetrieverExample from "@examples/guides/expression_language/cookbook_retriever.ts";
+
+<CodeBlock language="typescript">{RetrieverExample}</CodeBlock>
+
+## Mapping multiple input keys
+
+In the above example, we pass a string input directly into our chain. If we want our chain to take multiple inputs, we can pass a map of functions to parse the inputs:
+
+import RetrieverMapExample from "@examples/guides/expression_language/cookbook_retriever_map.ts";
+
+<CodeBlock language="typescript">{RetrieverMapExample}</CodeBlock>
+
+## Conversational Retrieval Chain
+
+Because `RunnableSequence.from` and `runnable.pipe` both accept runnable-like objects, including single-argument functions, we can add in conversation history via a formatting function.
+This allows us to recreate the popular `ConversationalRetrievalQAChain` to "chat with data":
+
+import ConversationalRetrievalExample from "@examples/guides/expression_language/cookbook_conversational_retrieval.ts";
+
+<CodeBlock language="typescript">{ConversationalRetrievalExample}</CodeBlock>
+
+Note that the individual chains we created are themselves `Runnables` and can therefore be piped into each other.
+
+## Tools
+
+You can use LangChain tools as well:
+
+import ToolExample from "@examples/guides/expression_language/cookbook_tools.ts";
+
+<CodeBlock language="typescript">{ToolExample}</CodeBlock>

--- a/docs/extras/guides/expression_language/interface.mdx
+++ b/docs/extras/guides/expression_language/interface.mdx
@@ -13,6 +13,13 @@ The type of the input varies by component. For a prompt it is an object, for a r
 
 The output type also varies by component. For an LLM it is a string, for a ChatModel it's a ChatMessage, for a prompt it's a PromptValue, and for a retriever it's a list of documents.
 
+You can combine runnables (and runnable-like objects such as functions and objects whose values are all functions) into sequences in two ways:
+
+- Call the `.pipe` instance method, which takes another runnable-like as an argument
+- Use the `RunnableSequence.from([])` static method with an array of runnable-likes, which will run in sequence when invoked
+
+See below for examples of how this looks.
+
 ## Stream
 
 import StreamExample from "@examples/guides/expression_language/interface_stream.ts";

--- a/docs/extras/guides/expression_language/interface.mdx
+++ b/docs/extras/guides/expression_language/interface.mdx
@@ -1,0 +1,32 @@
+import CodeBlock from "@theme/CodeBlock";
+
+# Interface
+
+In an effort to make it as easy as possible to create custom chains, we've implemented a ["Runnable"](/docs/api/schema_runnable/classes/Runnable) protocol that most components implement.
+This is a standard interface with a few different methods, which make it easy to define custom chains as well as making it possible to invoke them in a standard way. The standard interface exposed includes:
+
+- `stream`: stream back chunks of the response
+- `invoke`: call the chain on an input
+- `batch`: call the chain on a list of inputs
+
+The type of the input varies by component. For a prompt it is an object, for a retriever it is a single string, for a model either a single string, a list of chat messages, or a PromptValue.
+
+The output type also varies by component. For an LLM it is a string, for a ChatModel it's a ChatMessage, for a prompt it's a PromptValue, and for a retriever it's a list of documents.
+
+## Stream
+
+import StreamExample from "@examples/guides/expression_language/interface_stream.ts";
+
+<CodeBlock language="typescript">{StreamExample}</CodeBlock>
+
+## Invoke
+
+import InvokeExample from "@examples/guides/expression_language/interface_invoke.ts";
+
+<CodeBlock language="typescript">{InvokeExample}</CodeBlock>
+
+## Batch
+
+import BatchExample from "@examples/guides/expression_language/interface_batch.ts";
+
+<CodeBlock language="typescript">{BatchExample}</CodeBlock>

--- a/examples/src/guides/expression_language/cookbook_basic.ts
+++ b/examples/src/guides/expression_language/cookbook_basic.ts
@@ -1,18 +1,17 @@
 import { PromptTemplate } from "langchain/prompts";
 import { ChatOpenAI } from "langchain/chat_models/openai";
-import { RunnableSequence } from "langchain/schema/runnable";
 
 const model = new ChatOpenAI({});
 const promptTemplate = PromptTemplate.fromTemplate(
   "Tell me a joke about {topic}"
 );
 
-// You can also create a chain using an array of runnables
-const chain = RunnableSequence.from([promptTemplate, model]);
+const chain = promptTemplate.pipe(model);
 
 const result = await chain.invoke({ topic: "bears" });
 
 console.log(result);
+
 /*
   AIMessage {
     content: "Why don't bears wear shoes?\n\nBecause they have bear feet!",

--- a/examples/src/guides/expression_language/cookbook_conversational_retrieval.ts
+++ b/examples/src/guides/expression_language/cookbook_conversational_retrieval.ts
@@ -1,0 +1,102 @@
+import { PromptTemplate } from "langchain/prompts";
+import {
+  RunnableSequence,
+  RunnablePassthrough,
+} from "langchain/schema/runnable";
+import { Document } from "langchain/document";
+import { ChatOpenAI } from "langchain/chat_models/openai";
+import { HNSWLib } from "langchain/vectorstores/hnswlib";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { StringOutputParser } from "langchain/schema/output_parser";
+
+const model = new ChatOpenAI({});
+
+const condenseQuestionTemplate = `Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question, in its original language.
+
+Chat History:
+{chat_history}
+Follow Up Input: {question}
+Standalone question:`;
+const CONDENSE_QUESTION_PROMPT = PromptTemplate.fromTemplate(
+  condenseQuestionTemplate
+);
+
+const answerTemplate = `Answer the question based only on the following context:
+{context}
+
+Question: {question}
+`;
+const ANSWER_PROMPT = PromptTemplate.fromTemplate(answerTemplate);
+
+const combineDocumentsFn = (docs: Document[], separator = "\n\n") => {
+  const serializedDocs = docs.map((doc) => doc.pageContent);
+  return serializedDocs.join(separator);
+};
+
+const formatChatHistory = (chatHistory: [string, string][]) => {
+  const formattedDialogueTurns = chatHistory.map(
+    (dialogueTurn) => `Human: ${dialogueTurn[0]}\nAssistant: ${dialogueTurn[1]}`
+  );
+  return formattedDialogueTurns.join("\n");
+};
+
+const vectorStore = await HNSWLib.fromTexts(
+  [
+    "mitochondria is the powerhouse of the cell",
+    "mitochondria is made of lipids",
+  ],
+  [{ id: 1 }, { id: 2 }],
+  new OpenAIEmbeddings()
+);
+const retriever = vectorStore.asRetriever();
+
+type ConversationalRetrievalQAChainInput = {
+  question: string;
+  chat_history: [string, string][];
+};
+
+const standaloneQuestionChain = RunnableSequence.from([
+  {
+    question: (input: ConversationalRetrievalQAChainInput) => input.question,
+    chat_history: (input: ConversationalRetrievalQAChainInput) =>
+      formatChatHistory(input.chat_history),
+  },
+  CONDENSE_QUESTION_PROMPT,
+  model,
+  new StringOutputParser(),
+]);
+
+const answerChain = RunnableSequence.from([
+  {
+    context: retriever.pipe(combineDocumentsFn),
+    question: new RunnablePassthrough(),
+  },
+  ANSWER_PROMPT,
+  model,
+]);
+
+const conversationalRetrievalQAChain =
+  standaloneQuestionChain.pipe(answerChain);
+
+const result1 = await conversationalRetrievalQAChain.invoke({
+  question: "What is the powerhouse of the cell?",
+  chat_history: [],
+});
+console.log(result1);
+/*
+  AIMessage { content: "The powerhouse of the cell is the mitochondria." }
+*/
+
+const result2 = await conversationalRetrievalQAChain.invoke({
+  question: "What are they made out of?",
+  chat_history: [
+    [
+      "What is the powerhouse of the cell?",
+      "The powerhouse of the cell is the mitochondria.",
+    ],
+  ],
+});
+console.log(result2);
+/*
+  AIMessage { content: "Mitochondria are made out of lipids." }
+*/

--- a/examples/src/guides/expression_language/cookbook_output_parser.ts
+++ b/examples/src/guides/expression_language/cookbook_output_parser.ts
@@ -1,20 +1,20 @@
 import { PromptTemplate } from "langchain/prompts";
 import { ChatOpenAI } from "langchain/chat_models/openai";
 import { RunnableSequence } from "langchain/schema/runnable";
+import { StringOutputParser } from "langchain/schema/output_parser";
 
 const model = new ChatOpenAI({});
 const promptTemplate = PromptTemplate.fromTemplate(
   "Tell me a joke about {topic}"
 );
+const outputParser = new StringOutputParser();
 
-// You can also create a chain using an array of runnables
-const chain = RunnableSequence.from([promptTemplate, model]);
+const chain = RunnableSequence.from([promptTemplate, model, outputParser]);
 
 const result = await chain.invoke({ topic: "bears" });
 
 console.log(result);
+
 /*
-  AIMessage {
-    content: "Why don't bears wear shoes?\n\nBecause they have bear feet!",
-  }
+  "Why don't bears wear shoes?\n\nBecause they have bear feet!"
 */

--- a/examples/src/guides/expression_language/cookbook_retriever.ts
+++ b/examples/src/guides/expression_language/cookbook_retriever.ts
@@ -1,0 +1,46 @@
+import { ChatOpenAI } from "langchain/chat_models/openai";
+import { HNSWLib } from "langchain/vectorstores/hnswlib";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { PromptTemplate } from "langchain/prompts";
+import {
+  RunnableSequence,
+  RunnablePassthrough,
+} from "langchain/schema/runnable";
+import { StringOutputParser } from "langchain/schema/output_parser";
+import { Document } from "langchain/document";
+
+const model = new ChatOpenAI({});
+
+const vectorStore = await HNSWLib.fromTexts(
+  ["mitochondria is the powerhouse of the cell"],
+  [{ id: 1 }],
+  new OpenAIEmbeddings()
+);
+const retriever = vectorStore.asRetriever();
+
+const prompt =
+  PromptTemplate.fromTemplate(`Answer the question based only on the following context:
+{context}
+
+Question: {question}`);
+
+const serializeDocs = (docs: Document[]) =>
+  docs.map((doc) => doc.pageContent).join("\n");
+
+const chain = RunnableSequence.from([
+  {
+    context: retriever.pipe(serializeDocs),
+    question: new RunnablePassthrough(),
+  },
+  prompt,
+  model,
+  new StringOutputParser(),
+]);
+
+const result = await chain.invoke("What is the powerhouse of the cell?");
+
+console.log(result);
+
+/*
+  "The powerhouse of the cell is the mitochondria."
+*/

--- a/examples/src/guides/expression_language/cookbook_retriever_map.ts
+++ b/examples/src/guides/expression_language/cookbook_retriever_map.ts
@@ -1,0 +1,55 @@
+import { ChatOpenAI } from "langchain/chat_models/openai";
+import { HNSWLib } from "langchain/vectorstores/hnswlib";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { PromptTemplate } from "langchain/prompts";
+import { RunnableSequence } from "langchain/schema/runnable";
+import { StringOutputParser } from "langchain/schema/output_parser";
+import { Document } from "langchain/document";
+
+const model = new ChatOpenAI({});
+
+const vectorStore = await HNSWLib.fromTexts(
+  ["mitochondria is the powerhouse of the cell"],
+  [{ id: 1 }],
+  new OpenAIEmbeddings()
+);
+const retriever = vectorStore.asRetriever();
+
+const languagePrompt =
+  PromptTemplate.fromTemplate(`Answer the question based only on the following context:
+{context}
+
+Question: {question}
+
+Answer in the following language: {language}`);
+
+type LanguageChainInput = {
+  question: string;
+  language: string;
+};
+
+const serializeDocs = (docs: Document[]) =>
+  docs.map((doc) => doc.pageContent).join("\n");
+
+const languageChain = RunnableSequence.from([
+  {
+    question: (input: LanguageChainInput) => input.question,
+    language: (input: LanguageChainInput) => input.language,
+    context: (input: LanguageChainInput) =>
+      retriever.pipe(serializeDocs).invoke(input.question),
+  },
+  languagePrompt,
+  model,
+  new StringOutputParser(),
+]);
+
+const result2 = await languageChain.invoke({
+  question: "What is the powerhouse of the cell?",
+  language: "German",
+});
+
+console.log(result2);
+
+/*
+  "Mitochondrien sind das Kraftwerk der Zelle."
+*/

--- a/examples/src/guides/expression_language/cookbook_tools.ts
+++ b/examples/src/guides/expression_language/cookbook_tools.ts
@@ -1,0 +1,24 @@
+import { SerpAPI } from "langchain/tools";
+import { ChatOpenAI } from "langchain/chat_models/openai";
+import { PromptTemplate } from "langchain/prompts";
+import { StringOutputParser } from "langchain/schema/output_parser";
+
+const search = new SerpAPI();
+
+const prompt =
+  PromptTemplate.fromTemplate(`Turn the following user input into a search query for a search engine:
+
+{input}`);
+
+const model = new ChatOpenAI({});
+
+const chain = prompt.pipe(model).pipe(new StringOutputParser()).pipe(search);
+
+const result = await chain.invoke({
+  input: "Who is the current prime minister of Malaysia?",
+});
+
+console.log(result);
+/*
+  Anwar Ibrahim
+*/

--- a/examples/src/guides/expression_language/interface_batch.ts
+++ b/examples/src/guides/expression_language/interface_batch.ts
@@ -1,0 +1,23 @@
+import { PromptTemplate } from "langchain/prompts";
+import { ChatOpenAI } from "langchain/chat_models/openai";
+
+const model = new ChatOpenAI({});
+const promptTemplate = PromptTemplate.fromTemplate(
+  "Tell me a joke about {topic}"
+);
+
+const chain = promptTemplate.pipe(model);
+
+const result = await chain.batch([{ topic: "bears" }, { topic: "cats" }]);
+
+console.log(result);
+/*
+  [
+    AIMessage {
+      content: "Why don't bears wear shoes?\n\nBecause they have bear feet!",
+    },
+    AIMessage {
+      content: "Why don't cats play poker in the wild?\n\nToo many cheetahs!"
+    }
+  ]
+*/

--- a/examples/src/guides/expression_language/interface_invoke.ts
+++ b/examples/src/guides/expression_language/interface_invoke.ts
@@ -1,0 +1,18 @@
+import { PromptTemplate } from "langchain/prompts";
+import { ChatOpenAI } from "langchain/chat_models/openai";
+
+const model = new ChatOpenAI({});
+const promptTemplate = PromptTemplate.fromTemplate(
+  "Tell me a joke about {topic}"
+);
+
+const chain = promptTemplate.pipe(model);
+
+const result = await chain.invoke({ topic: "bears" });
+
+console.log(result);
+/*
+  AIMessage {
+    content: "Why don't bears wear shoes?\n\nBecause they have bear feet!",
+  }
+*/

--- a/examples/src/guides/expression_language/interface_stream.ts
+++ b/examples/src/guides/expression_language/interface_stream.ts
@@ -1,0 +1,22 @@
+import { PromptTemplate } from "langchain/prompts";
+import { ChatOpenAI } from "langchain/chat_models/openai";
+
+const model = new ChatOpenAI({});
+const promptTemplate = PromptTemplate.fromTemplate(
+  "Tell me a joke about {topic}"
+);
+
+const chain = promptTemplate.pipe(model);
+
+const stream = await chain.stream({ topic: "bears" });
+
+// Each chunk has the same interface as a chat message
+for await (const chunk of stream) {
+  console.log(chunk?.content);
+}
+
+/*
+Why don't bears wear shoes?
+
+Because they have bear feet!
+*/

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -343,6 +343,9 @@ schema/query_constructor.d.ts
 schema/retriever.cjs
 schema/retriever.js
 schema/retriever.d.ts
+schema/runnable.cjs
+schema/runnable.js
+schema/runnable.d.ts
 sql_db.cjs
 sql_db.js
 sql_db.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -880,7 +880,7 @@
     "js-tiktoken": "^1.0.7",
     "js-yaml": "^4.1.0",
     "jsonpointer": "^5.0.1",
-    "langsmith": "~0.0.11",
+    "langsmith": "~0.0.16",
     "ml-distance": "^4.0.0",
     "object-hash": "^3.0.0",
     "openai": "^3.3.0",

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -355,6 +355,9 @@
     "schema/retriever.cjs",
     "schema/retriever.js",
     "schema/retriever.d.ts",
+    "schema/runnable.cjs",
+    "schema/runnable.js",
+    "schema/runnable.d.ts",
     "sql_db.cjs",
     "sql_db.js",
     "sql_db.d.ts",
@@ -1496,6 +1499,11 @@
       "types": "./schema/retriever.d.ts",
       "import": "./schema/retriever.js",
       "require": "./schema/retriever.cjs"
+    },
+    "./schema/runnable": {
+      "types": "./schema/runnable.d.ts",
+      "import": "./schema/runnable.js",
+      "require": "./schema/runnable.cjs"
     },
     "./sql_db": {
       "types": "./sql_db.d.ts",

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -141,6 +141,7 @@ const entrypoints = {
   "schema/output_parser": "schema/output_parser",
   "schema/query_constructor": "schema/query_constructor",
   "schema/retriever": "schema/retriever",
+  "schema/runnable": "schema/runnable",
   // sql_db
   sql_db: "sql_db",
   // callbacks

--- a/langchain/src/base_language/index.ts
+++ b/langchain/src/base_language/index.ts
@@ -32,10 +32,10 @@ export interface BaseLangChainParams {
  */
 export abstract class BaseLangChain<
     RunInput,
-    CallOptions extends RunnableConfig,
-    RunOutput
+    RunOutput,
+    CallOptions extends RunnableConfig = RunnableConfig
   >
-  extends Runnable<RunInput, CallOptions, RunOutput>
+  extends Runnable<RunInput, RunOutput, CallOptions>
   implements BaseLangChainParams
 {
   /**
@@ -105,11 +105,11 @@ export type BaseLanguageModelInput = BasePromptValue | string | BaseMessage[];
  * Base class for language models.
  */
 export abstract class BaseLanguageModel<
-    CallOptions extends BaseLanguageModelCallOptions = BaseLanguageModelCallOptions,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    RunOutput = any
+    RunOutput = any,
+    CallOptions extends BaseLanguageModelCallOptions = BaseLanguageModelCallOptions
   >
-  extends BaseLangChain<BaseLanguageModelInput, CallOptions, RunOutput>
+  extends BaseLangChain<BaseLanguageModelInput, RunOutput, CallOptions>
   implements BaseLanguageModelParams
 {
   declare CallOptions: CallOptions;

--- a/langchain/src/callbacks/base.ts
+++ b/langchain/src/callbacks/base.ts
@@ -105,7 +105,8 @@ abstract class BaseCallbackHandlerMethodsClass {
     runId: string,
     parentRunId?: string,
     tags?: string[],
-    metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>,
+    runType?: string
   ): Promise<void> | void;
 
   /**

--- a/langchain/src/callbacks/handlers/tracer.ts
+++ b/langchain/src/callbacks/handlers/tracer.ts
@@ -15,7 +15,7 @@ import {
 } from "../base.js";
 import { Document } from "../../document.js";
 
-export type RunType = "llm" | "chain" | "tool";
+export type RunType = string;
 
 export interface Run extends BaseRun {
   // some optional fields are always present here
@@ -201,7 +201,8 @@ export abstract class BaseTracer extends BaseCallbackHandler {
     runId: string,
     parentRunId?: string,
     tags?: string[],
-    metadata?: KVMap
+    metadata?: KVMap,
+    runType?: string
   ): Promise<void> {
     const execution_order = this._getExecutionOrder(parentRunId);
     const start_time = Date.now();
@@ -220,7 +221,7 @@ export abstract class BaseTracer extends BaseCallbackHandler {
       inputs,
       execution_order,
       child_execution_order: execution_order,
-      run_type: "chain",
+      run_type: runType ?? "chain",
       child_runs: [],
       extra: metadata ? { metadata } : {},
       tags: tags || [],
@@ -232,7 +233,7 @@ export abstract class BaseTracer extends BaseCallbackHandler {
 
   async handleChainEnd(outputs: ChainValues, runId: string): Promise<void> {
     const run = this.runMap.get(runId);
-    if (!run || run?.run_type !== "chain") {
+    if (!run) {
       throw new Error("No chain run to end.");
     }
     run.end_time = Date.now();
@@ -247,7 +248,7 @@ export abstract class BaseTracer extends BaseCallbackHandler {
 
   async handleChainError(error: Error, runId: string): Promise<void> {
     const run = this.runMap.get(runId);
-    if (!run || run?.run_type !== "chain") {
+    if (!run) {
       throw new Error("No chain run to end.");
     }
     run.end_time = Date.now();

--- a/langchain/src/callbacks/manager.ts
+++ b/langchain/src/callbacks/manager.ts
@@ -573,7 +573,8 @@ export class CallbackManager
   async handleChainStart(
     chain: Serialized,
     inputs: ChainValues,
-    runId = uuidv4()
+    runId = uuidv4(),
+    runType: string | undefined = undefined
   ): Promise<CallbackManagerForChainRun> {
     await Promise.all(
       this.handlers.map((handler) =>
@@ -586,7 +587,8 @@ export class CallbackManager
                 runId,
                 this._parentRunId,
                 this.tags,
-                this.metadata
+                this.metadata,
+                runType
               );
             } catch (err) {
               console.error(

--- a/langchain/src/chains/base.ts
+++ b/langchain/src/chains/base.ts
@@ -29,7 +29,7 @@ export abstract class BaseChain<
     RunInput extends ChainValues = ChainValues,
     RunOutput extends ChainValues = ChainValues
   >
-  extends BaseLangChain<RunInput, RunnableConfig, RunOutput>
+  extends BaseLangChain<RunInput, RunOutput>
   implements ChainInputs
 {
   declare memory?: BaseMemory;

--- a/langchain/src/chat_models/tests/chatopenai.int.test.ts
+++ b/langchain/src/chat_models/tests/chatopenai.int.test.ts
@@ -433,7 +433,7 @@ test("Function calling with streaming", async () => {
     chunks.push(chunk);
     if (!streamedOutput) {
       streamedOutput = chunk;
-    } else {
+    } else if (chunk) {
       streamedOutput = streamedOutput.concat(chunk);
     }
   }

--- a/langchain/src/llms/base.ts
+++ b/langchain/src/llms/base.ts
@@ -45,7 +45,7 @@ export interface BaseLLMCallOptions extends BaseLanguageModelCallOptions {}
  */
 export abstract class BaseLLM<
   CallOptions extends BaseLLMCallOptions = BaseLLMCallOptions
-> extends BaseLanguageModel<CallOptions, string> {
+> extends BaseLanguageModel<string, CallOptions> {
   declare ParsedCallOptions: Omit<
     CallOptions,
     keyof RunnableConfig & "timeout"
@@ -89,7 +89,7 @@ export abstract class BaseLLM<
   }
 
   protected _separateRunnableConfigFromCallOptions(
-    options: CallOptions
+    options?: Partial<CallOptions>
   ): [RunnableConfig, this["ParsedCallOptions"]] {
     const [runnableConfig, callOptions] =
       super._separateRunnableConfigFromCallOptions(options);
@@ -111,9 +111,7 @@ export abstract class BaseLLM<
     } else {
       const prompt = BaseLLM._convertInputToPromptValue(input);
       const [runnableConfig, callOptions] =
-        this._separateRunnableConfigFromCallOptions(
-          (options ?? {}) as CallOptions
-        );
+        this._separateRunnableConfigFromCallOptions(options);
       const callbackManager_ = await CallbackManager.configure(
         runnableConfig.callbacks,
         this.callbacks,
@@ -288,11 +286,11 @@ export abstract class BaseLLM<
       throw new Error("Argument 'prompts' is expected to be a string[]");
     }
 
-    let parsedOptions: CallOptions;
+    let parsedOptions: CallOptions | undefined;
     if (Array.isArray(options)) {
       parsedOptions = { stop: options } as CallOptions;
     } else {
-      parsedOptions = options ?? ({} as CallOptions);
+      parsedOptions = options;
     }
 
     const [runnableConfig, callOptions] =

--- a/langchain/src/load/import_map.ts
+++ b/langchain/src/load/import_map.ts
@@ -33,6 +33,7 @@ export * as schema from "../schema/index.js";
 export * as schema__output_parser from "../schema/output_parser.js";
 export * as schema__query_constructor from "../schema/query_constructor.js";
 export * as schema__retriever from "../schema/retriever.js";
+export * as schema__runnable from "../schema/runnable.js";
 export * as callbacks from "../callbacks/index.js";
 export * as output_parsers from "../output_parsers/index.js";
 export * as retrievers__remote from "../retrievers/remote/index.js";

--- a/langchain/src/load/import_type.d.ts
+++ b/langchain/src/load/import_type.d.ts
@@ -338,7 +338,7 @@ export interface SecretMap {
   REDIS_URL?: string;
   REDIS_USERNAME?: string;
   REMOTE_RETRIEVER_AUTH_BEARER?: string;
-  REPLICATE_API_KEY?: string;
+  REPLICATE_API_TOKEN?: string;
   SEARXNG_API_BASE?: string;
   UPSTASH_REDIS_REST_TOKEN?: string;
   UPSTASH_REDIS_REST_URL?: string;

--- a/langchain/src/output_parsers/noop.ts
+++ b/langchain/src/output_parsers/noop.ts
@@ -1,15 +1,4 @@
-import { BaseOutputParser } from "../schema/output_parser.js";
+import { StringOutputParser } from "../schema/output_parser.js";
 
-export class NoOpOutputParser extends BaseOutputParser<string> {
-  lc_namespace = ["langchain", "output_parsers", "default"];
-
-  lc_serializable = true;
-
-  parse(text: string): Promise<string> {
-    return Promise.resolve(text);
-  }
-
-  getFormatInstructions(): string {
-    return "";
-  }
-}
+/** @deprecated Use StringOutputParser instead */
+export class NoOpOutputParser extends StringOutputParser {}

--- a/langchain/src/prompts/base.ts
+++ b/langchain/src/prompts/base.ts
@@ -115,7 +115,7 @@ export abstract class BasePromptTemplate<
     return this._callWithConfig(
       (input: InputValues) => this.formatPromptValue(input),
       input,
-      options
+      { ...options, runType: "prompt" }
     );
   }
 

--- a/langchain/src/prompts/base.ts
+++ b/langchain/src/prompts/base.ts
@@ -108,7 +108,7 @@ export abstract class BasePromptTemplate<
     return allKwargs;
   }
 
-  invoke(
+  async invoke(
     input: InputValues,
     options?: BaseCallbackConfig
   ): Promise<FormattedOutput> {

--- a/langchain/src/prompts/base.ts
+++ b/langchain/src/prompts/base.ts
@@ -9,6 +9,8 @@ import { BaseOutputParser } from "../schema/output_parser.js";
 import { Serializable } from "../load/serializable.js";
 import { SerializedBasePromptTemplate } from "./serde.js";
 import { SerializedFields } from "../load/map_keys.js";
+import { Runnable } from "../schema/runnable.js";
+import { BaseCallbackConfig } from "../callbacks/manager.js";
 
 export class StringPromptValue extends BasePromptValue {
   lc_namespace = ["langchain", "prompts", "base"];
@@ -51,11 +53,13 @@ export interface BasePromptTemplateInput {
  * Base class for prompt templates. Exposes a format method that returns a
  * string prompt given a set of input values.
  */
-export abstract class BasePromptTemplate
-  extends Serializable
+export abstract class BasePromptTemplate<
+    FormattedOutput extends BasePromptValue = BasePromptValue
+  >
+  extends Runnable<InputValues, FormattedOutput>
   implements BasePromptTemplateInput
 {
-  declare PromptValueReturnType: BasePromptValue;
+  declare PromptValueReturnType: FormattedOutput;
 
   lc_serializable = true;
 
@@ -104,6 +108,17 @@ export abstract class BasePromptTemplate
     return allKwargs;
   }
 
+  invoke(
+    input: InputValues,
+    options?: BaseCallbackConfig
+  ): Promise<FormattedOutput> {
+    return this._callWithConfig(
+      (input: InputValues) => this.formatPromptValue(input),
+      input,
+      options
+    );
+  }
+
   /**
    * Format the prompt given the input values.
    *
@@ -122,7 +137,7 @@ export abstract class BasePromptTemplate
    * @param values
    * @returns A formatted PromptValue.
    */
-  abstract formatPromptValue(values: InputValues): Promise<BasePromptValue>;
+  abstract formatPromptValue(values: InputValues): Promise<FormattedOutput>;
 
   /**
    * Return the string type key uniquely identifying this class of prompt template.

--- a/langchain/src/prompts/chat.ts
+++ b/langchain/src/prompts/chat.ts
@@ -122,9 +122,7 @@ export abstract class BaseMessageStringPromptTemplate extends BaseMessagePromptT
   }
 }
 
-export abstract class BaseChatPromptTemplate extends BasePromptTemplate {
-  declare PromptValueReturnType: ChatPromptValue;
-
+export abstract class BaseChatPromptTemplate extends BasePromptTemplate<ChatPromptValue> {
   constructor(input: BasePromptTemplateInput) {
     super(input);
   }

--- a/langchain/src/schema/output_parser.ts
+++ b/langchain/src/schema/output_parser.ts
@@ -1,13 +1,16 @@
 import { Callbacks } from "../callbacks/manager.js";
 import { BasePromptValue, Generation, ChatGeneration } from "./index.js";
-import { Serializable } from "../load/serializable.js";
+import { Runnable, RunnableConfig } from "./runnable.js";
 
 /**
  * Options for formatting instructions.
  */
 export interface FormatInstructionsOptions {}
 
-export abstract class BaseLLMOutputParser<T = unknown> extends Serializable {
+export abstract class BaseLLMOutputParser<T = unknown> extends Runnable<
+  Generation[] | ChatGeneration[],
+  T
+> {
   abstract parseResult(
     generations: Generation[] | ChatGeneration[],
     callbacks?: Callbacks
@@ -20,9 +23,17 @@ export abstract class BaseLLMOutputParser<T = unknown> extends Serializable {
   ): Promise<T> {
     return this.parseResult(generations, callbacks);
   }
+
+  invoke(
+    input: Generation[] | ChatGeneration[],
+    options?: RunnableConfig
+  ): Promise<T> {
+    return this.parseResult(input, options?.callbacks);
+  }
 }
 
-/** Class to parse the output of an LLM call.
+/**
+ * Class to parse the output of an LLM call.
  */
 export abstract class BaseOutputParser<
   T = unknown

--- a/langchain/src/schema/output_parser.ts
+++ b/langchain/src/schema/output_parser.ts
@@ -101,6 +101,23 @@ export abstract class BaseOutputParser<
   }
 }
 
+/**
+ * OutputParser that parses LLMResult into the top likely string.
+ */
+export class StringOutputParser extends BaseOutputParser<string> {
+  lc_namespace = ["schema", "output_parser"];
+
+  lc_serializable = true;
+
+  parse(text: string): Promise<string> {
+    return Promise.resolve(text);
+  }
+
+  getFormatInstructions(): string {
+    return "";
+  }
+}
+
 export class OutputParserException extends Error {
   output?: string;
 

--- a/langchain/src/schema/output_parser.ts
+++ b/langchain/src/schema/output_parser.ts
@@ -38,14 +38,14 @@ export abstract class BaseLLMOutputParser<T = unknown> extends Runnable<
         async (input: string): Promise<T> =>
           this.parseResult([{ text: input }]),
         input,
-        options
+        { ...options, runType: "parser" }
       );
     } else {
       return this._callWithConfig(
         async (input: BaseMessage): Promise<T> =>
           this.parseResult([{ message: input, text: input.content }]),
         input,
-        options
+        { ...options, runType: "parser" }
       );
     }
   }

--- a/langchain/src/schema/retriever.ts
+++ b/langchain/src/schema/retriever.ts
@@ -6,7 +6,7 @@ import {
   parseCallbackConfigArg,
 } from "../callbacks/manager.js";
 import { Document } from "../document.js";
-import { Serializable } from "../load/serializable.js";
+import { Runnable, RunnableConfig } from "./runnable.js";
 
 /**
  * Base Index class. All indexes should extend this class.
@@ -19,7 +19,7 @@ export interface BaseRetrieverInput {
   verbose?: boolean;
 }
 
-export abstract class BaseRetriever extends Serializable {
+export abstract class BaseRetriever extends Runnable<string, Document[]> {
   callbacks?: Callbacks;
 
   tags?: string[];
@@ -46,6 +46,10 @@ export abstract class BaseRetriever extends Serializable {
     _callbacks?: CallbackManagerForRetrieverRun
   ): Promise<Document[]> {
     throw new Error("Not implemented!");
+  }
+
+  async invoke(input: string, options?: RunnableConfig): Promise<Document[]> {
+    return this.getRelevantDocuments(input, options);
   }
 
   async getRelevantDocuments(

--- a/langchain/src/schema/runnable.ts
+++ b/langchain/src/schema/runnable.ts
@@ -1,20 +1,30 @@
-import { BaseCallbackConfig } from "../callbacks/manager.js";
+import { BaseCallbackConfig, CallbackManager } from "../callbacks/manager.js";
 import { Serializable } from "../load/serializable.js";
 import { IterableReadableStream } from "../util/stream.js";
 
 export type RunnableConfig = BaseCallbackConfig;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function _coerceToDict(value: any, defaultKey: string) {
+  return value && !Array.isArray(value) && typeof value === "object"
+    ? value
+    : { [defaultKey]: value };
+}
+
 export abstract class Runnable<
   RunInput,
-  CallOptions extends RunnableConfig,
-  RunOutput
+  RunOutput,
+  CallOptions extends RunnableConfig = RunnableConfig
 > extends Serializable {
-  abstract invoke(input: RunInput, options?: CallOptions): Promise<RunOutput>;
+  abstract invoke(
+    input: RunInput,
+    options?: Partial<CallOptions>
+  ): Promise<RunOutput>;
 
   protected _getOptionsList(
-    options: CallOptions | CallOptions[],
+    options: Partial<CallOptions> | Partial<CallOptions>[],
     length = 0
-  ): CallOptions[] {
+  ): Partial<CallOptions>[] {
     if (Array.isArray(options)) {
       if (options.length !== length) {
         throw new Error(
@@ -28,15 +38,12 @@ export abstract class Runnable<
 
   async batch(
     inputs: RunInput[],
-    options?: CallOptions | CallOptions[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
     batchOptions?: {
       maxConcurrency?: number;
     }
   ): Promise<RunOutput[]> {
-    const configList = this._getOptionsList(
-      (options ?? {}) as CallOptions,
-      inputs.length
-    );
+    const configList = this._getOptionsList(options ?? {}, inputs.length);
     const batchSize =
       batchOptions?.maxConcurrency && batchOptions.maxConcurrency > 0
         ? batchOptions?.maxConcurrency
@@ -54,14 +61,14 @@ export abstract class Runnable<
 
   async *_streamIterator(
     input: RunInput,
-    options?: CallOptions
+    options: Partial<CallOptions> = {}
   ): AsyncGenerator<RunOutput> {
     yield this.invoke(input, options);
   }
 
   async stream(
     input: RunInput,
-    options?: CallOptions
+    options: Partial<CallOptions> = {}
   ): Promise<IterableReadableStream<RunOutput>> {
     return IterableReadableStream.fromAsyncGenerator(
       this._streamIterator(input, options)
@@ -69,8 +76,8 @@ export abstract class Runnable<
   }
 
   protected _separateRunnableConfigFromCallOptions(
-    options: CallOptions
-  ): [RunnableConfig, Omit<CallOptions, keyof RunnableConfig>] {
+    options: Partial<CallOptions> = {}
+  ): [RunnableConfig, Omit<Partial<CallOptions>, keyof RunnableConfig>] {
     const runnableConfig: RunnableConfig = {
       callbacks: options.callbacks,
       tags: options.tags,
@@ -81,5 +88,264 @@ export abstract class Runnable<
     delete callOptions.tags;
     delete callOptions.metadata;
     return [runnableConfig, callOptions];
+  }
+
+  protected async _callWithConfig<T extends RunInput>(
+    func: (input: T) => Promise<RunOutput>,
+    input: T,
+    options?: RunnableConfig
+  ) {
+    const callbackManager_ = await CallbackManager.configure(
+      options?.callbacks,
+      undefined,
+      options?.tags,
+      undefined,
+      options?.metadata
+    );
+    const runManager = await callbackManager_?.handleChainStart(
+      this.toJSON(),
+      _coerceToDict(input, "input")
+    );
+    let output;
+    try {
+      output = func.bind(this)(input);
+    } catch (e) {
+      await runManager?.handleChainError(e);
+      throw e;
+    }
+    await runManager?.handleChainEnd(_coerceToDict(output, "output"));
+    return output;
+  }
+
+  _patchConfig(
+    config: Partial<CallOptions>,
+    callbackManager?: CallbackManager
+  ): Partial<CallOptions> {
+    return { ...config, callbacks: callbackManager };
+  }
+
+  pipe<NewRunOutput>(
+    runnable: Runnable<RunOutput, NewRunOutput>
+  ): RunnableSequence<RunInput, NewRunOutput> {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return RunnableSequence.fromRunnables<RunInput, NewRunOutput>([
+      this,
+      runnable,
+    ]);
+  }
+}
+
+export class RunnableSequence<
+  RunInput,
+  RunOutput,
+  CallOptions extends RunnableConfig = RunnableConfig
+> extends Runnable<RunInput, RunOutput, CallOptions> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected first: Runnable<RunInput, any, CallOptions>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected middle: Runnable<any, any, CallOptions>[];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected last: Runnable<any, RunOutput, CallOptions>;
+
+  lc_serializable = true;
+
+  lc_namespace = ["schema", "runnable"];
+
+  constructor(fields: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    first: Runnable<RunInput, any, CallOptions>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    middle: Runnable<any, any, CallOptions>[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    last: Runnable<any, RunOutput, CallOptions>;
+  }) {
+    super(fields);
+    this.first = fields.first;
+    this.middle = fields.middle;
+    this.last = fields.last;
+  }
+
+  get steps() {
+    return [this.first, ...this.middle, this.last];
+  }
+
+  static fromRunnables<RunSequenceInput, RunSequenceOutput>(
+    runnables: [
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Runnable<RunSequenceInput, any>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...Runnable<any, any>[],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Runnable<any, RunSequenceOutput>
+    ]
+  ) {
+    if (runnables.length < 2) {
+      throw new Error("A runnable sequence must have at least two items.");
+    }
+    return new RunnableSequence<RunSequenceInput, RunSequenceOutput>({
+      first: runnables[0],
+      middle: runnables.slice(1, -1),
+      last: runnables[runnables.length - 1],
+    });
+  }
+
+  async invoke(
+    input: RunInput,
+    options: Partial<CallOptions> = {}
+  ): Promise<RunOutput> {
+    const callbackManager_ = await CallbackManager.configure(
+      options?.callbacks,
+      undefined,
+      options?.tags,
+      undefined,
+      options?.metadata
+    );
+    const runManager = await callbackManager_?.handleChainStart(
+      this.toJSON(),
+      _coerceToDict(input, "input")
+    );
+    let nextStepInput = input;
+    let finalOutput: RunOutput;
+    try {
+      for (const step of [this.first, ...this.middle]) {
+        nextStepInput = await step.invoke(
+          nextStepInput,
+          this._patchConfig(options, runManager?.getChild())
+        );
+      }
+      // TypeScript can't detect that the last output of the sequence returns RunOutput, so call it out of the loop here
+      finalOutput = await this.last.invoke(
+        nextStepInput,
+        this._patchConfig(options, runManager?.getChild())
+      );
+    } catch (e) {
+      await runManager?.handleChainError(e);
+      throw e;
+    }
+    await runManager?.handleChainEnd(_coerceToDict(finalOutput, "output"));
+    return finalOutput;
+  }
+
+  async batch(
+    inputs: RunInput[],
+    options?: Partial<CallOptions> | Partial<CallOptions>[],
+    batchOptions?: { maxConcurrency?: number }
+  ): Promise<RunOutput[]> {
+    const configList = this._getOptionsList(options ?? {}, inputs.length);
+    const callbackManagers = await Promise.all(
+      configList.map((config) =>
+        CallbackManager.configure(
+          config?.callbacks,
+          undefined,
+          config?.tags,
+          undefined,
+          config?.metadata
+        )
+      )
+    );
+    const runManagers = await Promise.all(
+      callbackManagers.map((callbackManager, i) =>
+        callbackManager?.handleChainStart(
+          this.toJSON(),
+          _coerceToDict(inputs[i], "input")
+        )
+      )
+    );
+    let nextStepInputs = inputs;
+    let finalOutputs: RunOutput[];
+    try {
+      for (let i = 0; i < [this.first, ...this.middle].length; i += 1) {
+        const step = this.steps[i];
+        nextStepInputs = await step.batch(
+          nextStepInputs,
+          runManagers.map(
+            (runManager) =>
+              this._patchConfig(configList[i], runManager?.getChild()),
+            batchOptions
+          )
+        );
+      }
+      finalOutputs = await this.last.batch(
+        nextStepInputs,
+        runManagers.map(
+          (runManager) =>
+            this._patchConfig(
+              configList[this.steps.length - 1],
+              runManager?.getChild()
+            ),
+          batchOptions
+        )
+      );
+    } catch (e) {
+      await Promise.all(
+        runManagers.map((runManager) => runManager?.handleChainError(e))
+      );
+      throw e;
+    }
+    await Promise.all(
+      runManagers.map((runManager, i) =>
+        runManager?.handleChainEnd(_coerceToDict(finalOutputs[i], "output"))
+      )
+    );
+    return finalOutputs;
+  }
+
+  async *_streamIterator(
+    input: RunInput,
+    options: Partial<CallOptions> = {}
+  ): AsyncGenerator<RunOutput> {
+    const callbackManager_ = await CallbackManager.configure(
+      options?.callbacks,
+      undefined,
+      options?.tags,
+      undefined,
+      options?.metadata
+    );
+    const runManager = await callbackManager_?.handleChainStart(
+      this.toJSON(),
+      _coerceToDict(input, "input")
+    );
+    let nextStepInput = input;
+    try {
+      for (const step of [this.first, ...this.middle]) {
+        nextStepInput = await step.invoke(
+          nextStepInput,
+          this._patchConfig(options, runManager?.getChild())
+        );
+      }
+    } catch (e) {
+      await runManager?.handleChainError(e);
+      throw e;
+    }
+    let concatSupported = true;
+    let finalOutput;
+    try {
+      const iterator = await this.last._streamIterator(
+        nextStepInput,
+        this._patchConfig(options, runManager?.getChild())
+      );
+      for await (const chunk of iterator) {
+        yield chunk;
+        if (concatSupported) {
+          if (finalOutput === undefined) {
+            finalOutput = chunk;
+          } else {
+            try {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              finalOutput = (finalOutput as any).concat(chunk);
+            } catch (e) {
+              finalOutput = undefined;
+              concatSupported = false;
+            }
+          }
+        }
+      }
+    } catch (e) {
+      await runManager?.handleChainError(e);
+      throw e;
+    }
+    await runManager?.handleChainEnd(_coerceToDict(finalOutput, "output"));
   }
 }

--- a/langchain/src/schema/runnable.ts
+++ b/langchain/src/schema/runnable.ts
@@ -216,7 +216,6 @@ export class RunnableSequence<
         nextStepInput,
         this._patchConfig(options, runManager?.getChild())
       );
-      console.log(finalOutput);
     } catch (e) {
       await runManager?.handleChainError(e);
       throw e;

--- a/langchain/src/schema/runnable.ts
+++ b/langchain/src/schema/runnable.ts
@@ -154,7 +154,7 @@ export abstract class Runnable<
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static isInstance(thing: any): thing is Runnable {
+  static isRunnable(thing: any): thing is Runnable {
     return thing.lc_runnable;
   }
 }
@@ -351,7 +351,7 @@ export class RunnableSequence<
   pipe<NewRunOutput>(
     coerceable: RunnableLike<RunOutput, NewRunOutput>
   ): RunnableSequence<RunInput, NewRunOutput> {
-    if (RunnableSequence.isInstance(coerceable)) {
+    if (RunnableSequence.isRunnableSequence(coerceable)) {
       return new RunnableSequence({
         first: this.first,
         middle: this.middle.concat([
@@ -371,8 +371,8 @@ export class RunnableSequence<
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static isInstance(thing: any): thing is RunnableSequence {
-    return Array.isArray(thing.middle) && Runnable.isInstance(thing);
+  static isRunnableSequence(thing: any): thing is RunnableSequence {
+    return Array.isArray(thing.middle) && Runnable.isRunnable(thing);
   }
 
   static from<RunInput, RunOutput>([first, ...runnables]: [
@@ -492,7 +492,7 @@ function _coerceToRunnable<RunInput, RunOutput>(
 ): Runnable<RunInput, RunOutput> {
   if (typeof coerceable === "function") {
     return new RunnableLambda({ func: coerceable });
-  } else if (Runnable.isInstance(coerceable)) {
+  } else if (Runnable.isRunnable(coerceable)) {
     return coerceable;
   } else if (!Array.isArray(coerceable) && typeof coerceable === "object") {
     const runnables: Record<string, Runnable<RunInput>> = {};

--- a/langchain/src/schema/tests/runnable.test.ts
+++ b/langchain/src/schema/tests/runnable.test.ts
@@ -1,4 +1,4 @@
-// import { z } from "zod";
+import { z } from "zod";
 import { test } from "@jest/globals";
 import { LLM } from "../../llms/base.js";
 import {
@@ -6,8 +6,17 @@ import {
   createChatMessageChunkEncoderStream,
 } from "../../chat_models/base.js";
 import { AIMessage, BaseMessage, ChatResult } from "../index.js";
-import { PromptTemplate } from "../../prompts/index.js";
-// import { StructuredOutputParser } from "../../output_parsers/structured.js";
+import {
+  ChatPromptTemplate,
+  HumanMessagePromptTemplate,
+  PromptTemplate,
+  SystemMessagePromptTemplate,
+} from "../../prompts/index.js";
+import { StructuredOutputParser } from "../../output_parsers/structured.js";
+import { RunnableMap, RunnableSequence } from "../runnable.js";
+import { BaseRetriever } from "../retriever.js";
+import { Document } from "../../document.js";
+import { OutputParserException } from "../output_parser.js";
 
 class FakeLLM extends LLM {
   _llmType() {
@@ -29,12 +38,10 @@ class FakeChatModel extends BaseChatModel {
   }
 
   async _generate(
-    _messages: BaseMessage[],
+    messages: BaseMessage[],
     _options: this["ParsedCallOptions"]
   ): Promise<ChatResult> {
-    const text = `\`\`\`
-{"outputValue": "testing"}
-\`\`\``;
+    const text = messages.map((m) => m.content).join("\n");
     return {
       generations: [
         {
@@ -44,6 +51,20 @@ class FakeChatModel extends BaseChatModel {
       ],
       llmOutput: {},
     };
+  }
+}
+
+class FakeRetriever extends BaseRetriever {
+  lc_namespace = ["test", "fake"];
+
+  async _getRelevantDocuments(
+    _query: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<Document<Record<string, any>>[]> {
+    return [
+      new Document({ pageContent: "foo" }),
+      new Document({ pageContent: "bar" }),
+    ];
   }
 }
 
@@ -94,11 +115,55 @@ test("Pipe from one runnable to the next", async () => {
 test("Create a runnable sequence and run it", async () => {
   const promptTemplate = PromptTemplate.fromTemplate("{input}");
   const llm = new FakeChatModel({});
-  // const parser = StructuredOutputParser.fromZodSchema(
-  //   z.object({ outputValue: z.string().describe("A test value") })
-  // );
-  const runnable = promptTemplate.pipe(llm);
-  const result = await runnable.invoke({ input: "Hello sequence!" });
+  const parser = StructuredOutputParser.fromZodSchema(
+    z.object({ outputValue: z.string().describe("A test value") })
+  );
+  const text = `\`\`\`
+{"outputValue": "testing"}
+\`\`\``;
+  const runnable = promptTemplate.pipe(llm).pipe(parser);
+  const result = await runnable.invoke({ input: text });
   console.log(result);
-  expect(result).toBe({ outputValue: "testing" });
+  expect(result).toEqual({ outputValue: "testing" });
+});
+
+test("Create a runnable sequence with a static method with invalid output and catch the error", async () => {
+  const promptTemplate = PromptTemplate.fromTemplate("{input}");
+  const llm = new FakeChatModel({});
+  const parser = StructuredOutputParser.fromZodSchema(
+    z.object({ outputValue: z.string().describe("A test value") })
+  );
+  const runnable = RunnableSequence.fromRunnables([
+    promptTemplate,
+    llm,
+    parser,
+  ]);
+  await expect(async () => {
+    const result = await runnable.invoke({ input: "Hello sequence!" });
+    console.log(result);
+  }).rejects.toThrow(OutputParserException);
+});
+
+test("Create a runnable sequence with a runnable map", async () => {
+  const promptTemplate = ChatPromptTemplate.fromPromptMessages([
+    SystemMessagePromptTemplate.fromTemplate(`You are a nice assistant.`),
+    HumanMessagePromptTemplate.fromTemplate(
+      `Context:\n{documents}\n\nQuestion:\n{question}`
+    ),
+  ]);
+  const llm = new FakeChatModel({});
+  const inputs = {
+    question: (input: string) => input,
+    documents: RunnableSequence.fromRunnables([
+      new FakeRetriever(),
+      (docs: Document[]) => JSON.stringify(docs),
+    ]),
+    extraField: new FakeLLM({}),
+  };
+  const runnable = new RunnableMap(inputs).pipe(promptTemplate).pipe(llm);
+  const result = await runnable.invoke("Do you know the Muffin Man?");
+  console.log(result);
+  expect(result.content).toEqual(
+    `You are a nice assistant.\nContext:\n[{"pageContent":"foo","metadata":{}},{"pageContent":"bar","metadata":{}}]\n\nQuestion:\nDo you know the Muffin Man?`
+  );
 });

--- a/langchain/src/schema/tests/runnable.test.ts
+++ b/langchain/src/schema/tests/runnable.test.ts
@@ -133,11 +133,7 @@ test("Create a runnable sequence with a static method with invalid output and ca
   const parser = StructuredOutputParser.fromZodSchema(
     z.object({ outputValue: z.string().describe("A test value") })
   );
-  const runnable = RunnableSequence.fromRunnables([
-    promptTemplate,
-    llm,
-    parser,
-  ]);
+  const runnable = RunnableSequence.from([promptTemplate, llm, parser]);
   await expect(async () => {
     const result = await runnable.invoke({ input: "Hello sequence!" });
     console.log(result);
@@ -154,13 +150,15 @@ test("Create a runnable sequence with a runnable map", async () => {
   const llm = new FakeChatModel({});
   const inputs = {
     question: (input: string) => input,
-    documents: RunnableSequence.fromRunnables([
+    documents: RunnableSequence.from([
       new FakeRetriever(),
       (docs: Document[]) => JSON.stringify(docs),
     ]),
     extraField: new FakeLLM({}),
   };
-  const runnable = new RunnableMap(inputs).pipe(promptTemplate).pipe(llm);
+  const runnable = new RunnableMap({ steps: inputs })
+    .pipe(promptTemplate)
+    .pipe(llm);
   const result = await runnable.invoke("Do you know the Muffin Man?");
   console.log(result);
   expect(result.content).toEqual(

--- a/langchain/src/tools/base.ts
+++ b/langchain/src/tools/base.ts
@@ -18,7 +18,6 @@ export abstract class StructuredTool<
   T extends z.ZodObject<any, any, any, any> = z.ZodObject<any, any, any, any>
 > extends BaseLangChain<
   (z.output<T> extends string ? string : never) | z.input<T>,
-  RunnableConfig,
   string
 > {
   abstract schema: T | z.ZodEffects<T>;

--- a/langchain/src/util/stream.ts
+++ b/langchain/src/util/stream.ts
@@ -41,7 +41,7 @@ export function readableStreamToAsyncIterable(
 }
 
 export class IterableReadableStream<T> extends ReadableStream<T> {
-  public reader: ReadableStreamDefaultReader;
+  public reader: ReadableStreamDefaultReader<T>;
 
   ensureReader() {
     if (!this.reader) {

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -142,6 +142,7 @@
       "src/schema/output_parser.ts",
       "src/schema/query_constructor.ts",
       "src/schema/retriever.ts",
+      "src/schema/runnable.ts",
       "src/sql_db.ts",
       "src/callbacks/index.ts",
       "src/output_parsers/index.ts",

--- a/test-exports-cf/src/entrypoints.js
+++ b/test-exports-cf/src/entrypoints.js
@@ -32,6 +32,7 @@ export * from "langchain/schema";
 export * from "langchain/schema/output_parser";
 export * from "langchain/schema/query_constructor";
 export * from "langchain/schema/retriever";
+export * from "langchain/schema/runnable";
 export * from "langchain/callbacks";
 export * from "langchain/output_parsers";
 export * from "langchain/retrievers/remote";

--- a/test-exports-cjs/src/entrypoints.js
+++ b/test-exports-cjs/src/entrypoints.js
@@ -32,6 +32,7 @@ const schema = require("langchain/schema");
 const schema_output_parser = require("langchain/schema/output_parser");
 const schema_query_constructor = require("langchain/schema/query_constructor");
 const schema_retriever = require("langchain/schema/retriever");
+const schema_runnable = require("langchain/schema/runnable");
 const callbacks = require("langchain/callbacks");
 const output_parsers = require("langchain/output_parsers");
 const retrievers_remote = require("langchain/retrievers/remote");

--- a/test-exports-esbuild/src/entrypoints.js
+++ b/test-exports-esbuild/src/entrypoints.js
@@ -32,6 +32,7 @@ import * as schema from "langchain/schema";
 import * as schema_output_parser from "langchain/schema/output_parser";
 import * as schema_query_constructor from "langchain/schema/query_constructor";
 import * as schema_retriever from "langchain/schema/retriever";
+import * as schema_runnable from "langchain/schema/runnable";
 import * as callbacks from "langchain/callbacks";
 import * as output_parsers from "langchain/output_parsers";
 import * as retrievers_remote from "langchain/retrievers/remote";

--- a/test-exports-esm/src/entrypoints.js
+++ b/test-exports-esm/src/entrypoints.js
@@ -32,6 +32,7 @@ import * as schema from "langchain/schema";
 import * as schema_output_parser from "langchain/schema/output_parser";
 import * as schema_query_constructor from "langchain/schema/query_constructor";
 import * as schema_retriever from "langchain/schema/retriever";
+import * as schema_runnable from "langchain/schema/runnable";
 import * as callbacks from "langchain/callbacks";
 import * as output_parsers from "langchain/output_parsers";
 import * as retrievers_remote from "langchain/retrievers/remote";

--- a/test-exports-vercel/src/entrypoints.js
+++ b/test-exports-vercel/src/entrypoints.js
@@ -32,6 +32,7 @@ export * from "langchain/schema";
 export * from "langchain/schema/output_parser";
 export * from "langchain/schema/query_constructor";
 export * from "langchain/schema/retriever";
+export * from "langchain/schema/runnable";
 export * from "langchain/callbacks";
 export * from "langchain/output_parsers";
 export * from "langchain/retrievers/remote";

--- a/test-exports-vite/src/entrypoints.js
+++ b/test-exports-vite/src/entrypoints.js
@@ -32,6 +32,7 @@ export * from "langchain/schema";
 export * from "langchain/schema/output_parser";
 export * from "langchain/schema/query_constructor";
 export * from "langchain/schema/retriever";
+export * from "langchain/schema/runnable";
 export * from "langchain/callbacks";
 export * from "langchain/output_parsers";
 export * from "langchain/retrievers/remote";

--- a/yarn.lock
+++ b/yarn.lock
@@ -13171,7 +13171,7 @@ __metadata:
     js-tiktoken: ^1.0.7
     js-yaml: ^4.1.0
     jsonpointer: ^5.0.1
-    langsmith: ~0.0.11
+    langsmith: ~0.0.16
     mammoth: ^1.5.1
     ml-distance: ^4.0.0
     ml-matrix: ^6.10.4
@@ -13412,9 +13412,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"langsmith@npm:~0.0.11":
-  version: 0.0.11
-  resolution: "langsmith@npm:0.0.11"
+"langsmith@npm:~0.0.16":
+  version: 0.0.16
+  resolution: "langsmith@npm:0.0.16"
   dependencies:
     "@types/uuid": ^9.0.1
     commander: ^10.0.1
@@ -13423,7 +13423,7 @@ __metadata:
     uuid: ^9.0.0
   bin:
     langsmith: dist/cli/main.cjs
-  checksum: 003e0ed0eb975512fc11cbc9d6880fa9bac1cf24cb963b89127d1d601e849faa2f5eff6216a6abb359f4b7c7cae96f056529e74b063af5c593fdee36e56c2249
+  checksum: fc738ef9a563af14a7dc06027f98eb6ac2641b95e384b109ae388c32e9abd5e098fe07925139e489eaed17df84a8e32b961207d4cc760631b4c14e4c06e418d9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds RunnableSequence, RunnableMap, RunnableLambda, and RunnablePassthrough and associated compositional `.pipe` methods, also makes retrievers and output parsers runnable.