### PR TITLE
Redis cache: Doc fix for importing

### DIFF
--- a/docs/snippets/modules/model_io/models/llms/how_to/llm_caching.mdx
+++ b/docs/snippets/modules/model_io/models/llms/how_to/llm_caching.mdx
@@ -71,7 +71,7 @@ Then, you can pass a `cache` option when you instantiate the LLM. For example:
 
 ```typescript
 import { OpenAI } from "langchain/llms/openai";
-import { RedisCache } from "langchain/cache/ioredis";
+import { RedisCache } from "langchain/cache/redis";
 import { Redis } from "ioredis";
 
 // See https://github.com/redis/ioredis for connection options


### PR DESCRIPTION
When I ran the redis example proposed by cache documentation i got this error

```
<rejected> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './cache/ioredis' is not defined by "exports" in /Users/italojs/dev/nodesource/llm_presentation/node_modules/langchain/package.json
      at new NodeError (node:internal/errors:399:5)
      at exportsNotFound (node:internal/modules/esm/resolve:361:10)
      at packageExportsResolve (node:internal/modules/esm/resolve:697:9)
      at resolveExports (node:internal/modules/cjs/loader:565:36)
      at Module._findPath (node:internal/modules/cjs/loader:634:31)
      at Module._resolveFilename (node:internal/modules/cjs/loader:1061:27)
      at Module._load (node:internal/modules/cjs/loader:920:27)
      at Module.require (node:internal/modules/cjs/loader:1141:19)
      at require (node:internal/modules/cjs/helpers:110:18)
      at evalmachine.<anonymous>:3:28 {
    code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
  }
}
```

I just checked the langchain source and figured there have a redis file instead ioredis

<img width="206" alt="Screenshot 2023-08-01 at 11 47 02" src="https://github.com/hwchase17/langchainjs/assets/12226189/e8b75952-a426-47e7-ba34-a1d95c5fc4cf">

using just `redis` on importing worked
