### PR TITLE
Fix: Partial Prompt Template docs typo

### DIFF
--- a/docs/snippets/modules/model_io/prompts/prompt_templates/partial.mdx
+++ b/docs/snippets/modules/model_io/prompts/prompt_templates/partial.mdx
@@ -10,11 +10,11 @@ const prompt = new PromptTemplate({
   inputVariables: ["foo", "bar"]
 });
 
-const paritalPrompt = await prompt.partial({
+const partialPrompt = await prompt.partial({
   foo: "foo",
 });
 
-const formattedPrompt = await paritalPrompt.format({
+const formattedPrompt = await partialPrompt.format({
   bar: "baz",
 });
 


### PR DESCRIPTION
The typo can be seen [here](https://js.langchain.com/docs/modules/model_io/prompts/prompt_templates/partial#partial-with-strings). 