### PR TITLE
🧑‍💻 Make 'QAEvalChain' available.

### DIFF
--- a/langchain/src/evaluation/index.ts
+++ b/langchain/src/evaluation/index.ts
@@ -1,0 +1,1 @@
+export * from "./qa/index.js";


### PR DESCRIPTION
Fix import { QAEvalChain } from 'langchain/evaluation'.
