### PR TITLE
Remove precommit compilation hook

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -15,7 +15,7 @@
     "start:dist": "yarn build && node -r dotenv/config dist/index.js",
     "lint": "eslint src",
     "lint:fix": "yarn lint --fix",
-    "precommit": "tsc --noEmit && lint-staged",
+    "precommit": "lint-staged",
     "format": "prettier --write \"**/*.ts\"",
     "format:check": "prettier --check \"**/*.ts\""
   },

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -511,7 +511,7 @@
     "build:watch": "node scripts/create-entrypoints.js && tsc --outDir dist/ --watch",
     "lint": "eslint src && dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint:fix": "yarn lint --fix",
-    "precommit": "tsc --noEmit && lint-staged",
+    "precommit": "lint-staged",
     "clean": "rimraf dist/ && node scripts/create-entrypoints.js pre",
     "prepack": "yarn build",
     "release": "release-it --only-version --config .release-it.json",


### PR DESCRIPTION
The `tsc` check required a separate `yarn build` run to work in some cases. This should reduce friction for contributors.