### PR TITLE
Update code model defaults for code-gecko in GoogleVertexAI

### DIFF
--- a/langchain/src/llms/googlevertexai.ts
+++ b/langchain/src/llms/googlevertexai.ts
@@ -67,7 +67,7 @@ export class GoogleVertexAI extends BaseLLM implements GoogleVertexAITextInput {
     this.model = fields?.model ?? this.model;
 
     // Change the defaults for code models
-    if (this.model === "code-gecko") {
+    if (this.model.startsWith("code-gecko")) {
       this.maxOutputTokens = 64;
     }
     if (this.model.startsWith("code-")) {


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # 
we can handle version of the model vertex ai by adding like `@001` in the end of model name. official document is [here](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/code-completion)
thus If I set model name as `code-gecko@001`, it don't work and this is not implementer want.

