### PR TITLE
Allow runnables to implement transform streaming

### DIFF
--- a/langchain/src/chains/transform.ts
+++ b/langchain/src/chains/transform.ts
@@ -11,11 +11,11 @@ export interface TransformChainFields<
   outputVariables: (keyof O extends string ? keyof O : never)[];
 }
 
-export class TransformChain<I extends ChainValues, O extends ChainValues>
-  extends BaseChain
-  implements TransformChainFields<I, O>
-{
-  transform: (values: I, callbacks?: Callbacks) => O | Promise<O>;
+export class TransformChain<
+  I extends ChainValues,
+  O extends ChainValues
+> extends BaseChain {
+  transformFunc: (values: I, callbacks?: Callbacks) => O | Promise<O>;
 
   inputVariables: (keyof I extends string ? keyof I : never)[];
 
@@ -35,12 +35,12 @@ export class TransformChain<I extends ChainValues, O extends ChainValues>
 
   constructor(fields: TransformChainFields<I, O>) {
     super(fields);
-    this.transform = fields.transform;
+    this.transformFunc = fields.transform;
     this.inputVariables = fields.inputVariables;
     this.outputVariables = fields.outputVariables;
   }
 
   async _call(values: I, runManager?: CallbackManagerForChainRun): Promise<O> {
-    return this.transform(values, runManager?.getChild("transform"));
+    return this.transformFunc(values, runManager?.getChild("transform"));
   }
 }

--- a/langchain/src/output_parsers/noop.ts
+++ b/langchain/src/output_parsers/noop.ts
@@ -1,4 +1,15 @@
-import { StringOutputParser } from "../schema/output_parser.js";
+import { BaseOutputParser } from "../schema/output_parser.js";
 
-/** @deprecated Use StringOutputParser instead */
-export class NoOpOutputParser extends StringOutputParser {}
+export class NoOpOutputParser extends BaseOutputParser<string> {
+  lc_namespace = ["langchain", "output_parsers", "default"];
+
+  lc_serializable = true;
+
+  parse(text: string): Promise<string> {
+    return Promise.resolve(text);
+  }
+
+  getFormatInstructions(): string {
+    return "";
+  }
+}

--- a/langchain/src/schema/runnable.ts
+++ b/langchain/src/schema/runnable.ts
@@ -154,6 +154,7 @@ export abstract class Runnable<
       undefined,
       options?.metadata
     );
+    // TODO: Find a way to pass the entire streamed value into the callback.
     const runManager = await callbackManager_?.handleChainStart(
       this.toJSON(),
       _coerceToDict("<streamed value>", "input"),

--- a/langchain/src/schema/runnable.ts
+++ b/langchain/src/schema/runnable.ts
@@ -143,7 +143,7 @@ export abstract class Runnable<
     return output;
   }
 
-  protected async *_streamWithConfig<T extends RunInput>(
+  protected async *_streamWithConfig<T extends RunOutput>(
     generator: AsyncGenerator<T>,
     options?: RunnableConfig & { runType?: string }
   ) {

--- a/langchain/src/schema/runnable.ts
+++ b/langchain/src/schema/runnable.ts
@@ -143,6 +143,49 @@ export abstract class Runnable<
     return output;
   }
 
+  protected async *_streamWithConfig<T extends RunInput>(
+    generator: AsyncGenerator<T>,
+    options?: RunnableConfig & { runType?: string }
+  ) {
+    const callbackManager_ = await CallbackManager.configure(
+      options?.callbacks,
+      undefined,
+      options?.tags,
+      undefined,
+      options?.metadata
+    );
+    const runManager = await callbackManager_?.handleChainStart(
+      this.toJSON(),
+      _coerceToDict("<streamed value>", "input"),
+      undefined,
+      options?.runType
+    );
+    let output;
+    let concatSupported = true;
+    try {
+      for await (const chunk of generator) {
+        yield chunk;
+        if (concatSupported) {
+          if (output === undefined) {
+            output = chunk;
+          } else {
+            try {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              output = (output as any).concat(chunk);
+            } catch (e) {
+              output = undefined;
+              concatSupported = false;
+            }
+          }
+        }
+      }
+    } catch (e) {
+      await runManager?.handleChainError(e);
+      throw e;
+    }
+    await runManager?.handleChainEnd(_coerceToDict(output, "output"));
+  }
+
   _patchConfig(
     config: Partial<CallOptions> = {},
     callbackManager: CallbackManager | undefined = undefined
@@ -159,6 +202,11 @@ export abstract class Runnable<
       last: _coerceToRunnable(coerceable),
     });
   }
+
+  transform?(
+    generator: AsyncGenerator<RunInput>,
+    options: Partial<CallOptions>
+  ): AsyncGenerator<RunOutput>;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static isRunnable(thing: any): thing is Runnable {
@@ -314,8 +362,17 @@ export class RunnableSequence<
       _coerceToDict(input, "input")
     );
     let nextStepInput = input;
+    const steps = [this.first, ...this.middle, this.last];
+    // Find the index of the last runnable in the sequence that doesn't have a .transform() method
+    // and start streaming from there
+    const streamingStartStepIndex =
+      steps.length -
+      [...steps]
+        .reverse()
+        .findIndex((step) => typeof step.transform !== "function") -
+      1;
     try {
-      for (const step of [this.first, ...this.middle]) {
+      for (const step of steps.slice(0, streamingStartStepIndex)) {
         nextStepInput = await step.invoke(
           nextStepInput,
           this._patchConfig(options, runManager?.getChild())
@@ -328,11 +385,18 @@ export class RunnableSequence<
     let concatSupported = true;
     let finalOutput;
     try {
-      const iterator = await this.last._streamIterator(
+      let finalGenerator = await steps[streamingStartStepIndex]._streamIterator(
         nextStepInput,
         this._patchConfig(options, runManager?.getChild())
       );
-      for await (const chunk of iterator) {
+      for (const step of steps.slice(streamingStartStepIndex + 1)) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        finalGenerator = await step.transform!(
+          finalGenerator,
+          this._patchConfig(options, runManager?.getChild())
+        );
+      }
+      for await (const chunk of finalGenerator) {
         yield chunk;
         if (concatSupported) {
           if (finalOutput === undefined) {

--- a/langchain/src/schema/tests/output_parser.test.ts
+++ b/langchain/src/schema/tests/output_parser.test.ts
@@ -1,0 +1,35 @@
+/* eslint-disable no-promise-executor-return */
+
+import { test } from "@jest/globals";
+import { LLM } from "../../llms/base.js";
+import { GenerationChunk } from "../index.js";
+import { BytesOutputParser } from "../output_parser.js";
+
+class FakeStreamingLLM extends LLM {
+  _llmType() {
+    return "fake";
+  }
+
+  async _call(prompt: string): Promise<string> {
+    return prompt;
+  }
+
+  async *_streamResponseChunks(input: string) {
+    for (const c of input) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      yield { text: c, generationInfo: {} } as GenerationChunk;
+    }
+  }
+}
+
+test("BytesOutputParser", async () => {
+  const llm = new FakeStreamingLLM({});
+  const stream = await llm.pipe(new BytesOutputParser()).stream("Hi there!");
+  const chunks = [];
+  const decoder = new TextDecoder();
+  for await (const chunk of stream) {
+    chunks.push(decoder.decode(chunk));
+  }
+  expect(chunks.length).toEqual("Hi there!".length);
+  expect(chunks.join("")).toEqual("Hi there!");
+});


### PR DESCRIPTION
Primary use-case is to allow LLM/chat model streaming with an output parser that can handle streamed generated chunks.