### PR TITLE
Fix: pass retriever metadata to the filter argument of the Postgres (…

### DIFF
--- a/langchain/src/retrievers/supabase.ts
+++ b/langchain/src/retrievers/supabase.ts
@@ -10,6 +10,7 @@ import {
 interface SearchEmbeddingsParams {
   query_embedding: number[];
   match_count: number; // int
+  filter: Record<string, unknown>; //jsonb
 }
 
 interface SearchKeywordParams {
@@ -96,6 +97,7 @@ export class SupabaseHybridSearch extends BaseRetriever {
     const matchDocumentsParams: SearchEmbeddingsParams = {
       query_embedding: embeddedQuery,
       match_count: k,
+      filter: this.metadata || {},
     };
 
     const { data: searches, error } = await this.client.rpc(

--- a/langchain/src/retrievers/supabase.ts
+++ b/langchain/src/retrievers/supabase.ts
@@ -10,7 +10,7 @@ import {
 interface SearchEmbeddingsParams {
   query_embedding: number[];
   match_count: number; // int
-  filter: Record<string, unknown>; //jsonb
+  filter?: Record<string, unknown>; // jsonb
 }
 
 interface SearchKeywordParams {
@@ -97,8 +97,11 @@ export class SupabaseHybridSearch extends BaseRetriever {
     const matchDocumentsParams: SearchEmbeddingsParams = {
       query_embedding: embeddedQuery,
       match_count: k,
-      filter: this.metadata || {},
     };
+
+    if (Object.keys(this.metadata ?? {}).length > 0) {
+      matchDocumentsParams.filter = this.metadata;
+    }
 
     const { data: searches, error } = await this.client.rpc(
       this.similarityQueryName,


### PR DESCRIPTION
Metadata filtering wasn't working on SupabaseHybridSearch. Metadata was not getting passed to the Postgres function.
This fixes it.


Twitter: https://twitter.com/Enejdd_

Fixes #2182