### PR TITLE
Returning score info in result Documents for SimilaritySearch and MDB ATLAS MMR Search

### DIFF
--- a/langchain/src/prompts/tests/selectors.test.ts
+++ b/langchain/src/prompts/tests/selectors.test.ts
@@ -32,12 +32,23 @@ test("Test using LengthBasedExampleSelector", async () => {
 test("Test using SemanticSimilarityExampleSelector", async () => {
   const vectorStore = await HNSWLib.fromTexts(
     ["Hello world", "Bye bye", "hello nice world", "bye", "hi"],
-    [{ id: 2 }, { id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    [
+      { id: 2, score: 0 },
+      { id: 1, score: 0 },
+      { id: 3, score: 0 },
+      { id: 4, score: 0 },
+      { id: 5, score: 0 },
+    ],
     new FakeEmbeddings() // not using  OpenAIEmbeddings() because would be extra dependency
   );
   const selector = new SemanticSimilarityExampleSelector({
     vectorStore,
   });
   const chosen = await selector.selectExamples({ id: 1 });
-  expect(chosen).toEqual([{ id: 1 }, { id: 3 }, { id: 4 }, { id: 5 }]);
+  expect(chosen).toEqual([
+    { id: 1, score: 0 },
+    { id: 3, score: 0 },
+    { id: 4, score: 0 },
+    { id: 5, score: 0 },
+  ]);
 });

--- a/langchain/src/retrievers/tests/vectorstores.test.ts
+++ b/langchain/src/retrievers/tests/vectorstores.test.ts
@@ -36,7 +36,9 @@ test("Test HNSWLib Retriever with Callback", async () => {
 
   const results = await retriever.getRelevantDocuments(queryStr);
 
-  expect(results).toEqual([new Document({ metadata: { id: 4 }, pageContent })]);
+  expect(results).toEqual([
+    new Document({ metadata: { id: 4, score: 0 }, pageContent }),
+  ]);
   expect(startRun).toBe(1);
   expect(endRun).toBe(1);
 });
@@ -79,7 +81,12 @@ test("Test Memory Retriever with Callback", async () => {
 
   const results = await retriever.getRelevantDocuments(queryStr);
 
-  expect(results).toEqual([new Document({ metadata: { a: 1 }, pageContent })]);
+  expect(results).toEqual([
+    new Document({
+      metadata: { a: 1, score: 0.9999999999999998 },
+      pageContent,
+    }),
+  ]);
   expect(startRun).toBe(1);
   expect(endRun).toBe(1);
 });
@@ -126,7 +133,9 @@ test("Test Faiss Retriever with Callback", async () => {
 
   const results = await retriever.getRelevantDocuments(queryStr);
 
-  expect(results).toEqual([new Document({ metadata: { a: 1 }, pageContent })]);
+  expect(results).toEqual([
+    new Document({ metadata: { a: 1, score: 0 }, pageContent }),
+  ]);
   expect(startRun).toBe(1);
   expect(endRun).toBe(1);
 });

--- a/langchain/src/vectorstores/base.ts
+++ b/langchain/src/vectorstores/base.ts
@@ -157,7 +157,9 @@ export abstract class VectorStore extends Serializable {
       filter
     );
 
-    return results.map((result) => result[0]);
+    return results.map(([doc, score]) => {
+      return { ...doc, score };
+    });
   }
 
   async similaritySearchWithScore(

--- a/langchain/src/vectorstores/base.ts
+++ b/langchain/src/vectorstores/base.ts
@@ -159,7 +159,7 @@ export abstract class VectorStore extends Serializable {
 
     return results.map(([doc, score]) => ({
       pageContent: doc?.pageContent,
-      metadata: { ...doc?.metadata, score },
+      metadata: { score, ...doc?.metadata },
     }));
   }
 

--- a/langchain/src/vectorstores/base.ts
+++ b/langchain/src/vectorstores/base.ts
@@ -157,9 +157,10 @@ export abstract class VectorStore extends Serializable {
       filter
     );
 
-    return results.map(([doc, score]) => {
-      return { ...doc, score };
-    });
+    return results.map(([doc, score]) => ({
+      pageContent: doc?.pageContent,
+      metadata: { ...doc?.metadata, score },
+    }));
   }
 
   async similaritySearchWithScore(

--- a/langchain/src/vectorstores/mongodb_atlas.ts
+++ b/langchain/src/vectorstores/mongodb_atlas.ts
@@ -171,13 +171,13 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
     );
 
     return mmrIndexes.map((idx) => {
-      const doc = resultDocs[idx][0];
+      const [doc, score] = resultDocs[idx];
 
       // remove embeddings if they were not requested originally
       if (!includeEmbeddingsFlag) {
         delete doc.metadata[this.embeddingKey];
       }
-      return doc;
+      return { ...doc, score };
     });
   }
 

--- a/langchain/src/vectorstores/mongodb_atlas.ts
+++ b/langchain/src/vectorstores/mongodb_atlas.ts
@@ -179,9 +179,8 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
       }
       return {
         pageContent: doc?.pageContent,
-        metadata: { ...doc?.metadata, score },
+        metadata: { score, ...doc?.metadata },
       };
-      // return { ...doc, score };
     });
   }
 

--- a/langchain/src/vectorstores/mongodb_atlas.ts
+++ b/langchain/src/vectorstores/mongodb_atlas.ts
@@ -177,7 +177,11 @@ export class MongoDBAtlasVectorSearch extends VectorStore {
       if (!includeEmbeddingsFlag) {
         delete doc.metadata[this.embeddingKey];
       }
-      return { ...doc, score };
+      return {
+        pageContent: doc?.pageContent,
+        metadata: { ...doc?.metadata, score },
+      };
+      // return { ...doc, score };
     });
   }
 

--- a/langchain/src/vectorstores/tests/hnswlib.test.ts
+++ b/langchain/src/vectorstores/tests/hnswlib.test.ts
@@ -59,5 +59,7 @@ test("Test HNSWLib metadata filtering", async () => {
     (document) => document.metadata.id === 3
   );
 
-  expect(results).toEqual([new Document({ metadata: { id: 3 }, pageContent })]);
+  expect(results).toEqual([
+    new Document({ metadata: { id: 3, score: 0 }, pageContent }),
+  ]);
 });


### PR DESCRIPTION
_getRelevantDocuments: Since SimilaritySearch is using by default SearchWithScore under the hood, worths including in returned documents metadata the score info. (applied same logic to MDB Atlas MMR Search)

Fixes # (2191)