### PR TITLE
Adds base case for functional translator filter

### DIFF
--- a/langchain/src/retrievers/self_query/functional.ts
+++ b/langchain/src/retrievers/self_query/functional.ts
@@ -131,6 +131,9 @@ export class FunctionalTranslator extends BaseTranslator {
   visitStructuredQuery(
     query: StructuredQuery
   ): this["VisitStructuredQueryOutput"] {
+    if (!query.filter) {
+      return { filter: () => false };
+    }
     const filterFunction = query.filter?.accept(this);
     if (typeof filterFunction !== "function") {
       throw new Error("Structured query filter is not a function");


### PR DESCRIPTION
If no filter could be generated for a given query, the translator would throw a cryptic error. 

This PR makes the filter return false for all documents.