### PR TITLE
Adds parent document retriever

### DIFF
--- a/docs/extras/modules/data_connection/retrievers/integrations/parent-document-retriever.mdx
+++ b/docs/extras/modules/data_connection/retrievers/integrations/parent-document-retriever.mdx
@@ -6,8 +6,9 @@ hide_table_of_contents: true
 
 When splitting documents for retrieval, there are often conflicting desires:
 
-You may want to have small documents, so that their embeddings can most accurately reflect their meaning. If too long, then the embeddings can lose meaning.
-You want to have long enough documents that the context of each chunk is retained.
+1. You may want to have small documents, so that their embeddings can most accurately reflect their meaning. If too long, then the embeddings can lose meaning.
+2. You want to have long enough documents that the context of each chunk is retained.
+
 The ParentDocumentRetriever strikes that balance by splitting and storing small chunks of data. During retrieval, it first fetches the small chunks but then looks up the parent ids for those chunks and returns those larger documents.
 
 Note that "parent document" refers to the document that a small chunk originated from. This can either be the whole raw document OR a larger chunk.

--- a/docs/extras/modules/data_connection/retrievers/integrations/parent-document-retriever.mdx
+++ b/docs/extras/modules/data_connection/retrievers/integrations/parent-document-retriever.mdx
@@ -1,0 +1,20 @@
+---
+hide_table_of_contents: true
+---
+
+# Parent Document Retriever
+
+When splitting documents for retrieval, there are often conflicting desires:
+
+You may want to have small documents, so that their embeddings can most accurately reflect their meaning. If too long, then the embeddings can lose meaning.
+You want to have long enough documents that the context of each chunk is retained.
+The ParentDocumentRetriever strikes that balance by splitting and storing small chunks of data. During retrieval, it first fetches the small chunks but then looks up the parent ids for those chunks and returns those larger documents.
+
+Note that "parent document" refers to the document that a small chunk originated from. This can either be the whole raw document OR a larger chunk.
+
+## Usage
+
+import CodeBlock from "@theme/CodeBlock";
+import Example from "@examples/retrievers/parent_document_retriever.ts";
+
+<CodeBlock language="typescript">{Example}</CodeBlock>

--- a/examples/src/retrievers/parent_document_retriever.ts
+++ b/examples/src/retrievers/parent_document_retriever.ts
@@ -1,0 +1,52 @@
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { MemoryVectorStore } from "langchain/vectorstores/memory";
+import { InMemoryDocstore } from "langchain/stores/doc/in_memory";
+import { ParentDocumentRetriever } from "langchain/retrievers/parent_document";
+import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
+import { TextLoader } from "langchain/document_loaders/fs/text";
+
+const vectorstore = new MemoryVectorStore(new OpenAIEmbeddings());
+const docstore = new InMemoryDocstore();
+const retriever = new ParentDocumentRetriever({
+  vectorstore,
+  docstore,
+  // Optional, not required if you're already passing in split documents
+  parentSplitter: new RecursiveCharacterTextSplitter({
+    chunkOverlap: 0,
+    chunkSize: 500,
+  }),
+  childSplitter: new RecursiveCharacterTextSplitter({
+    chunkOverlap: 0,
+    chunkSize: 50,
+  }),
+});
+const textLoader = new TextLoader("../examples/state_of_the_union.txt");
+const parentDocuments = await textLoader.load();
+
+// We must add the parent documents via the retriever's addDocuments method
+await retriever.addDocuments(parentDocuments);
+
+const retrievedDocs = await retriever.getRelevantDocuments("justice breyer");
+
+// Retrieved chunks are the larger parent chunks
+console.log(retrievedDocs);
+/*
+  [
+    Document {
+      pageContent: 'Tonight, I call on the Senate to pass — pass the Freedom to Vote Act. Pass the John Lewis Act — Voting Rights Act. And while you’re at it, pass the DISCLOSE Act so Americans know who is funding our elections.\n' +
+        '\n' +
+        'Look, tonight, I’d — I’d like to honor someone who has dedicated his life to serve this country: Justice Breyer — an Army veteran, Constitutional scholar, retiring Justice of the United States Supreme Court.',
+      metadata: { source: '../examples/state_of_the_union.txt', loc: [Object] }
+    },
+    Document {
+      pageContent: 'As I did four days ago, I’ve nominated a Circuit Court of Appeals — Ketanji Brown Jackson. One of our nation’s top legal minds who will continue in just Brey- — Justice Breyer’s legacy of excellence. A former top litigator in private practice, a former federal public defender from a family of public-school educators and police officers — she’s a consensus builder.',
+      metadata: { source: '../examples/state_of_the_union.txt', loc: [Object] }
+    },
+    Document {
+      pageContent: 'Justice Breyer, thank you for your service. Thank you, thank you, thank you. I mean it. Get up. Stand — let me see you. Thank you.\n' +
+        '\n' +
+        'And we all know — no matter what your ideology, we all know one of the most serious constitutional responsibilities a President has is nominating someone to serve on the United States Supreme Court.',
+      metadata: { source: '../examples/state_of_the_union.txt', loc: [Object] }
+    }
+  ]
+*/

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -406,6 +406,9 @@ retrievers/contextual_compression.d.ts
 retrievers/document_compressors.cjs
 retrievers/document_compressors.js
 retrievers/document_compressors.d.ts
+retrievers/parent_document.cjs
+retrievers/parent_document.js
+retrievers/parent_document.d.ts
 retrievers/time_weighted.cjs
 retrievers/time_weighted.js
 retrievers/time_weighted.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -418,6 +418,9 @@
     "retrievers/document_compressors.cjs",
     "retrievers/document_compressors.js",
     "retrievers/document_compressors.d.ts",
+    "retrievers/parent_document.cjs",
+    "retrievers/parent_document.js",
+    "retrievers/parent_document.d.ts",
     "retrievers/time_weighted.cjs",
     "retrievers/time_weighted.js",
     "retrievers/time_weighted.d.ts",
@@ -1640,6 +1643,11 @@
       "types": "./retrievers/document_compressors.d.ts",
       "import": "./retrievers/document_compressors.js",
       "require": "./retrievers/document_compressors.cjs"
+    },
+    "./retrievers/parent_document": {
+      "types": "./retrievers/parent_document.d.ts",
+      "import": "./retrievers/parent_document.js",
+      "require": "./retrievers/parent_document.cjs"
     },
     "./retrievers/time_weighted": {
       "types": "./retrievers/time_weighted.d.ts",

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -167,6 +167,7 @@ const entrypoints = {
   "retrievers/databerry": "retrievers/databerry",
   "retrievers/contextual_compression": "retrievers/contextual_compression",
   "retrievers/document_compressors": "retrievers/document_compressors/index",
+  "retrievers/parent_document": "retrievers/parent_document",
   "retrievers/time_weighted": "retrievers/time_weighted",
   "retrievers/document_compressors/chain_extract":
     "retrievers/document_compressors/chain_extract",

--- a/langchain/src/load/import_map.ts
+++ b/langchain/src/load/import_map.ts
@@ -44,6 +44,7 @@ export * as retrievers__remote from "../retrievers/remote/index.js";
 export * as retrievers__databerry from "../retrievers/databerry.js";
 export * as retrievers__contextual_compression from "../retrievers/contextual_compression.js";
 export * as retrievers__document_compressors from "../retrievers/document_compressors/index.js";
+export * as retrievers__parent_document from "../retrievers/parent_document.js";
 export * as retrievers__time_weighted from "../retrievers/time_weighted.js";
 export * as retrievers__document_compressors__chain_extract from "../retrievers/document_compressors/chain_extract.js";
 export * as retrievers__hyde from "../retrievers/hyde.js";

--- a/langchain/src/retrievers/parent_document.ts
+++ b/langchain/src/retrievers/parent_document.ts
@@ -1,0 +1,118 @@
+import * as uuid from "uuid";
+
+import { BaseRetriever, BaseRetrieverInput } from "../schema/retriever.js";
+import { Document } from "../document.js";
+import { VectorStore } from "../vectorstores/base.js";
+import { Docstore } from "../schema/index.js";
+import { TextSplitter } from "../text_splitter.js";
+
+export interface ParentDocumentRetrieverFields extends BaseRetrieverInput {
+  vectorstore: VectorStore;
+  docstore: Docstore;
+  childSplitter: TextSplitter;
+  parentSplitter?: TextSplitter;
+  idKey?: string;
+}
+
+export class ParentDocumentRetriever extends BaseRetriever {
+  lc_namespace = ["langchain", "retrievers", "parent_document"];
+
+  protected vectorstore: VectorStore;
+
+  protected docstore: Docstore;
+
+  protected childSplitter: TextSplitter;
+
+  protected parentSplitter?: TextSplitter;
+
+  protected idKey = "doc_id";
+
+  constructor(fields: ParentDocumentRetrieverFields) {
+    super(fields);
+    this.vectorstore = fields.vectorstore;
+    this.docstore = fields.docstore;
+    this.childSplitter = fields.childSplitter;
+    this.parentSplitter = fields.parentSplitter;
+    this.idKey = fields.idKey ?? this.idKey;
+  }
+
+  async _getRelevantDocuments(query: string): Promise<Document[]> {
+    const subDocs = await this.vectorstore.similaritySearch(query);
+    // Maintain order
+    const parentDocIds: string[] = [];
+    for (const doc of subDocs) {
+      if (!parentDocIds.includes(doc.metadata[this.idKey])) {
+        parentDocIds.push(doc.metadata[this.idKey]);
+      }
+    }
+    const parentDocs: Document[] = [];
+    for (const parentDocId of parentDocIds) {
+      const parentDoc = await this.docstore.search(parentDocId);
+      if (parentDoc !== undefined) {
+        parentDocs.push(parentDoc);
+      }
+    }
+    return parentDocs;
+  }
+
+  /**
+   * Adds documents to the docstore and vectorstores.
+   * @param docs The documents to add
+   * @param config.ids Optional list of ids for documents. If provided should be the same
+   *   length as the list of documents. Can provided if parent documents
+   *   are already in the document store and you don't want to re-add
+   *   to the docstore. If not provided, random UUIDs will be used as ids.
+   * @param config.addToDocstore Boolean of whether to add documents to docstore.
+   * This can be false if and only if `ids` are provided. You may want
+   *   to set this to False if the documents are already in the docstore
+   *   and you don't want to re-add them.
+   */
+  async addDocuments(
+    docs: Document[],
+    config?: {
+      ids?: string[];
+      addToDocstore?: boolean;
+    }
+  ): Promise<void> {
+    const { ids, addToDocstore = true } = config ?? {};
+    const parentDocs = this.parentSplitter
+      ? await this.parentSplitter.splitDocuments(docs)
+      : docs;
+    let parentDocIds;
+    if (ids === undefined) {
+      if (!addToDocstore) {
+        throw new Error(
+          `If ids are not passed in, "config.addToDocstore" MUST be true`
+        );
+      }
+      parentDocIds = parentDocs.map((_doc: Document) => uuid.v4());
+    } else {
+      parentDocIds = ids;
+    }
+    if (parentDocs.length !== parentDocIds.length) {
+      throw new Error(
+        `Got uneven list of documents and ids.\nIf "ids" is provided, should be same length as "documents".`
+      );
+    }
+    const embeddedDocs: Document[] = [];
+    const fullDocs: Record<string, Document> = {};
+    for (let i = 0; i < parentDocs.length; i += 1) {
+      const parentDoc = parentDocs[i];
+      const parentDocId = parentDocIds[i];
+      const subDocs = await this.childSplitter.splitDocuments([parentDoc]);
+      const taggedSubDocs = subDocs.map(
+        (subDoc: Document) =>
+          new Document({
+            pageContent: subDoc.pageContent,
+            metadata: { ...subDoc.metadata, [this.idKey]: parentDocId },
+          })
+      );
+      embeddedDocs.push(...taggedSubDocs);
+      fullDocs[parentDocId] = parentDoc;
+    }
+    await this.vectorstore.addDocuments(embeddedDocs);
+    if (addToDocstore) {
+      await this.docstore.add(fullDocs);
+    }
+  }
+}

--- a/langchain/src/retrievers/tests/parent_document.int.test.ts
+++ b/langchain/src/retrievers/tests/parent_document.int.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@jest/globals";
+import { TextLoader } from "../../document_loaders/fs/text.js";
+import { InMemoryDocstore } from "../../stores/doc/in_memory.js";
+import { OpenAIEmbeddings } from "../../embeddings/openai.js";
+import { MemoryVectorStore } from "../../vectorstores/memory.js";
+import { ParentDocumentRetriever } from "../parent_document.js";
+import { RecursiveCharacterTextSplitter } from "../../text_splitter.js";
+
+test("Should return the full document if an unsplit parent document has been added", async () => {
+  const vectorstore = new MemoryVectorStore(new OpenAIEmbeddings());
+  const retriever = new ParentDocumentRetriever({
+    vectorstore,
+    docstore: new InMemoryDocstore(),
+    childSplitter: new RecursiveCharacterTextSplitter({
+      chunkOverlap: 0,
+      chunkSize: 100,
+    }),
+  });
+  const docs = await new TextLoader(
+    "../examples/state_of_the_union.txt"
+  ).load();
+  await retriever.addDocuments(docs);
+
+  const query = "justice breyer";
+  const retrievedDocs = await retriever.getRelevantDocuments(query);
+  expect(retrievedDocs.length).toEqual(1);
+  expect(retrievedDocs[0].pageContent.length).toBeGreaterThan(1000);
+});
+
+test("Should return a part of a document if a parent splitter is passed", async () => {
+  const vectorstore = new MemoryVectorStore(new OpenAIEmbeddings());
+  const docstore = new InMemoryDocstore();
+  const retriever = new ParentDocumentRetriever({
+    vectorstore,
+    docstore,
+    parentSplitter: new RecursiveCharacterTextSplitter({
+      chunkOverlap: 0,
+      chunkSize: 500,
+    }),
+    childSplitter: new RecursiveCharacterTextSplitter({
+      chunkOverlap: 0,
+      chunkSize: 50,
+    }),
+  });
+  const docs = await new TextLoader(
+    "../examples/state_of_the_union.txt"
+  ).load();
+  await retriever.addDocuments(docs);
+  console.log(docstore._docs.size);
+  const query = "justice breyer";
+  const retrievedDocs = await retriever.getRelevantDocuments(query);
+  const vectorstoreRetreivedDocs = await vectorstore.similaritySearch(
+    "justice breyer"
+  );
+  console.log(vectorstoreRetreivedDocs, vectorstoreRetreivedDocs.length);
+  console.log(retrievedDocs);
+  expect(retrievedDocs.length).toBeGreaterThan(1);
+  expect(retrievedDocs[0].pageContent.length).toBeGreaterThan(100);
+});

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -162,6 +162,7 @@
       "src/retrievers/databerry.ts",
       "src/retrievers/contextual_compression.ts",
       "src/retrievers/document_compressors/index.ts",
+      "src/retrievers/parent_document.ts",
       "src/retrievers/time_weighted.ts",
       "src/retrievers/document_compressors/chain_extract.ts",
       "src/retrievers/hyde.ts",

--- a/test-exports-cf/src/entrypoints.js
+++ b/test-exports-cf/src/entrypoints.js
@@ -43,6 +43,7 @@ export * from "langchain/retrievers/remote";
 export * from "langchain/retrievers/databerry";
 export * from "langchain/retrievers/contextual_compression";
 export * from "langchain/retrievers/document_compressors";
+export * from "langchain/retrievers/parent_document";
 export * from "langchain/retrievers/time_weighted";
 export * from "langchain/retrievers/document_compressors/chain_extract";
 export * from "langchain/retrievers/hyde";

--- a/test-exports-cjs/src/entrypoints.js
+++ b/test-exports-cjs/src/entrypoints.js
@@ -43,6 +43,7 @@ const retrievers_remote = require("langchain/retrievers/remote");
 const retrievers_databerry = require("langchain/retrievers/databerry");
 const retrievers_contextual_compression = require("langchain/retrievers/contextual_compression");
 const retrievers_document_compressors = require("langchain/retrievers/document_compressors");
+const retrievers_parent_document = require("langchain/retrievers/parent_document");
 const retrievers_time_weighted = require("langchain/retrievers/time_weighted");
 const retrievers_document_compressors_chain_extract = require("langchain/retrievers/document_compressors/chain_extract");
 const retrievers_hyde = require("langchain/retrievers/hyde");

--- a/test-exports-esbuild/src/entrypoints.js
+++ b/test-exports-esbuild/src/entrypoints.js
@@ -43,6 +43,7 @@ import * as retrievers_remote from "langchain/retrievers/remote";
 import * as retrievers_databerry from "langchain/retrievers/databerry";
 import * as retrievers_contextual_compression from "langchain/retrievers/contextual_compression";
 import * as retrievers_document_compressors from "langchain/retrievers/document_compressors";
+import * as retrievers_parent_document from "langchain/retrievers/parent_document";
 import * as retrievers_time_weighted from "langchain/retrievers/time_weighted";
 import * as retrievers_document_compressors_chain_extract from "langchain/retrievers/document_compressors/chain_extract";
 import * as retrievers_hyde from "langchain/retrievers/hyde";

--- a/test-exports-esm/src/entrypoints.js
+++ b/test-exports-esm/src/entrypoints.js
@@ -43,6 +43,7 @@ import * as retrievers_remote from "langchain/retrievers/remote";
 import * as retrievers_databerry from "langchain/retrievers/databerry";
 import * as retrievers_contextual_compression from "langchain/retrievers/contextual_compression";
 import * as retrievers_document_compressors from "langchain/retrievers/document_compressors";
+import * as retrievers_parent_document from "langchain/retrievers/parent_document";
 import * as retrievers_time_weighted from "langchain/retrievers/time_weighted";
 import * as retrievers_document_compressors_chain_extract from "langchain/retrievers/document_compressors/chain_extract";
 import * as retrievers_hyde from "langchain/retrievers/hyde";

--- a/test-exports-vercel/src/entrypoints.js
+++ b/test-exports-vercel/src/entrypoints.js
@@ -43,6 +43,7 @@ export * from "langchain/retrievers/remote";
 export * from "langchain/retrievers/databerry";
 export * from "langchain/retrievers/contextual_compression";
 export * from "langchain/retrievers/document_compressors";
+export * from "langchain/retrievers/parent_document";
 export * from "langchain/retrievers/time_weighted";
 export * from "langchain/retrievers/document_compressors/chain_extract";
 export * from "langchain/retrievers/hyde";

--- a/test-exports-vite/src/entrypoints.js
+++ b/test-exports-vite/src/entrypoints.js
@@ -43,6 +43,7 @@ export * from "langchain/retrievers/remote";
 export * from "langchain/retrievers/databerry";
 export * from "langchain/retrievers/contextual_compression";
 export * from "langchain/retrievers/document_compressors";
+export * from "langchain/retrievers/parent_document";
 export * from "langchain/retrievers/time_weighted";
 export * from "langchain/retrievers/document_compressors/chain_extract";
 export * from "langchain/retrievers/hyde";


### PR DESCRIPTION
When splitting documents for retrieval, there are often conflicting desires:

1. You may want to have small documents, so that their embeddings can most accurately reflect their meaning. If too long, then the embeddings can lose meaning.

2. You want to have long enough documents that the context of each chunk is retained.

The ParentDocumentRetriever strikes that balance by splitting and storing small chunks of data. During retrieval, it first fetches the small chunks but then looks up the parent ids for those chunks and returns those larger documents.