### PR TITLE
Fix openai function calling parameter format parsing error

### DIFF
--- a/langchain/src/agents/tests/openai.int.test.ts
+++ b/langchain/src/agents/tests/openai.int.test.ts
@@ -1,9 +1,11 @@
 /* eslint-disable no-process-env */
 import { test } from "@jest/globals";
-import { initializeAgentExecutorWithOptions } from "../initialize.js";
+import { ChatOpenAI } from "../../chat_models/openai.js";
+import { SystemMessage } from "../../schema/index.js";
+import { Tool } from "../../tools/base.js";
 import { Calculator } from "../../tools/calculator.js";
 import { SerpAPI } from "../../tools/serpapi.js";
-import { ChatOpenAI } from "../../chat_models/openai.js";
+import { initializeAgentExecutorWithOptions } from "../initialize.js";
 
 test("OpenAIAgent", async () => {
   const executor = await initializeAgentExecutorWithOptions(
@@ -61,6 +63,51 @@ test("OpenAIAgent streaming", async () => {
 
   const result = await executor.call({
     input: "What is the weather in New York?",
+  });
+
+  console.log(result);
+});
+
+test("OpenAIAgent code interpreter", async () => {
+  class PythonTool extends Tool {
+    name = "python";
+
+    description = `Input a string of code to a python interpreter (jupyter kernel). `;
+
+    private async run(code: string) {
+      console.log("run code: ", code);
+      // simulation code running results
+      return ":)";
+    }
+
+    async _call(code: string) {
+      const output = await this.run(code);
+      return output;
+    }
+  }
+
+  const executor = await initializeAgentExecutorWithOptions(
+    [new PythonTool()],
+    new ChatOpenAI({
+      modelName: "gpt-3.5-turbo",
+      temperature: 0,
+      streaming: true,
+      openAIApiKey: process.env.OPENAI_API_KEY,
+    }),
+    {
+      agentType: "openai-functions",
+      returnIntermediateSteps: true,
+      maxIterations: 1,
+      agentArgs: {
+        systemMessage: new SystemMessage(
+          `You are a Assistant is called "Code Interpreter" and capable of using a python code interpreter (sandboxed jupyter kernel) to run code`
+        ),
+      },
+    }
+  );
+
+  const result = await executor.call({
+    input: "Plot a sin wave and show it to me.",
   });
 
   console.log(result);


### PR DESCRIPTION
additional_kwargs.function_call.arguments will sometimes be in a non-JSON format and should be compatible with the string format.

I added a test case (code-interpreter), when the parameter returned by OpenAI function calling is in non-JSON format, the following problems will occur:
<img width="1005" alt="image" src="https://github.com/hwchase17/langchainjs/assets/32236122/9c4b120e-3e74-4ad8-b498-d2514f1a8352">
<img width="547" alt="image" src="https://github.com/hwchase17/langchainjs/assets/32236122/f31f3d1b-0c69-42f2-98e4-8164930af457">

This PR fixes this problem and supports parameter parsing in non-JSON format, which can be tested by `yarn test:single ./src/agents/tests/openai.int.test.ts -t "OpenAIAgent code interpreter"`.
https://app.warp.dev/block/uopAv2WHtht4SB5lRT2xOI