### PR TITLE
Optional 'user' input param for OpenAI API

### DIFF
--- a/langchain/src/chat_models/openai.ts
+++ b/langchain/src/chat_models/openai.ts
@@ -219,6 +219,8 @@ export class ChatOpenAI
 
   stop?: string[];
 
+  user?: string;
+
   timeout?: number;
 
   streaming = false;
@@ -291,6 +293,7 @@ export class ChatOpenAI
     this.n = fields?.n ?? this.n;
     this.logitBias = fields?.logitBias;
     this.stop = fields?.stop;
+    this.user = fields?.user;
 
     this.streaming = fields?.streaming ?? false;
 
@@ -329,6 +332,7 @@ export class ChatOpenAI
       n: this.n,
       logit_bias: this.logitBias,
       stop: options?.stop ?? this.stop,
+      user: this.user,
       stream: this.streaming,
       functions:
         options?.functions ??

--- a/langchain/src/llms/openai-chat.ts
+++ b/langchain/src/llms/openai-chat.ts
@@ -106,6 +106,8 @@ export class OpenAIChat
 
   stop?: string[];
 
+  user?: string;
+
   streaming = false;
 
   openAIApiKey?: string;
@@ -177,6 +179,7 @@ export class OpenAIChat
     this.logitBias = fields?.logitBias;
     this.maxTokens = fields?.maxTokens;
     this.stop = fields?.stop;
+    this.user = fields?.user;
 
     this.streaming = fields?.streaming ?? false;
 
@@ -221,6 +224,7 @@ export class OpenAIChat
       logit_bias: this.logitBias,
       max_tokens: this.maxTokens === -1 ? undefined : this.maxTokens,
       stop: options?.stop ?? this.stop,
+      user: this.user,
       stream: this.streaming,
       ...this.modelKwargs,
     };

--- a/langchain/src/llms/openai.ts
+++ b/langchain/src/llms/openai.ts
@@ -105,6 +105,8 @@ export class OpenAI
 
   stop?: string[];
 
+  user?: string;
+
   streaming = false;
 
   openAIApiKey?: string;
@@ -185,6 +187,7 @@ export class OpenAI
     this.bestOf = fields?.bestOf ?? this.bestOf;
     this.logitBias = fields?.logitBias;
     this.stop = fields?.stop;
+    this.user = fields?.user;
 
     this.streaming = fields?.streaming ?? false;
 
@@ -228,6 +231,7 @@ export class OpenAI
       best_of: this.bestOf,
       logit_bias: this.logitBias,
       stop: options?.stop ?? this.stop,
+      user: this.user,
       stream: this.streaming,
       ...this.modelKwargs,
     };

--- a/langchain/src/types/openai-types.ts
+++ b/langchain/src/types/openai-types.ts
@@ -28,6 +28,9 @@ export declare interface OpenAIBaseInput {
   /** Dictionary used to adjust the probability of specific tokens being generated */
   logitBias?: Record<string, number>;
 
+  /** Unique string identifier representing your end-user, which can help OpenAI to monitor and detect abuse. */
+  user?: string;
+
   /** Whether to stream the results or not. Enabling disables tokenUsage reporting */
   streaming: boolean;
 


### PR DESCRIPTION
Added support for optional 'user' input parameter for OpenAI API.

> A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse

Relevant documentation links:
- https://platform.openai.com/docs/api-reference/completions/create
- https://platform.openai.com/docs/api-reference/chat/create