### PR TITLE
fix loose metadata when retrieve from Chroma

### DIFF
--- a/langchain/src/vectorstores/chroma.ts
+++ b/langchain/src/vectorstores/chroma.ts
@@ -184,16 +184,15 @@ export class Chroma extends VectorStore {
 
     const results: [Document, number][] = [];
     for (let i = 0; i < firstIds.length; i += 1) {
-      let metadata: Document["metadata"] = {};
-      const storedMetadata = firstMetadatas?.[i];
+      let metadata: Document["metadata"] = firstMetadatas?.[i] ?? {};
 
-      if (storedMetadata && storedMetadata.locFrom && storedMetadata.locTo) {
+      if (metadata.locFrom && metadata.locTo) {
         metadata = {
-          ...firstMetadatas[i],
+          ...metadata,
           loc: {
             lines: {
-              from: storedMetadata.locFrom,
-              to: storedMetadata.locTo,
+              from: metadata.locFrom,
+              to: metadata.locTo,
             },
           },
         };


### PR DESCRIPTION
metadata was lost if no line-of-code keys present