### PR TITLE
Mark retriever tool input schema as required

### DIFF
--- a/langchain/src/agents/toolkits/conversational_retrieval/tool.ts
+++ b/langchain/src/agents/toolkits/conversational_retrieval/tool.ts
@@ -1,13 +1,17 @@
+import { z } from "zod";
 import { CallbackManagerForToolRun } from "../../../callbacks/manager.js";
 import { BaseRetriever } from "../../../schema/retriever.js";
-import { DynamicTool, DynamicToolInput } from "../../../tools/dynamic.js";
+import {
+  DynamicStructuredTool,
+  DynamicStructuredToolInput,
+} from "../../../tools/dynamic.js";
 
 export function createRetrieverTool(
   retriever: BaseRetriever,
-  input: Omit<DynamicToolInput, "func">
+  input: Omit<DynamicStructuredToolInput, "func" | "schema">
 ) {
   const func = async (
-    input: string,
+    { input }: { input: string },
     runManager?: CallbackManagerForToolRun
   ) => {
     const docs = await retriever.getRelevantDocuments(
@@ -16,5 +20,10 @@ export function createRetrieverTool(
     );
     return docs.map((doc) => doc.pageContent).join("\n");
   };
-  return new DynamicTool({ ...input, func });
+  const schema = z.object({
+    input: z
+      .string()
+      .describe("Natural language query used as input to the retriever"),
+  });
+  return new DynamicStructuredTool({ ...input, func, schema });
 }

--- a/langchain/src/agents/toolkits/tests/conversational_retrieval.int.test.ts
+++ b/langchain/src/agents/toolkits/tests/conversational_retrieval.int.test.ts
@@ -22,7 +22,7 @@ test("Test ConversationalRetrievalAgent", async () => {
   const tools = [
     createRetrieverTool(vectorStore.asRetriever(), {
       name: "search_LangCo_knowledge",
-      description: "Searches and returns documents regarding LangCo",
+      description: "Searches for and returns documents regarding LangCo",
     }),
   ];
   const executor = await createConversationalRetrievalAgent(llm, tools, {


### PR DESCRIPTION
Fixes #2258.

The retriever tool extended the standard tool class sets a default schema equivalent to `{input?: string}`. This changes the tool to extend structured tool and pass a schema equivalent to `{input: string}` instead.