### PR TITLE
Fix stored function message mapping to chat (#2303)

### DIFF
--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -109,6 +109,10 @@ export interface ChatMessageFieldsWithRole extends BaseMessageFields {
   role: string;
 }
 
+export interface FunctionMessageFieldsWithName extends BaseMessageFields {
+  name: string;
+}
+
 export abstract class BaseMessage
   extends Serializable
   implements BaseMessageFields
@@ -292,14 +296,22 @@ export const AIChatMessage = AIMessage;
 export const SystemChatMessage = SystemMessage;
 
 export class FunctionMessage extends BaseMessage {
+  constructor(fields: FunctionMessageFieldsWithName);
+
   constructor(
     fields: string | BaseMessageFields,
     /** @deprecated */
     name: string
+  )
+
+  constructor(
+    fields: string | FunctionMessageFieldsWithName,
+    /** @deprecated */
+    name?: string
   ) {
     if (typeof fields === "string") {
-      // eslint-disable-next-line no-param-reassign
-      fields = { content: fields, name };
+      // eslint-disable-next-line no-param-reassign, @typescript-eslint/no-non-null-assertion
+      fields = { content: fields, name: name! };
     }
     super(fields);
   }

--- a/langchain/src/schema/index.ts
+++ b/langchain/src/schema/index.ts
@@ -302,7 +302,7 @@ export class FunctionMessage extends BaseMessage {
     fields: string | BaseMessageFields,
     /** @deprecated */
     name: string
-  )
+  );
 
   constructor(
     fields: string | FunctionMessageFieldsWithName,

--- a/langchain/src/stores/message/utils.ts
+++ b/langchain/src/stores/message/utils.ts
@@ -51,7 +51,9 @@ export function mapStoredMessagesToChatMessages(
         if (storedMessage.data.name === undefined) {
           throw new Error("Name must be defined for function messages");
         }
-        return new FunctionMessage(storedMessage.data as FunctionMessageFieldsWithName);
+        return new FunctionMessage(
+          storedMessage.data as FunctionMessageFieldsWithName
+        );
       case "chat": {
         if (storedMessage.data.role === undefined) {
           throw new Error("Role must be defined for chat messages");

--- a/langchain/src/stores/message/utils.ts
+++ b/langchain/src/stores/message/utils.ts
@@ -3,6 +3,8 @@ import {
   BaseMessage,
   ChatMessage,
   ChatMessageFieldsWithRole,
+  FunctionMessage,
+  FunctionMessageFieldsWithName,
   HumanMessage,
   StoredMessage,
   SystemMessage,
@@ -45,6 +47,11 @@ export function mapStoredMessagesToChatMessages(
         return new AIMessage(storedMessage.data);
       case "system":
         return new SystemMessage(storedMessage.data);
+      case "function":
+        if (storedMessage.data.name === undefined) {
+          throw new Error("Name must be defined for function messages");
+        }
+        return new FunctionMessage(storedMessage.data as FunctionMessageFieldsWithName);
       case "chat": {
         if (storedMessage.data.role === undefined) {
           throw new Error("Role must be defined for chat messages");


### PR DESCRIPTION
Added `function` message option to Stored Messages to Chat Messages mapper. Modified constructor for compatibility.

Fixes #2303