### PR TITLE
update myscale default index type

### DIFF
--- a/langchain/src/vectorstores/myscale.ts
+++ b/langchain/src/vectorstores/myscale.ts
@@ -58,7 +58,7 @@ export class MyScaleStore extends VectorStore {
   constructor(embeddings: Embeddings, args: MyScaleLibArgs) {
     super(embeddings, args);
 
-    this.indexType = args.indexType || "IVFFLAT";
+    this.indexType = args.indexType || "MSTG";
     this.indexParam = args.indexParam || {};
     this.columnMap = args.columnMap || {
       id: "id",


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

We update the default index type from `IVFFLAT` to `MSTG`, a new vector type developed by MyScale.