### PR TITLE
Fix serialisation of StrOutputParser and ByteOutputParser

### DIFF
--- a/langchain/src/schema/output_parser.ts
+++ b/langchain/src/schema/output_parser.ts
@@ -176,7 +176,7 @@ export class StringOutputParser extends BaseTransformOutputParser<string> {
     return "StrOutputParser";
   }
 
-  lc_namespace = ["schema", "output_parser"];
+  lc_namespace = ["langchain", "schema", "output_parser"];
 
   lc_serializable = true;
 
@@ -206,7 +206,7 @@ export class BytesOutputParser extends BaseTransformOutputParser<Uint8Array> {
     return "BytesOutputParser";
   }
 
-  lc_namespace = ["schema", "output_parser"];
+  lc_namespace = ["langchain", "schema", "output_parser"];
 
   lc_serializable = true;
 


### PR DESCRIPTION
Missing `langchain` prefix in `lc_namespace` causes the deserialisation of StrOutputParser and BytesOutputParser to fail

SImilar to #2329