### PR TITLE
fix: ListTablesSqlTool to consider includeTables and ignoreTables

### DIFF
--- a/langchain/src/agents/tests/sql.test.ts
+++ b/langchain/src/agents/tests/sql.test.ts
@@ -113,3 +113,37 @@ test("QueryCheckerTool", async () => {
   expect(queryCheckerTool.llmChain).not.toBeNull();
   expect(queryCheckerTool.llmChain.inputKeys).toEqual(["query"]);
 });
+
+test("ListTablesSqlTool with include tables", async () => {
+  const includeTables = ["users"];
+  const datasource = new DataSource({
+    type: "sqlite",
+    database: ":memory:",
+    synchronize: true,
+  });
+  await datasource.initialize();
+  db = await SqlDatabase.fromDataSourceParams({
+    appDataSource: datasource,
+    includesTables: includeTables,
+  });
+  const listSqlTool = new ListTablesSqlTool(db);
+  const result = await listSqlTool.call("");
+  expect(result).toBe("users");
+});
+
+test("ListTablesSqlTool with ignore tables", async () => {
+  const ignoreTables = ["products"];
+  const datasource = new DataSource({
+    type: "sqlite",
+    database: ":memory:",
+    synchronize: true,
+  });
+  await datasource.initialize();
+  db = await SqlDatabase.fromDataSourceParams({
+    appDataSource: datasource,
+    ignoreTables: ignoreTables,
+  });
+  const listSqlTool = new ListTablesSqlTool(db);
+  const result = await listSqlTool.call("");
+  expect(result).toBe("users");
+});

--- a/langchain/src/agents/tests/sql.test.ts
+++ b/langchain/src/agents/tests/sql.test.ts
@@ -115,17 +115,8 @@ test("QueryCheckerTool", async () => {
 });
 
 test("ListTablesSqlTool with include tables", async () => {
-  const includeTables = ["users"];
-  const datasource = new DataSource({
-    type: "sqlite",
-    database: ":memory:",
-    synchronize: true,
-  });
-  await datasource.initialize();
-  db = await SqlDatabase.fromDataSourceParams({
-    appDataSource: datasource,
-    includesTables: includeTables,
-  });
+  const includesTables = ["users"];
+  db.includesTables = includesTables;
   const listSqlTool = new ListTablesSqlTool(db);
   const result = await listSqlTool.call("");
   expect(result).toBe("users");
@@ -133,16 +124,7 @@ test("ListTablesSqlTool with include tables", async () => {
 
 test("ListTablesSqlTool with ignore tables", async () => {
   const ignoreTables = ["products"];
-  const datasource = new DataSource({
-    type: "sqlite",
-    database: ":memory:",
-    synchronize: true,
-  });
-  await datasource.initialize();
-  db = await SqlDatabase.fromDataSourceParams({
-    appDataSource: datasource,
-    ignoreTables: ignoreTables,
-  });
+  db.ignoreTables = ignoreTables;
   const listSqlTool = new ListTablesSqlTool(db);
   const result = await listSqlTool.call("");
   expect(result).toBe("users");

--- a/langchain/src/tools/sql.ts
+++ b/langchain/src/tools/sql.ts
@@ -105,19 +105,30 @@ export class ListTablesSqlTool extends Tool implements SqlTool {
     this.db = db;
   }
 
-  /** @ignore */
   async _call(_: string) {
     try {
-      const tables = this.db.allTables.map(
-        (table: SqlTable) => table.tableName
-      );
+      let selectedTables: SqlTable[] = this.db.allTables;
+
+      if (this.db.includesTables.length > 0) {
+        selectedTables = selectedTables.filter((currentTable) =>
+          this.db.includesTables.includes(currentTable.tableName)
+        );
+      }
+
+      if (this.db.ignoreTables.length > 0) {
+        selectedTables = selectedTables.filter(
+          (currentTable) => !this.db.ignoreTables.includes(currentTable.tableName)
+        );
+      }
+
+      const tables = selectedTables.map((table: SqlTable) => table.tableName);
       return tables.join(", ");
     } catch (error) {
       return `${error}`;
     }
   }
 
-  description = `Input is an empty string, output is a comma separated list of tables in the database.`;
+  description = `Input is an empty string, output is a comma-separated list of tables in the database.`;
 }
 
 /**

--- a/langchain/src/tools/sql.ts
+++ b/langchain/src/tools/sql.ts
@@ -117,7 +117,8 @@ export class ListTablesSqlTool extends Tool implements SqlTool {
 
       if (this.db.ignoreTables.length > 0) {
         selectedTables = selectedTables.filter(
-          (currentTable) => !this.db.ignoreTables.includes(currentTable.tableName)
+          (currentTable) =>
+            !this.db.ignoreTables.includes(currentTable.tableName)
         );
       }
 


### PR DESCRIPTION
### Issue:
The issue was that the ListTablesSqlTool was iterating through all tables in the SqlDatabase instance without considering the includeTables and ignoreTables options. This resulted in the tool listing all tables, regardless of the specified options.

### Fix:
To resolve this issue, the following changes were made:
In the `ListTablesSqlTool` class, the tool now considers the `includesTables` and `ignoreTables` options of the associated `SqlDatabase` instance. The tool uses conditional logic to filter the list of tables based on the provided options, ensuring that only the appropriate tables are listed.

### Changes Made:
1. Modified ListTablesSqlTool implementation to correctly consider `includesTables` and `ignoreTables` options.
2. Added new tests to the test suite to cover scenarios with both includeTables and ignoreTables options.

### Test Cases Added:
1. ListTablesSqlTool with includeTables option: Verifies that only the specified tables are listed.
2. ListTablesSqlTool with ignoreTables option: Verifies that the specified tables are excluded from the list.
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
--> @polpuigdemont


<!-- Remove if not applicable -->

Fixes #2370 