### PR TITLE
fix: improve the ChatConversationalAgentOutputParser filter for markd…

### DIFF
--- a/langchain/src/agents/chat_convo/outputParser.ts
+++ b/langchain/src/agents/chat_convo/outputParser.ts
@@ -38,15 +38,19 @@ export class ChatConversationalAgentOutputParser extends AgentActionOutputParser
    */
   async parse(text: string): Promise<AgentAction | AgentFinish> {
     let jsonOutput = text.trim();
-    if (jsonOutput.includes("```json")) {
-      jsonOutput = jsonOutput.split("```json")[1].trimStart();
-    } else if (jsonOutput.includes("```")) {
-      const firstIndex = jsonOutput.indexOf("```");
-      jsonOutput = jsonOutput.slice(firstIndex + 3).trimStart();
-    }
-    const lastIndex = jsonOutput.lastIndexOf("```");
-    if (lastIndex !== -1) {
-      jsonOutput = jsonOutput.slice(0, lastIndex).trimEnd();
+    if (jsonOutput.includes("```json") || jsonOutput.includes("```")) {
+      const testString = jsonOutput.includes("```json") ? "```json" : "```";
+      const firstIndex = jsonOutput.indexOf(testString);
+      const actionInputIndex = jsonOutput.indexOf("action_input");
+      if (actionInputIndex > firstIndex) {
+        jsonOutput = jsonOutput
+          .slice(firstIndex + testString.length)
+          .trimStart();
+        const lastIndex = jsonOutput.lastIndexOf("```");
+        if (lastIndex !== -1) {
+          jsonOutput = jsonOutput.slice(0, lastIndex).trimEnd();
+        }
+      }
     }
 
     try {

--- a/langchain/src/agents/tests/chat_convo_output_parser.test.ts
+++ b/langchain/src/agents/tests/chat_convo_output_parser.test.ts
@@ -43,6 +43,54 @@ test("Can parse JSON with text in front of it", async () => {
       toolInput:
         "```sql\nSELECT * FROM orders\nJOIN users ON users.id = orders.user_id\nWHERE users.email = 'bud'```",
     },
+    {
+      input:
+        '{\n \t\r\n"action":"Final Answer",\n\t\r  "action_input":"The tool input ```json\\n{\\"yes\\":true}\\n```"\n\t\r}',
+      output:
+        '{"action":"Final Answer","action_input":"The tool input ```json\\n{\\"yes\\":true}\\n```"}',
+      tool: "Final Answer",
+      toolInput: 'The tool input ```json\\n{\\"yes\\":true}\\n```',
+    },
+    {
+      input:
+        '```json\n{\n \t\r\n"action":"Final Answer",\n\t\r  "action_input":"The tool input ```json\\n{\\"yes\\":true}\\n```"\n\t\r}\n\n\n\t\r```',
+      output:
+        '{"action":"Final Answer","action_input":"The tool input ```json\\n{\\"yes\\":true}\\n```"}',
+      tool: "Final Answer",
+      toolInput: 'The tool input ```json\\n{\\"yes\\":true}\\n```',
+    },
+    {
+      input:
+        'Here we have some boilerplate nonsense```json\n{\n \t\r\n"action":"Final Answer",\n\t\r  "action_input":"The tool input ```json\\n{\\"yes\\":true}\\n```"\n\t\r}\n\n\n\t\r``` and at the end there is more nonsense',
+      output:
+        '{"action":"Final Answer","action_input":"The tool input ```json\\n{\\"yes\\":true}\\n```"}',
+      tool: "Final Answer",
+      toolInput: 'The tool input ```json\\n{\\"yes\\":true}\\n```',
+    },
+    {
+      input:
+        'Here we have some boilerplate nonsense```\n{\n \t\r\n"action":"Final Answer",\n\t\r  "action_input":"The tool input ```javascript\\n{\\"yes\\":true}\\n```"\n\t\r}\n\n\n\t\r``` and at the end there is more nonsense',
+      output:
+        '{"action":"Final Answer","action_input":"The tool input ```javascript\\n{\\"yes\\":true}\\n```"}',
+      tool: "Final Answer",
+      toolInput: 'The tool input ```javascript\\n{\\"yes\\":true}\\n```',
+    },
+    {
+      input:
+        '{\n \t\r\n"action":"Final Answer",\n\t\r  "action_input":"The tool input ```javascript\\n{\\"yes\\":true}\\n```"\n\t\r}',
+      output:
+        '{"action":"Final Answer","action_input":"The tool input ```javascript\\n{\\"yes\\":true}\\n```"}',
+      tool: "Final Answer",
+      toolInput: 'The tool input ```javascript\\n{\\"yes\\":true}\\n```',
+    },
+    {
+      input:
+        '{\n \t\r\n"action":"Final Answer",\n\t\r  "action_input":"this is a regular text response"\n\t\r}',
+      output:
+        '{"action":"Final Answer","action_input":"this is a regular text response"}',
+      tool: "Final Answer",
+      toolInput: "this is a regular text response",
+    },
   ];
 
   const p = new ChatConversationalAgentOutputParser({


### PR DESCRIPTION
this pr fixes this [issue](https://github.com/hwchase17/langchainjs/issues/2322) reported by @italojs  it changes the filter logic of the ChatConversationalAgentOutputParser so it can better handle markdown responses,in particular, having json code snippets inside the responses, it also improves dealing with other code snippets beside json formats.