### PR TITLE
Export CallbackManagerForRetrieverRun

### DIFF
--- a/langchain/src/callbacks/index.ts
+++ b/langchain/src/callbacks/index.ts
@@ -20,6 +20,7 @@ export {
 
 export {
   CallbackManager,
+  CallbackManagerForRetrieverRun,
   CallbackManagerForChainRun,
   CallbackManagerForLLMRun,
   CallbackManagerForToolRun,


### PR DESCRIPTION
This simply makes the CallbackManagerForRetrieverRun available, just like the other classes in the file (e.g. CallbackManagerForLLMRun, CallbackManagerForChainRun etc). I'm using it in a new MultiQueryRetriever.