### PR TITLE
feat: custom descriptions to SqlDatabase

### DIFF
--- a/langchain/src/agents/tests/sql.test.ts
+++ b/langchain/src/agents/tests/sql.test.ts
@@ -94,6 +94,34 @@ SELECT * FROM "users" LIMIT 3;
   expect(result.trim()).toBe(expectStr.trim());
 });
 
+test("InfoSqlTool with customDescription", async () => {
+  db.customDescription = {
+    products: "Custom Description for Products Table",
+    users: "Custom Description for Users Table",
+    userss: "Should not appear",
+  };
+  const infoSqlTool = new InfoSqlTool(db);
+  const result = await infoSqlTool.call("users, products");
+  const expectStr = `
+Custom Description for Products Table
+CREATE TABLE products (
+id INTEGER , name TEXT , price INTEGER ) 
+SELECT * FROM "products" LIMIT 3;
+ id name price
+ 1 Apple 100
+ 2 Banana 200
+ 3 Orange 300
+Custom Description for Users Table
+CREATE TABLE users (
+id INTEGER , name TEXT , age INTEGER ) 
+SELECT * FROM "users" LIMIT 3;
+ id name age
+ 1 Alice 20
+ 2 Bob 21
+ 3 Charlie 22`;
+  expect(result.trim()).toBe(expectStr.trim());
+});
+
 test("InfoSqlTool with error", async () => {
   const infoSqlTool = new InfoSqlTool(db);
   const result = await infoSqlTool.call("userss, products");

--- a/langchain/src/sql_db.ts
+++ b/langchain/src/sql_db.ts
@@ -36,6 +36,8 @@ export class SqlDatabase
 
   sampleRowsInTableInfo = 3;
 
+  customDescription?: Record<string, string>;
+
   protected constructor(fields: SqlDatabaseDataSourceParams) {
     super(...arguments);
     this.appDataSource = fields.appDataSource;
@@ -47,6 +49,11 @@ export class SqlDatabase
     this.ignoreTables = fields?.ignoreTables ?? [];
     this.sampleRowsInTableInfo =
       fields?.sampleRowsInTableInfo ?? this.sampleRowsInTableInfo;
+    this.customDescription = Object.fromEntries(
+      Object.entries(fields?.customDescription ?? {}).filter(([key, _]) =>
+        this.allTables.map((table: SqlTable) => table.tableName).includes(key)
+      )
+    );
   }
 
   static async fromDataSourceParams(
@@ -119,7 +126,8 @@ export class SqlDatabase
     return generateTableInfoFromTables(
       selectedTables,
       this.appDataSource,
-      this.sampleRowsInTableInfo
+      this.sampleRowsInTableInfo,
+      this.customDescription
     );
   }
 

--- a/langchain/src/util/sql_utils.ts
+++ b/langchain/src/util/sql_utils.ts
@@ -20,6 +20,7 @@ export interface SqlDatabaseParams {
   includesTables?: Array<string>;
   ignoreTables?: Array<string>;
   sampleRowsInTableInfo?: number;
+  customDescription?: Record<string, string>;
 }
 
 export interface SqlDatabaseOptionsParams extends SqlDatabaseParams {
@@ -238,7 +239,8 @@ const formatSqlResponseToSimpleTableString = (rawResult: unknown): string => {
 export const generateTableInfoFromTables = async (
   tables: Array<SqlTable> | undefined,
   appDataSource: DataSource,
-  nbSampleRow: number
+  nbSampleRow: number,
+  customDescription?: Record<string, string>
 ): Promise<string> => {
   if (!tables) {
     return "";
@@ -246,6 +248,12 @@ export const generateTableInfoFromTables = async (
 
   let globalString = "";
   for (const currentTable of tables) {
+    // Add the custom info of the table
+    const tableCustomDescription =
+      customDescription &&
+      Object.keys(customDescription).includes(currentTable.tableName)
+        ? `${customDescription[currentTable.tableName]}\n`
+        : "";
     // Add the creation of the table in SQL
     let schema = null;
     if (appDataSource.options.type === "postgres") {
@@ -305,7 +313,8 @@ export const generateTableInfoFromTables = async (
     }
 
     globalString = globalString.concat(
-      sqlCreateTableQuery +
+      tableCustomDescription +
+        sqlCreateTableQuery +
         sqlSelectInfoQuery +
         columnNamesConcatString +
         sample


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->


This PR adds implementation and test for custom descriptions for tables in SqlDatabase ( already existing in [python version](libs/langchain/langchain/utilities/sql_database.py)) those descriptions are added to the db class and then used in the get tables info command.

@polpuigdemont