### PR TITLE
fix(issue: 2417): Fixed the bug that the call's values will be filted in RetrivealQaChain

### DIFF
--- a/langchain/src/chains/retrieval_qa.ts
+++ b/langchain/src/chains/retrieval_qa.ts
@@ -74,7 +74,7 @@ export class RetrievalQAChain
       question,
       runManager?.getChild("retriever")
     );
-    const inputs = { question, input_documents: docs };
+    const inputs = { question, input_documents: docs, ...values };
     const result = await this.combineDocumentsChain.call(
       inputs,
       runManager?.getChild("combine_documents")


### PR DESCRIPTION
# Backgroud

RetrievalQAChain extends BaseChain, so it should inherit all the functionalities provided by BaseChain. However, I've noticed that function calls to RetrievalQAChain are filtered, causing some BaseChain features to malfunction.

Example: 
```
import {
  ChatPromptTemplate,
  SystemMessagePromptTemplate,
} from "langchain/prompts";

// 1: this prompt  wants to be used in RetrievalqaChain
const rolePrompt = 'You are a helpful assistant of {field} field.';
const systemMessagePrompt = SystemMessagePromptTemplate.fromTemplate(rolePrompt);
const chatPrompt = ChatPromptTemplate.fromPromptMessages([systemMessagePrompt]);

....

const chain = RetrievalQAChain.fromLLM(model, vectorStoreRetriever, {
    prompt: chatPrompt,
  });

//  2:  Invoking the 'call' function and passing the 'field' variable to the prompt
  const res = await chain.call({
    query: question,
    field: 'aircode',
  });

```

## Expect
-  The field variable in step 2 should be successfully passed to the prompt.

## Actual
- An error is thrown stating that the field variable cannot be found.
