### PR TITLE
Specify number of both child and parent documents in ParentDocumentRetriever

### DIFF
--- a/examples/src/retrievers/parent_document_retriever.ts
+++ b/examples/src/retrievers/parent_document_retriever.ts
@@ -23,9 +23,9 @@ const retriever = new ParentDocumentRetriever({
   // Note that this does not exactly correspond to the number of final (parent) documents
   // retrieved, as multiple child documents can point to the same parent.
   childK: 20,
-  // Optional `k` parameter to limit number of final, parent documents that will be returned from this retriever and
-  // send to LLM
-  parentK: 200,
+  // Optional `k` parameter to limit number of final, parent documents returned from this
+  // retriever and sent to LLM. This is an upper-bound, and the final count may be lower than this.
+  parentK: 5,
 });
 const textLoader = new TextLoader("../examples/state_of_the_union.txt");
 const parentDocuments = await textLoader.load();

--- a/examples/src/retrievers/parent_document_retriever.ts
+++ b/examples/src/retrievers/parent_document_retriever.ts
@@ -23,6 +23,9 @@ const retriever = new ParentDocumentRetriever({
   // Note that this does not exactly correspond to the number of final (parent) documents
   // retrieved, as multiple child documents can point to the same parent.
   childK: 20,
+  // Optional `k` parameter to limit number of final, parent documents that will be returned from this retriever and
+  // send to LLM
+  parentK: 200,
 });
 const textLoader = new TextLoader("../examples/state_of_the_union.txt");
 const parentDocuments = await textLoader.load();

--- a/langchain/src/retrievers/parent_document.ts
+++ b/langchain/src/retrievers/parent_document.ts
@@ -17,6 +17,7 @@ export interface ParentDocumentRetrieverFields extends BaseRetrieverInput {
   parentSplitter?: TextSplitter;
   idKey?: string;
   childK?: number;
+  parentK?: number;
 }
 
 /**
@@ -47,6 +48,8 @@ export class ParentDocumentRetriever extends BaseRetriever {
 
   protected childK?: number;
 
+  protected parentK?: number;
+
   constructor(fields: ParentDocumentRetrieverFields) {
     super(fields);
     this.vectorstore = fields.vectorstore;
@@ -55,6 +58,7 @@ export class ParentDocumentRetriever extends BaseRetriever {
     this.parentSplitter = fields.parentSplitter;
     this.idKey = fields.idKey ?? this.idKey;
     this.childK = fields.childK;
+    this.parentK = fields.parentK;
   }
 
   async _getRelevantDocuments(query: string): Promise<Document[]> {
@@ -73,7 +77,7 @@ export class ParentDocumentRetriever extends BaseRetriever {
         parentDocs.push(parentDoc);
       }
     }
-    return parentDocs;
+    return parentDocs.slice(0, this.parentK);
   }
 
   /**


### PR DESCRIPTION
Allow for specifying number of both child and parent documents in `ParentDocumentRetriever` that will be returned.

Assume that you have 3 documents that are split by `ParentDocumentRetriever` in following way:
* 1 document (300 child documents, 3 parent documents)
* 2 document (500 child documents, 5 parent documents)
* 3 document (200 child documents, 2 parent documents)

If you use `ParentDocumentRetriever` in the old way, let's say with `childK === 20`, vectorstore might give you only 20 found child documents from many more available, which will result in sending to LLM only one parent document instead of more.

**This MR (a little inspired by the recently added `Similarity Score Threshold`) is adding the possibility to control the final number of returned documents.**

So now you have both:
* `childK`
* `parentK`

parameters that allow you to quickly choose how many small child docs you want to search and limit the number of parent documents that will be sent to LLM.

That way, specifying e.g. `childK === 300` and `parentK === 20` I can make sure that:
* all the relevant document are found in vectorstore
* only documents that fit context window of LLM are send to it