### PR TITLE
Recursive url fix

### DIFF
--- a/langchain/src/document_loaders/tests/recursive_url.int.test.ts
+++ b/langchain/src/document_loaders/tests/recursive_url.int.test.ts
@@ -8,7 +8,7 @@ describe("RecursiveUrlLoader", () => {
   test("loading valid url", async () => {
     const url = "https://js.langchain.com/docs/get_started/introduction";
 
-    const compiledConvert = compile({ wordwrap: 130 }); // returns (input: string;) => string;
+    const compiledConvert = compile({ wordwrap: 130 }); // returns (input: string) => string;
 
     const loader = new RecursiveUrlLoader(url, {
       extractor: compiledConvert,
@@ -17,7 +17,23 @@ describe("RecursiveUrlLoader", () => {
     });
 
     const docs = await loader.load();
-    expect(docs.length).toBeGreaterThan(0);
+    expect(docs.length).toBeGreaterThan(1);
+    expect(docs[0].pageContent).toContain("LangChain");
+  });
+
+  test("loading single page", async () => {
+    const url = "https://js.langchain.com/docs/get_started/introduction";
+
+    const compiledConvert = compile({ wordwrap: 130 }); // returns (input: string) => string;
+
+    const loader = new RecursiveUrlLoader(url, {
+      extractor: compiledConvert,
+      maxDepth: 0,
+      excludeDirs: ["https://js.langchain.com/docs/api/"],
+    });
+
+    const docs = await loader.load();
+    expect(docs.length).toBe(1);
     expect(docs[0].pageContent).toContain("LangChain");
   });
 

--- a/langchain/src/document_loaders/web/recursive_url.ts
+++ b/langchain/src/document_loaders/web/recursive_url.ts
@@ -140,7 +140,7 @@ export class RecursiveUrlLoader
     visited: Set<string> = new Set<string>(),
     depth = 0
   ): Promise<Document[]> {
-    if (depth > this.maxDepth) return [];
+    if (depth >= this.maxDepth) return [];
 
     let url = inputUrl;
     if (!inputUrl.endsWith("/")) url += "/";


### PR DESCRIPTION
I noticed a bug when running max depth as zero, which should only return the requested page but instead would return pages as max depth +1.

I also added a test for this with max depth as one.