### PR TITLE
feat(redis vectorstore): add deleteDocuments to redis vectorstore's dropIndex

### DIFF
--- a/docs/extras/modules/data_connection/vectorstores/integrations/redis.mdx
+++ b/docs/extras/modules/data_connection/vectorstores/integrations/redis.mdx
@@ -35,3 +35,9 @@ import IndexExample from "@examples/indexes/vector_stores/redis/redis.ts";
 import QueryExample from "@examples/indexes/vector_stores/redis/redis_query.ts";
 
 <CodeBlock language="typescript">{QueryExample}</CodeBlock>
+
+## Delete an index
+
+import DeleteExample from "@examples/indexes/vector_stores/redis/redis_delete.ts";
+
+<CodeBlock language="typescript">{DeleteExample}</CodeBlock>

--- a/examples/src/indexes/vector_stores/redis/redis_delete.ts
+++ b/examples/src/indexes/vector_stores/redis/redis_delete.ts
@@ -36,4 +36,6 @@ const vectorStore = await RedisVectorStore.fromDocuments(
   }
 );
 
+await vectorStore.delete({ deleteAll: true });
+
 await client.disconnect();

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langchain",
-  "version": "0.0.136",
+  "version": "0.0.137",
   "description": "Typescript bindings for langchain",
   "type": "module",
   "engines": {

--- a/langchain/src/vectorstores/redis.ts
+++ b/langchain/src/vectorstores/redis.ts
@@ -346,6 +346,19 @@ export class RedisVectorStore extends VectorStore {
     }
   }
 
+  /**
+   * Deletes vectors from the vector store.
+   * @param params The parameters for deleting vectors.
+   * @returns A promise that resolves when the vectors have been deleted.
+   */
+  async delete(params: { deleteAll: boolean }): Promise<void> {
+    if (params.deleteAll) {
+      await this.dropIndex(true);
+    } else {
+      throw new Error(`Invalid parameters passed to "delete".`);
+    }
+  }
+
   private buildQuery(
     query: number[],
     k: number,

--- a/langchain/src/vectorstores/redis.ts
+++ b/langchain/src/vectorstores/redis.ts
@@ -332,11 +332,13 @@ export class RedisVectorStore extends VectorStore {
 
   /**
    * Method for dropping an index from the RedisVectorStore.
+   * @param deleteDocuments Optional boolean indicating whether to drop the associated documents.
    * @returns A promise that resolves to a boolean indicating whether the index was dropped.
    */
-  async dropIndex(): Promise<boolean> {
+  async dropIndex(deleteDocuments?: boolean): Promise<boolean> {
     try {
-      await this.redisClient.ft.dropIndex(this.indexName);
+      const options = deleteDocuments ? { DD: deleteDocuments } : undefined;
+      await this.redisClient.ft.dropIndex(this.indexName, options);
 
       return true;
     } catch (err) {

--- a/langchain/src/vectorstores/tests/redis.test.ts
+++ b/langchain/src/vectorstores/tests/redis.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { jest, test, expect } from "@jest/globals";
+import { jest, test, expect, describe } from "@jest/globals";
 import { FakeEmbeddings } from "../../embeddings/fake.js";
 
 import { RedisVectorStore } from "../redis.js";
@@ -17,6 +17,7 @@ const createRedisClientMockup = () => {
         total: 0,
         documents: [],
       }),
+      dropIndex: jest.fn(),
     },
     hSet: hSetMock,
     multi: jest.fn<any>().mockImplementation(() => ({
@@ -111,4 +112,34 @@ test("RedisVectorStore with filters", async () => {
       },
     }
   );
+});
+
+describe("RedisVectorStore dropIndex", () => {
+  const client = createRedisClientMockup();
+  const embeddings = new FakeEmbeddings();
+
+  const store = new RedisVectorStore(embeddings, {
+    redisClient: client as any,
+    indexName: "documents",
+  });
+
+  test("without deleteDocuments param provided", async () => {
+    await store.dropIndex()
+
+    expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", undefined)
+  })
+
+  test("with deleteDocuments as false", async () => {
+    await store.dropIndex(false)
+
+    expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", undefined)
+  })
+
+  test("with deleteDocument as true", async () => {
+    await store.dropIndex(true)
+
+    expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", {
+      DD: true
+    })
+  })
 });

--- a/langchain/src/vectorstores/tests/redis.test.ts
+++ b/langchain/src/vectorstores/tests/redis.test.ts
@@ -124,22 +124,30 @@ describe("RedisVectorStore dropIndex", () => {
   });
 
   test("without deleteDocuments param provided", async () => {
-    await store.dropIndex()
+    await store.dropIndex();
 
-    expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", undefined)
-  })
+    expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", undefined);
+  });
 
   test("with deleteDocuments as false", async () => {
-    await store.dropIndex(false)
+    await store.dropIndex(false);
 
-    expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", undefined)
-  })
+    expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", undefined);
+  });
 
   test("with deleteDocument as true", async () => {
-    await store.dropIndex(true)
+    await store.dropIndex(true);
 
     expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", {
-      DD: true
-    })
-  })
+      DD: true,
+    });
+  });
+
+  test("through delete convenience method", async () => {
+    await store.delete({ deleteAll: true });
+
+    expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", {
+      DD: true,
+    });
+  });
 });


### PR DESCRIPTION
As [`FT.DROPINDEX`](https://redis.io/commands/ft.dropindex/) does not delete the documents associated with the index by default, this change adds a new option to delete documents when dropping an index.