### PR TITLE
Support all Ollama model options

### DIFF
--- a/langchain/src/chat_models/ollama.ts
+++ b/langchain/src/chat_models/ollama.ts
@@ -33,21 +33,47 @@ export class ChatOllama extends SimpleChatModel implements OllamaInput {
 
   baseUrl = "http://localhost:11434";
 
+  embeddingOnly?: boolean;
+
+  f16KV?: boolean;
+
+  frequencyPenalty?: number;
+
+  logitsAll?: boolean;
+
+  lowVram?: boolean;
+
+  mainGpu?: number;
+
   mirostat?: number;
 
   mirostatEta?: number;
 
   mirostatTau?: number;
 
+  numBatch?: number;
+
   numCtx?: number;
 
   numGpu?: number;
 
+  numGqa?: number;
+
+  numKeep?: number;
+
   numThread?: number;
+
+  penalizeNewline?: boolean;
+
+  presencePenalty?: number;
 
   repeatLastN?: number;
 
   repeatPenalty?: number;
+
+  ropeFrequencyBase?: number;
+
+  ropeFrequencyScale?: number;
 
   temperature?: number;
 
@@ -59,25 +85,50 @@ export class ChatOllama extends SimpleChatModel implements OllamaInput {
 
   topP?: number;
 
+  typicalP?: number;
+
+  useMLock?: boolean;
+
+  useMMap?: boolean;
+
+  vocabOnly?: boolean;
+
   constructor(fields: OllamaInput & BaseChatModelParams) {
     super(fields);
     this.model = fields.model ?? this.model;
     this.baseUrl = fields.baseUrl?.endsWith("/")
       ? fields.baseUrl.slice(0, -1)
       : fields.baseUrl ?? this.baseUrl;
+    this.embeddingOnly = fields.embeddingOnly;
+    this.f16KV = fields.f16KV;
+    this.frequencyPenalty = fields.frequencyPenalty;
+    this.logitsAll = fields.logitsAll;
+    this.lowVram = fields.lowVram;
+    this.mainGpu = fields.mainGpu;
     this.mirostat = fields.mirostat;
     this.mirostatEta = fields.mirostatEta;
     this.mirostatTau = fields.mirostatTau;
+    this.numBatch = fields.numBatch;
     this.numCtx = fields.numCtx;
     this.numGpu = fields.numGpu;
+    this.numGqa = fields.numGqa;
+    this.numKeep = fields.numKeep;
     this.numThread = fields.numThread;
+    this.penalizeNewline = fields.penalizeNewline;
+    this.presencePenalty = fields.presencePenalty;
     this.repeatLastN = fields.repeatLastN;
     this.repeatPenalty = fields.repeatPenalty;
+    this.ropeFrequencyBase = fields.ropeFrequencyBase;
+    this.ropeFrequencyScale = fields.ropeFrequencyScale;
     this.temperature = fields.temperature;
     this.stop = fields.stop;
     this.tfsZ = fields.tfsZ;
     this.topK = fields.topK;
     this.topP = fields.topP;
+    this.typicalP = fields.typicalP;
+    this.useMLock = fields.useMLock;
+    this.useMMap = fields.useMMap;
+    this.vocabOnly = fields.vocabOnly;
   }
 
   _llmType() {
@@ -94,19 +145,36 @@ export class ChatOllama extends SimpleChatModel implements OllamaInput {
     return {
       model: this.model,
       options: {
+        embedding_only: this.embeddingOnly,
+        f16_kv: this.f16KV,
+        frequency_penalty: this.frequencyPenalty,
+        logits_all: this.logitsAll,
+        low_vram: this.lowVram,
+        main_gpu: this.mainGpu,
         mirostat: this.mirostat,
         mirostat_eta: this.mirostatEta,
         mirostat_tau: this.mirostatTau,
+        num_batch: this.numBatch,
         num_ctx: this.numCtx,
         num_gpu: this.numGpu,
+        num_gqa: this.numGqa,
+        num_keep: this.numKeep,
         num_thread: this.numThread,
+        penalize_newline: this.penalizeNewline,
+        presence_penalty: this.presencePenalty,
         repeat_last_n: this.repeatLastN,
         repeat_penalty: this.repeatPenalty,
+        rope_frequency_base: this.ropeFrequencyBase,
+        rope_frequency_scale: this.ropeFrequencyScale,
         temperature: this.temperature,
         stop: options?.stop ?? this.stop,
         tfs_z: this.tfsZ,
         top_k: this.topK,
         top_p: this.topP,
+        typical_p: this.typicalP,
+        use_mlock: this.useMLock,
+        use_mmap: this.useMMap,
+        vocab_only: this.vocabOnly,
       },
     };
   }

--- a/langchain/src/llms/ollama.ts
+++ b/langchain/src/llms/ollama.ts
@@ -24,21 +24,47 @@ export class Ollama extends LLM implements OllamaInput {
 
   baseUrl = "http://localhost:11434";
 
+  embeddingOnly?: boolean;
+
+  f16KV?: boolean;
+
+  frequencyPenalty?: number;
+
+  logitsAll?: boolean;
+
+  lowVRAM?: boolean;
+
+  mainGPU?: number;
+
   mirostat?: number;
 
   mirostatEta?: number;
 
   mirostatTau?: number;
 
+  numBatch?: number;
+
   numCtx?: number;
 
   numGpu?: number;
 
+  numGQA?: number;
+
+  numKeep?: number;
+
   numThread?: number;
+
+  penalizeNewline?: boolean;
+
+  presencePenalty?: number;
 
   repeatLastN?: number;
 
   repeatPenalty?: number;
+
+  ropeFrequencyBase?: number;
+
+  ropeFrequencyScale?: number;
 
   temperature?: number;
 
@@ -50,25 +76,51 @@ export class Ollama extends LLM implements OllamaInput {
 
   topP?: number;
 
+  typicalP?: number;
+
+  useMLock?: boolean;
+
+  useMMap?: boolean;
+
+  vocabOnly?: boolean;
+
   constructor(fields: OllamaInput & BaseLLMParams) {
     super(fields);
     this.model = fields.model ?? this.model;
     this.baseUrl = fields.baseUrl?.endsWith("/")
       ? fields.baseUrl.slice(0, -1)
       : fields.baseUrl ?? this.baseUrl;
+
+    this.embeddingOnly = fields.embeddingOnly;
+    this.f16KV = fields.f16KV;
+    this.frequencyPenalty = fields.frequencyPenalty;
+    this.logitsAll = fields.logitsAll;
+    this.lowVRAM = fields.lowVRAM;
+    this.mainGPU = fields.mainGPU;
     this.mirostat = fields.mirostat;
     this.mirostatEta = fields.mirostatEta;
     this.mirostatTau = fields.mirostatTau;
+    this.numBatch = fields.numBatch;
     this.numCtx = fields.numCtx;
     this.numGpu = fields.numGpu;
+    this.numGQA = fields.numGQA;
+    this.numKeep = fields.numKeep;
     this.numThread = fields.numThread;
+    this.penalizeNewline = fields.penalizeNewline;
+    this.presencePenalty = fields.presencePenalty;
     this.repeatLastN = fields.repeatLastN;
     this.repeatPenalty = fields.repeatPenalty;
+    this.ropeFrequencyBase = fields.ropeFrequencyBase;
+    this.ropeFrequencyScale = fields.ropeFrequencyScale;
     this.temperature = fields.temperature;
     this.stop = fields.stop;
     this.tfsZ = fields.tfsZ;
     this.topK = fields.topK;
     this.topP = fields.topP;
+    this.typicalP = fields.typicalP;
+    this.useMLock = fields.useMLock;
+    this.useMMap = fields.useMMap;
+    this.vocabOnly = fields.vocabOnly;
   }
 
   _llmType() {
@@ -79,19 +131,36 @@ export class Ollama extends LLM implements OllamaInput {
     return {
       model: this.model,
       options: {
+        embedding_only: this.embeddingOnly,
+        f16_kv: this.f16KV,
+        frequency_penalty: this.frequencyPenalty,
+        logits_all: this.logitsAll,
+        low_vram: this.lowVRAM,
+        main_gpu: this.mainGPU,
         mirostat: this.mirostat,
         mirostat_eta: this.mirostatEta,
         mirostat_tau: this.mirostatTau,
+        num_batch: this.numBatch,
         num_ctx: this.numCtx,
         num_gpu: this.numGpu,
+        num_gqa: this.numGQA,
+        num_keep: this.numKeep,
         num_thread: this.numThread,
+        penalize_newline: this.penalizeNewline,
+        presence_penalty: this.presencePenalty,
         repeat_last_n: this.repeatLastN,
         repeat_penalty: this.repeatPenalty,
+        rope_frequency_base: this.ropeFrequencyBase,
+        rope_frequency_scale: this.ropeFrequencyScale,
         temperature: this.temperature,
         stop: options?.stop ?? this.stop,
         tfs_z: this.tfsZ,
         top_k: this.topK,
         top_p: this.topP,
+        typical_p: this.typicalP,
+        use_mlock: this.useMLock,
+        use_mmap: this.useMMap,
+        vocab_only: this.vocabOnly,
       },
     };
   }

--- a/langchain/src/llms/ollama.ts
+++ b/langchain/src/llms/ollama.ts
@@ -32,9 +32,9 @@ export class Ollama extends LLM implements OllamaInput {
 
   logitsAll?: boolean;
 
-  lowVRAM?: boolean;
+  lowVram?: boolean;
 
-  mainGPU?: number;
+  mainGpu?: number;
 
   mirostat?: number;
 
@@ -95,8 +95,8 @@ export class Ollama extends LLM implements OllamaInput {
     this.f16KV = fields.f16KV;
     this.frequencyPenalty = fields.frequencyPenalty;
     this.logitsAll = fields.logitsAll;
-    this.lowVRAM = fields.lowVRAM;
-    this.mainGPU = fields.mainGPU;
+    this.lowVram = fields.lowVram;
+    this.mainGpu = fields.mainGpu;
     this.mirostat = fields.mirostat;
     this.mirostatEta = fields.mirostatEta;
     this.mirostatTau = fields.mirostatTau;
@@ -135,8 +135,8 @@ export class Ollama extends LLM implements OllamaInput {
         f16_kv: this.f16KV,
         frequency_penalty: this.frequencyPenalty,
         logits_all: this.logitsAll,
-        low_vram: this.lowVRAM,
-        main_gpu: this.mainGPU,
+        low_vram: this.lowVram,
+        main_gpu: this.mainGpu,
         mirostat: this.mirostat,
         mirostat_eta: this.mirostatEta,
         mirostat_tau: this.mirostatTau,

--- a/langchain/src/llms/ollama.ts
+++ b/langchain/src/llms/ollama.ts
@@ -48,7 +48,7 @@ export class Ollama extends LLM implements OllamaInput {
 
   numGpu?: number;
 
-  numGQA?: number;
+  numGqa?: number;
 
   numKeep?: number;
 
@@ -103,7 +103,7 @@ export class Ollama extends LLM implements OllamaInput {
     this.numBatch = fields.numBatch;
     this.numCtx = fields.numCtx;
     this.numGpu = fields.numGpu;
-    this.numGQA = fields.numGQA;
+    this.numGqa = fields.numGqa;
     this.numKeep = fields.numKeep;
     this.numThread = fields.numThread;
     this.penalizeNewline = fields.penalizeNewline;
@@ -143,7 +143,7 @@ export class Ollama extends LLM implements OllamaInput {
         num_batch: this.numBatch,
         num_ctx: this.numCtx,
         num_gpu: this.numGpu,
-        num_gqa: this.numGQA,
+        num_gqa: this.numGqa,
         num_keep: this.numKeep,
         num_thread: this.numThread,
         penalize_newline: this.penalizeNewline,

--- a/langchain/src/util/ollama.ts
+++ b/langchain/src/util/ollama.ts
@@ -16,7 +16,7 @@ export interface OllamaInput {
   numBatch?: number;
   numCtx?: number;
   numGpu?: number;
-  numGQA?: number;
+  numGqa?: number;
   numKeep?: number;
   numThread?: number;
   penalizeNewline?: boolean;

--- a/langchain/src/util/ollama.ts
+++ b/langchain/src/util/ollama.ts
@@ -2,40 +2,74 @@ import { BaseLanguageModelCallOptions } from "../base_language/index.js";
 import { IterableReadableStream } from "./stream.js";
 
 export interface OllamaInput {
+  embeddingOnly?: boolean;
+  f16KV?: boolean;
+  frequencyPenalty?: number;
+  logitsAll?: boolean;
+  lowVRAM?: boolean;
+  mainGPU?: number;
   model?: string;
   baseUrl?: string;
   mirostat?: number;
   mirostatEta?: number;
   mirostatTau?: number;
+  numBatch?: number;
   numCtx?: number;
   numGpu?: number;
+  numGQA?: number;
+  numKeep?: number;
   numThread?: number;
+  penalizeNewline?: boolean;
+  presencePenalty?: number;
   repeatLastN?: number;
   repeatPenalty?: number;
+  ropeFrequencyBase?: number;
+  ropeFrequencyScale?: number;
   temperature?: number;
   stop?: string[];
   tfsZ?: number;
   topK?: number;
   topP?: number;
+  typicalP?: number;
+  useMLock?: boolean;
+  useMMap?: boolean;
+  vocabOnly?: boolean;
 }
 
 export interface OllamaRequestParams {
   model: string;
   prompt: string;
   options: {
+    embedding_only?: boolean;
+    f16_kv?: boolean;
+    frequency_penalty?: number;
+    logits_all?: boolean;
+    low_vram?: boolean;
+    main_gpu?: number;
     mirostat?: number;
     mirostat_eta?: number;
     mirostat_tau?: number;
+    num_batch?: number;
     num_ctx?: number;
     num_gpu?: number;
+    num_gqa?: number;
+    num_keep?: number;
     num_thread?: number;
+    penalize_newline?: boolean;
+    presence_penalty?: number;
     repeat_last_n?: number;
     repeat_penalty?: number;
+    rope_frequency_base?: number;
+    rope_frequency_scale?: number;
     temperature?: number;
     stop?: string[];
     tfs_z?: number;
     top_k?: number;
     top_p?: number;
+    typical_p?: number;
+    use_mlock?: boolean;
+    use_mmap?: boolean;
+    vocab_only?: boolean;
   };
 }
 

--- a/langchain/src/util/ollama.ts
+++ b/langchain/src/util/ollama.ts
@@ -6,8 +6,8 @@ export interface OllamaInput {
   f16KV?: boolean;
   frequencyPenalty?: number;
   logitsAll?: boolean;
-  lowVRAM?: boolean;
-  mainGPU?: number;
+  lowVram?: boolean;
+  mainGpu?: number;
   model?: string;
   baseUrl?: string;
   mirostat?: number;


### PR DESCRIPTION
According to the [Ollama source code](https://github.com/jmorganca/ollama/blob/main/api/types.go#L168C2-L168C2) there are a few model options which langchainjs does not support yet. This PR adds support for the missing Ollama model params.