### PR TITLE
Puigde/fix custom description from data source params

### DIFF
--- a/langchain/src/sql_db.ts
+++ b/langchain/src/sql_db.ts
@@ -49,11 +49,6 @@ export class SqlDatabase
     this.ignoreTables = fields?.ignoreTables ?? [];
     this.sampleRowsInTableInfo =
       fields?.sampleRowsInTableInfo ?? this.sampleRowsInTableInfo;
-    this.customDescription = Object.fromEntries(
-      Object.entries(fields?.customDescription ?? {}).filter(([key, _]) =>
-        this.allTables.map((table: SqlTable) => table.tableName).includes(key)
-      )
-    );
   }
 
   static async fromDataSourceParams(
@@ -65,6 +60,13 @@ export class SqlDatabase
     }
     sqlDatabase.allTables = await getTableAndColumnsName(
       sqlDatabase.appDataSource
+    );
+    sqlDatabase.customDescription = Object.fromEntries(
+      Object.entries(fields?.customDescription ?? {}).filter(([key, _]) =>
+        sqlDatabase.allTables
+          .map((table: SqlTable) => table.tableName)
+          .includes(key)
+      )
     );
     verifyIncludeTablesExistInDatabase(
       sqlDatabase.allTables,

--- a/langchain/src/tests/sql_database.int.test.ts
+++ b/langchain/src/tests/sql_database.int.test.ts
@@ -143,3 +143,16 @@ test("Test run with error", async () => {
     await db.run("SELECT * FROM userss");
   }).rejects.toThrow("SQLITE_ERROR: no such table: userss");
 });
+
+test("Test customDescription initialization from DataSourceParams", async () => {
+  const db = await SqlDatabase.fromDataSourceParams({
+    appDataSource: datasource,
+    customDescription: {
+      products: "this is a customDescription for table in db",
+      productss: "this customDescription should be skipped as table not in db",
+    },
+  });
+  expect(db.customDescription).toStrictEqual({
+    products: "this is a customDescription for table in db",
+  });
+});


### PR DESCRIPTION
<!--
Thank you for contributing to LangChainJS! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/hwchase17/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/hwchase17/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->
Last Week I added a feature to add customDescriptions to SqlDatabases. The logic works well if assign the property after db init but it is broken in fromDataSourceParams init.

The reason is because at the time of adding the param in the constructor the allTables property is undefined. So the code does not accept any field for customDescription (see code details in the issue description).

This PR fixes that by:
* moving the customDescription assignation after the allTables is set
* adding test

Fixes #2453 