### PR TITLE
Add JS Run Collector

### DIFF
--- a/langchain/src/callbacks/handlers/run_collector.ts
+++ b/langchain/src/callbacks/handlers/run_collector.ts
@@ -1,0 +1,22 @@
+import { BaseRun } from "langsmith/schemas";
+import { BaseTracer } from "./tracer.js";
+
+export class RunCollectorCallbackHandler extends BaseTracer {
+  name = "run_collector";
+
+  exampleId?: string;
+
+  tracedRuns: BaseRun[];
+
+  constructor({ exampleId }: { exampleId?: string } = {}) {
+    super();
+    this.exampleId = exampleId;
+    this.tracedRuns = [];
+  }
+
+  protected async persistRun(run: BaseRun): Promise<void> {
+    const run_ = { ...run };
+    run_.reference_example_id = this.exampleId;
+    this.tracedRuns.push(run_);
+  }
+}

--- a/langchain/src/callbacks/handlers/run_collector.ts
+++ b/langchain/src/callbacks/handlers/run_collector.ts
@@ -1,19 +1,34 @@
 import { BaseRun } from "langsmith/schemas";
 import { BaseTracer } from "./tracer.js";
 
+/**
+ * A callback handler that collects traced runs and makes it easy to fetch the traced run object from calls through any langchain object.
+ * For instance, it makes it easy to fetch the run ID and then do things with that, such as log feedback.
+ */
 export class RunCollectorCallbackHandler extends BaseTracer {
+  /** The name of the callback handler. */
   name = "run_collector";
 
+  /** The ID of the example. */
   exampleId?: string;
 
+  /** An array of traced runs. */
   tracedRuns: BaseRun[];
 
+  /**
+   * Creates a new instance of the RunCollectorCallbackHandler class.
+   * @param exampleId The ID of the example.
+   */
   constructor({ exampleId }: { exampleId?: string } = {}) {
     super();
     this.exampleId = exampleId;
     this.tracedRuns = [];
   }
 
+  /**
+   * Persists the given run object.
+   * @param run The run object to persist.
+   */
   protected async persistRun(run: BaseRun): Promise<void> {
     const run_ = { ...run };
     run_.reference_example_id = this.exampleId;

--- a/langchain/src/callbacks/handlers/run_collector.ts
+++ b/langchain/src/callbacks/handlers/run_collector.ts
@@ -1,4 +1,4 @@
-import { BaseRun } from "langsmith/schemas";
+import { BaseRun, Run } from "langsmith/schemas";
 import { BaseTracer } from "./tracer.js";
 
 /**
@@ -13,7 +13,7 @@ export class RunCollectorCallbackHandler extends BaseTracer {
   exampleId?: string;
 
   /** An array of traced runs. */
-  tracedRuns: BaseRun[];
+  tracedRuns: Run[];
 
   /**
    * Creates a new instance of the RunCollectorCallbackHandler class.
@@ -30,7 +30,7 @@ export class RunCollectorCallbackHandler extends BaseTracer {
    * @param run The run object to persist.
    */
   protected async persistRun(run: BaseRun): Promise<void> {
-    const run_ = { ...run };
+    const run_ = { ...run } as Run;
     run_.reference_example_id = this.exampleId;
     this.tracedRuns.push(run_);
   }

--- a/langchain/src/callbacks/index.ts
+++ b/langchain/src/callbacks/index.ts
@@ -9,6 +9,8 @@ export { Run, RunType, BaseTracer } from "./handlers/tracer.js";
 
 export { ConsoleCallbackHandler } from "./handlers/console.js";
 
+export { RunCollectorCallbackHandler } from "./handlers/run_collector.js";
+
 export { LangChainTracer } from "./handlers/tracer_langchain.js";
 
 export { LangChainTracerV1 } from "./handlers/tracer_langchain_v1.js";

--- a/langchain/src/callbacks/tests/run_collector.test.ts
+++ b/langchain/src/callbacks/tests/run_collector.test.ts
@@ -1,14 +1,16 @@
-import { BaseLLM } from "../../llms/base.js";
+import { v4 as uuidv4, validate } from "uuid";
+import { Run } from "langsmith/schemas";
 import {
   ChatPromptTemplate,
   HumanMessagePromptTemplate,
   SystemMessagePromptTemplate,
 } from "../../prompts/chat.js";
+
+import { BaseLLM } from "../../llms/base.js";
 import { LLMResult } from "../../schema/index.js";
-import { StringOutputParser } from "../../schema/output_parser.js";
+
 import { RunCollectorCallbackHandler } from "../handlers/run_collector.js";
-import { v4 as uuidv4, validate } from "uuid";
-import { Run } from "langsmith/schemas";
+import { StringOutputParser } from "../../schema/output_parser.js";
 
 class FakeLLM extends BaseLLM {
   nrMapCalls = 0;

--- a/langchain/src/callbacks/tests/run_collector.test.ts
+++ b/langchain/src/callbacks/tests/run_collector.test.ts
@@ -8,6 +8,7 @@ import { LLMResult } from "../../schema/index.js";
 import { StringOutputParser } from "../../schema/output_parser.js";
 import { RunCollectorCallbackHandler } from "../handlers/run_collector.js";
 import { v4 as uuidv4, validate } from "uuid";
+import { Run } from "langsmith/schemas";
 
 class FakeLLM extends BaseLLM {
   nrMapCalls = 0;
@@ -47,7 +48,12 @@ describe("RunCollectorCallbackHandler", () => {
     await chain.invoke({ input: "foo" }, { callbacks: [collector] });
 
     expect(collector.tracedRuns.length).toBe(1);
-    expect(validate(collector.tracedRuns[0].id ?? "")).toBe(true);
-    expect(collector.tracedRuns[0].reference_example_id).toBe(exampleId);
+    const tracedRun = collector.tracedRuns[0];
+    expect(tracedRun.id).toBeDefined();
+    if (tracedRun.id && validate(tracedRun.id)) {
+      expect(validate(tracedRun.id)).toBe(true);
+    }
+    expect(tracedRun.reference_example_id).toBe(exampleId);
+    expect((tracedRun as Run)?.child_runs?.length).toBe(3);
   });
 });

--- a/langchain/src/callbacks/tests/run_collector.test.ts
+++ b/langchain/src/callbacks/tests/run_collector.test.ts
@@ -1,0 +1,53 @@
+import { BaseLLM } from "../../llms/base.js";
+import {
+  ChatPromptTemplate,
+  HumanMessagePromptTemplate,
+  SystemMessagePromptTemplate,
+} from "../../prompts/chat.js";
+import { LLMResult } from "../../schema/index.js";
+import { StringOutputParser } from "../../schema/output_parser.js";
+import { RunCollectorCallbackHandler } from "../handlers/run_collector.js";
+import { v4 as uuidv4, validate } from "uuid";
+
+class FakeLLM extends BaseLLM {
+  nrMapCalls = 0;
+
+  nrReduceCalls = 0;
+
+  _llmType(): string {
+    return "fake_1";
+  }
+
+  async _generate(_prompts: string[]): Promise<LLMResult> {
+    return {
+      generations: [
+        [
+          {
+            text: "Foo.",
+          },
+        ],
+      ],
+    };
+  }
+}
+
+describe("RunCollectorCallbackHandler", () => {
+  it("should persist the given run object and set the reference_example_id to the exampleId", async () => {
+    // Create a chain that uses the dataset
+    const prompt = ChatPromptTemplate.fromPromptMessages([
+      SystemMessagePromptTemplate.fromTemplate("You are in a rap battle."),
+      HumanMessagePromptTemplate.fromTemplate("Write the following {input}"),
+    ]);
+    const model = new FakeLLM({});
+    const chain = prompt.pipe(model).pipe(new StringOutputParser());
+
+    const exampleId = uuidv4();
+    const collector = new RunCollectorCallbackHandler({ exampleId });
+
+    await chain.invoke({ input: "foo" }, { callbacks: [collector] });
+
+    expect(collector.tracedRuns.length).toBe(1);
+    expect(validate(collector.tracedRuns[0].id ?? "")).toBe(true);
+    expect(collector.tracedRuns[0].reference_example_id).toBe(exampleId);
+  });
+});


### PR DESCRIPTION
Open to other alternatives, but this PR adds a simple callback handler that adds root traces to a queue so it is easier to retrieve the run ID regardless of the API someone uses within langchain.

An alternative would be to combine this logic in the langchain tracer since the immediate motivation for this is logging feedback to langsmith or a similar service using the run ID