### PR TITLE
Fix typo for `AWS_SECRET_ACCESS_KEY` on sagemaker_endpoint LLM

### DIFF
--- a/langchain/src/llms/sagemaker_endpoint.ts
+++ b/langchain/src/llms/sagemaker_endpoint.ts
@@ -111,7 +111,7 @@ export class SageMakerEndpoint extends LLM {
   get lc_secrets(): { [key: string]: string } | undefined {
     return {
       "clientOptions.credentials.accessKeyId": "AWS_ACCESS_KEY_ID",
-      "clientOptions.credentials.secretAccessKey": "AWS_SECRETE_ACCESS_KEY",
+      "clientOptions.credentials.secretAccessKey": "AWS_SECRET_ACCESS_KEY",
       "clientOptions.credentials.sessionToken": "AWS_SESSION_TOKEN",
     };
   }


### PR DESCRIPTION
Typo fix for `AWS_SECRETE_ACCESS_KEY` -> `AWS_SECRET_ACCESS_KEY`