### PR TITLE
feat(redis vectorstore): add options to redis index creation

### DIFF
--- a/docs/extras/modules/data_connection/vectorstores/integrations/redis.mdx
+++ b/docs/extras/modules/data_connection/vectorstores/integrations/redis.mdx
@@ -36,6 +36,14 @@ import QueryExample from "@examples/indexes/vector_stores/redis/redis_query.ts";
 
 <CodeBlock language="typescript">{QueryExample}</CodeBlock>
 
+## Create index with options
+
+To pass arguments for [index creation](https://redis.io/commands/ft.create/), you can utilize the [available options](https://github.com/redis/node-redis/blob/294cbf8367295ac81cbe51ce2932493ab80493f1/packages/search/lib/commands/CREATE.ts#L4) offered by [node-redis](https://github.com/redis/node-redis) through `createIndexOptions` parameter.
+
+import IndexOptions from "@examples/indexes/vector_stores/redis/redis_index_options.ts";
+
+<CodeBlock language="typescript">{IndexOptions}</CodeBlock>
+
 ## Delete an index
 
 import DeleteExample from "@examples/indexes/vector_stores/redis/redis_delete.ts";

--- a/examples/src/indexes/vector_stores/redis/redis_index_options.ts
+++ b/examples/src/indexes/vector_stores/redis/redis_index_options.ts
@@ -1,0 +1,42 @@
+import { createClient } from "redis";
+import { Document } from "langchain/document";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { RedisVectorStore } from "langchain/vectorstores/redis";
+
+const client = createClient({
+  url: process.env.REDIS_URL ?? "redis://localhost:6379",
+});
+await client.connect();
+
+const docs = [
+  new Document({
+    metadata: { foo: "bar" },
+    pageContent: "redis is fast",
+  }),
+  new Document({
+    metadata: { foo: "bar" },
+    pageContent: "the quick brown fox jumped over the lazy dog",
+  }),
+  new Document({
+    metadata: { baz: "qux" },
+    pageContent: "lorem ipsum dolor sit amet",
+  }),
+  new Document({
+    metadata: { baz: "qux" },
+    pageContent: "consectetur adipiscing elit",
+  }),
+];
+
+const vectorStore = await RedisVectorStore.fromDocuments(
+  docs,
+  new OpenAIEmbeddings(),
+  {
+    redisClient: client,
+    indexName: "docs",
+    createIndexOptions: {
+      TEMPORARY: 1000,
+    },
+  }
+);
+
+await client.disconnect();

--- a/langchain/src/vectorstores/redis.ts
+++ b/langchain/src/vectorstores/redis.ts
@@ -45,40 +45,11 @@ export type CreateSchemaHNSWVectorField = CreateSchemaVectorField<
     EF_RUNTIME?: number;
   }
 >;
-export enum RedisSearchLanguages {
-  ARABIC = "Arabic",
-  BASQUE = "Basque",
-  CATALANA = "Catalan",
-  DANISH = "Danish",
-  DUTCH = "Dutch",
-  ENGLISH = "English",
-  FINNISH = "Finnish",
-  FRENCH = "French",
-  GERMAN = "German",
-  GREEK = "Greek",
-  HUNGARIAN = "Hungarian",
-  INDONESAIN = "Indonesian",
-  IRISH = "Irish",
-  ITALIAN = "Italian",
-  LITHUANIAN = "Lithuanian",
-  NEPALI = "Nepali",
-  NORWEIGAN = "Norwegian",
-  PORTUGUESE = "Portuguese",
-  ROMANIAN = "Romanian",
-  RUSSIAN = "Russian",
-  SPANISH = "Spanish",
-  SWEDISH = "Swedish",
-  TAMIL = "Tamil",
-  TURKISH = "Turkish",
-  CHINESE = "Chinese",
-}
 export type PropertyName = `${"@" | "$."}${string}`;
 export interface RedisVectorStoreIndexOptions {
   ON?: "HASH" | "JSON";
   PREFIX?: string | Array<string>;
   FILTER?: string;
-  LANGUAGE?: RedisSearchLanguages;
-  LANGUAGE_FIELD?: PropertyName;
   SCORE?: number;
   SCORE_FIELD?: PropertyName;
   MAXTEXTFIELDS?: true;

--- a/langchain/src/vectorstores/redis.ts
+++ b/langchain/src/vectorstores/redis.ts
@@ -46,13 +46,18 @@ export type CreateSchemaHNSWVectorField = CreateSchemaVectorField<
   }
 >;
 
-type CreateIndexOptions = NonNullable<Parameters<
-  ReturnType<typeof createClient>["ft"]["create"]
->[3]>;
+type CreateIndexOptions = NonNullable<
+  Parameters<ReturnType<typeof createClient>["ft"]["create"]>[3]
+>;
 
-export type RedisSearchLanguages = `${NonNullable<CreateIndexOptions["LANGUAGE"]>}`;
+export type RedisSearchLanguages = `${NonNullable<
+  CreateIndexOptions["LANGUAGE"]
+>}`;
 
-export type RedisVectorStoreIndexOptions = Omit<CreateIndexOptions, "LANGUAGE"> & { LANGUAGE?: RedisSearchLanguages };
+export type RedisVectorStoreIndexOptions = Omit<
+  CreateIndexOptions,
+  "LANGUAGE"
+> & { LANGUAGE?: RedisSearchLanguages };
 
 /**
  * Interface for the configuration of the RedisVectorStore. It includes
@@ -137,7 +142,7 @@ export class RedisVectorStore extends VectorStore {
     this.createIndexOptions = {
       ON: "HASH",
       PREFIX: this.keyPrefix,
-      ..._dbConfig.createIndexOptions as CreateIndexOptions,
+      ...(_dbConfig.createIndexOptions as CreateIndexOptions),
     };
   }
 

--- a/langchain/src/vectorstores/redis.ts
+++ b/langchain/src/vectorstores/redis.ts
@@ -46,33 +46,33 @@ export type CreateSchemaHNSWVectorField = CreateSchemaVectorField<
   }
 >;
 export enum RedisSearchLanguages {
-    ARABIC = "Arabic",
-    BASQUE = "Basque",
-    CATALANA = "Catalan",
-    DANISH = "Danish",
-    DUTCH = "Dutch",
-    ENGLISH = "English",
-    FINNISH = "Finnish",
-    FRENCH = "French",
-    GERMAN = "German",
-    GREEK = "Greek",
-    HUNGARIAN = "Hungarian",
-    INDONESAIN = "Indonesian",
-    IRISH = "Irish",
-    ITALIAN = "Italian",
-    LITHUANIAN = "Lithuanian",
-    NEPALI = "Nepali",
-    NORWEIGAN = "Norwegian",
-    PORTUGUESE = "Portuguese",
-    ROMANIAN = "Romanian",
-    RUSSIAN = "Russian",
-    SPANISH = "Spanish",
-    SWEDISH = "Swedish",
-    TAMIL = "Tamil",
-    TURKISH = "Turkish",
-    CHINESE = "Chinese"
+  ARABIC = "Arabic",
+  BASQUE = "Basque",
+  CATALANA = "Catalan",
+  DANISH = "Danish",
+  DUTCH = "Dutch",
+  ENGLISH = "English",
+  FINNISH = "Finnish",
+  FRENCH = "French",
+  GERMAN = "German",
+  GREEK = "Greek",
+  HUNGARIAN = "Hungarian",
+  INDONESAIN = "Indonesian",
+  IRISH = "Irish",
+  ITALIAN = "Italian",
+  LITHUANIAN = "Lithuanian",
+  NEPALI = "Nepali",
+  NORWEIGAN = "Norwegian",
+  PORTUGUESE = "Portuguese",
+  ROMANIAN = "Romanian",
+  RUSSIAN = "Russian",
+  SPANISH = "Spanish",
+  SWEDISH = "Swedish",
+  TAMIL = "Tamil",
+  TURKISH = "Turkish",
+  CHINESE = "Chinese",
 }
-export type PropertyName = `${'@' | '$.'}${string}`;
+export type PropertyName = `${"@" | "$."}${string}`;
 export interface RedisVectorStoreIndexOptions {
   ON?: "HASH" | "JSON";
   PREFIX?: string | Array<string>;
@@ -377,7 +377,11 @@ export class RedisVectorStore extends VectorStore {
       [this.metadataKey]: SchemaFieldTypes.TEXT,
     };
 
-    await this.redisClient.ft.create(this.indexName, schema, this.createIndexOptions);
+    await this.redisClient.ft.create(
+      this.indexName,
+      schema,
+      this.createIndexOptions
+    );
   }
 
   /**

--- a/langchain/src/vectorstores/redis.ts
+++ b/langchain/src/vectorstores/redis.ts
@@ -45,22 +45,14 @@ export type CreateSchemaHNSWVectorField = CreateSchemaVectorField<
     EF_RUNTIME?: number;
   }
 >;
-export type PropertyName = `${"@" | "$."}${string}`;
-export interface RedisVectorStoreIndexOptions {
-  ON?: "HASH" | "JSON";
-  PREFIX?: string | Array<string>;
-  FILTER?: string;
-  SCORE?: number;
-  SCORE_FIELD?: PropertyName;
-  MAXTEXTFIELDS?: true;
-  TEMPORARY?: number;
-  NOOFFSETS?: true;
-  NOHL?: true;
-  NOFIELDS?: true;
-  NOFREQS?: true;
-  SKIPINITIALSCAN?: true;
-  STOPWORDS?: string | Array<string>;
-}
+
+type CreateIndexOptions = NonNullable<Parameters<
+  ReturnType<typeof createClient>["ft"]["create"]
+>[3]>;
+
+export type RedisSearchLanguages = `${NonNullable<CreateIndexOptions["LANGUAGE"]>}`;
+
+export type RedisVectorStoreIndexOptions = Omit<CreateIndexOptions, "LANGUAGE"> & { LANGUAGE?: RedisSearchLanguages };
 
 /**
  * Interface for the configuration of the RedisVectorStore. It includes
@@ -112,7 +104,7 @@ export class RedisVectorStore extends VectorStore {
 
   indexOptions: CreateSchemaFlatVectorField | CreateSchemaHNSWVectorField;
 
-  createIndexOptions: RedisVectorStoreIndexOptions;
+  createIndexOptions: CreateIndexOptions;
 
   keyPrefix: string;
 
@@ -145,7 +137,7 @@ export class RedisVectorStore extends VectorStore {
     this.createIndexOptions = {
       ON: "HASH",
       PREFIX: this.keyPrefix,
-      ..._dbConfig.createIndexOptions,
+      ..._dbConfig.createIndexOptions as CreateIndexOptions,
     };
   }
 

--- a/langchain/src/vectorstores/tests/redis.test.ts
+++ b/langchain/src/vectorstores/tests/redis.test.ts
@@ -2,7 +2,7 @@
 import { jest, test, expect, describe } from "@jest/globals";
 import { FakeEmbeddings } from "../../embeddings/fake.js";
 
-import { RedisVectorStore } from "../redis.js";
+import { RedisSearchLanguages, RedisVectorStore } from "../redis.js";
 
 const createRedisClientMockup = () => {
   const hSetMock = jest.fn();
@@ -149,5 +149,76 @@ describe("RedisVectorStore dropIndex", () => {
     expect(client.ft.dropIndex).toHaveBeenCalledWith("documents", {
       DD: true,
     });
+  });
+});
+
+describe("RedisVectorStore createIndex when index does not exist", () => {
+  test("calls ft.create with default create options", async () => {
+    const client = createRedisClientMockup();
+    const embeddings = new FakeEmbeddings();
+    const store = new RedisVectorStore(embeddings, {
+      redisClient: client as any,
+      indexName: "documents",
+    })
+    store.checkIndexExists = jest.fn<any>().mockResolvedValue(false);
+
+    await store.createIndex();
+
+    expect(client.ft.create).toHaveBeenCalledWith(
+      "documents",
+      expect.any(Object),
+      {
+        ON: "HASH",
+        PREFIX: "doc:documents:"
+      },
+    );
+  });
+
+  test("calls ft.create with custom options", async () => {
+    const client = createRedisClientMockup();
+    const embeddings = new FakeEmbeddings();
+    const store = new RedisVectorStore(embeddings, {
+      redisClient: client as any,
+      indexName: "documents",
+      createIndexOptions: {
+        ON: "JSON",
+        FILTER: "@indexName == \"documents\"",
+        LANGUAGE: RedisSearchLanguages.HUNGARIAN,
+        LANGUAGE_FIELD: "@.language",
+        SCORE: 0.5,
+        MAXTEXTFIELDS: true,
+        TEMPORARY: 1000,
+        NOOFFSETS: true,
+        NOHL: true,
+        NOFIELDS: true,
+        NOFREQS: true,
+        SKIPINITIALSCAN: true,
+        STOPWORDS: ["a", "b"],
+      }
+    });
+    store.checkIndexExists = jest.fn<any>().mockResolvedValue(false);
+
+    await store.createIndex();
+
+    expect(client.ft.create).toHaveBeenCalledWith(
+      "documents",
+      expect.any(Object),
+      {
+        ON: "JSON",
+        PREFIX: "doc:documents:",
+        FILTER: "@indexName == \"documents\"",
+        LANGUAGE: "Hungarian",
+        LANGUAGE_FIELD: "@.language",
+        SCORE: 0.5,
+        MAXTEXTFIELDS: true,
+        TEMPORARY: 1000,
+        NOOFFSETS: true,
+        NOHL: true,
+        NOFIELDS: true,
+        NOFREQS: true,
+        SKIPINITIALSCAN: true,
+        STOPWORDS: ["a", "b"],
+      },
+    );
   });
 });

--- a/langchain/src/vectorstores/tests/redis.test.ts
+++ b/langchain/src/vectorstores/tests/redis.test.ts
@@ -159,7 +159,7 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
     const store = new RedisVectorStore(embeddings, {
       redisClient: client as any,
       indexName: "documents",
-    })
+    });
     store.checkIndexExists = jest.fn<any>().mockResolvedValue(false);
 
     await store.createIndex();
@@ -169,8 +169,8 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
       expect.any(Object),
       {
         ON: "HASH",
-        PREFIX: "doc:documents:"
-      },
+        PREFIX: "doc:documents:",
+      }
     );
   });
 
@@ -182,7 +182,7 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
       indexName: "documents",
       createIndexOptions: {
         ON: "JSON",
-        FILTER: "@indexName == \"documents\"",
+        FILTER: '@indexName == "documents"',
         LANGUAGE: RedisSearchLanguages.HUNGARIAN,
         LANGUAGE_FIELD: "@.language",
         SCORE: 0.5,
@@ -194,7 +194,7 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
         NOFREQS: true,
         SKIPINITIALSCAN: true,
         STOPWORDS: ["a", "b"],
-      }
+      },
     });
     store.checkIndexExists = jest.fn<any>().mockResolvedValue(false);
 
@@ -206,7 +206,7 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
       {
         ON: "JSON",
         PREFIX: "doc:documents:",
-        FILTER: "@indexName == \"documents\"",
+        FILTER: '@indexName == "documents"',
         LANGUAGE: "Hungarian",
         LANGUAGE_FIELD: "@.language",
         SCORE: 0.5,
@@ -218,7 +218,7 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
         NOFREQS: true,
         SKIPINITIALSCAN: true,
         STOPWORDS: ["a", "b"],
-      },
+      }
     );
   });
 });

--- a/langchain/src/vectorstores/tests/redis.test.ts
+++ b/langchain/src/vectorstores/tests/redis.test.ts
@@ -192,6 +192,7 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
         NOFREQS: true,
         SKIPINITIALSCAN: true,
         STOPWORDS: ["a", "b"],
+        LANGUAGE: "German",
       },
     });
     store.checkIndexExists = jest.fn<any>().mockResolvedValue(false);

--- a/langchain/src/vectorstores/tests/redis.test.ts
+++ b/langchain/src/vectorstores/tests/redis.test.ts
@@ -2,7 +2,7 @@
 import { jest, test, expect, describe } from "@jest/globals";
 import { FakeEmbeddings } from "../../embeddings/fake.js";
 
-import { RedisSearchLanguages, RedisVectorStore } from "../redis.js";
+import { RedisVectorStore } from "../redis.js";
 
 const createRedisClientMockup = () => {
   const hSetMock = jest.fn();
@@ -183,8 +183,6 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
       createIndexOptions: {
         ON: "JSON",
         FILTER: '@indexName == "documents"',
-        LANGUAGE: RedisSearchLanguages.HUNGARIAN,
-        LANGUAGE_FIELD: "@.language",
         SCORE: 0.5,
         MAXTEXTFIELDS: true,
         TEMPORARY: 1000,
@@ -207,8 +205,6 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
         ON: "JSON",
         PREFIX: "doc:documents:",
         FILTER: '@indexName == "documents"',
-        LANGUAGE: "Hungarian",
-        LANGUAGE_FIELD: "@.language",
         SCORE: 0.5,
         MAXTEXTFIELDS: true,
         TEMPORARY: 1000,

--- a/langchain/src/vectorstores/tests/redis.test.ts
+++ b/langchain/src/vectorstores/tests/redis.test.ts
@@ -215,6 +215,7 @@ describe("RedisVectorStore createIndex when index does not exist", () => {
         NOFREQS: true,
         SKIPINITIALSCAN: true,
         STOPWORDS: ["a", "b"],
+        LANGUAGE: "German",
       }
     );
   });


### PR DESCRIPTION
This change is introducing a `createIndexOptions` config object that accepts the available options for [`ft.create`](https://redis.io/commands/ft.create/). 

I copied the [corresponding interface/type/enum](https://github.com/redis/node-redis/blob/294cbf8367295ac81cbe51ce2932493ab80493f1/packages/search/lib/commands/CREATE.ts#L4) from node-redis as they aren't exported.

Fixes #1488 