### PR TITLE
New Feat: Passing results from OpenAI moderation call

### DIFF
--- a/examples/src/chains/openai_moderation.ts
+++ b/examples/src/chains/openai_moderation.ts
@@ -12,9 +12,14 @@ try {
   });
 
   // Send the user's input to the moderation chain and wait for the result
-  const { output: badResult } = await moderation.call({
+  const { output: badResult, results } = await moderation.call({
     input: badString,
   });
+
+  // You can view the category scores of each category. This is useful when dealing with non-english languages, as it allows you to have a more granular control over moderation.
+  if (results[0].category_scores["harassment/threatening"] > 0.01) {
+    throw new Error("Harassment detected!");
+  }
 
   // If the moderation chain does not detect violating content, it will return the original input and you can proceed to use the result in another chain.
   const model = new OpenAI({ temperature: 0 });

--- a/langchain/src/chains/openai_moderation.ts
+++ b/langchain/src/chains/openai_moderation.ts
@@ -107,6 +107,7 @@ export class OpenAIModerationChain
     const output = this._moderate(text, mod.results[0]);
     return {
       [this.outputKey]: output,
+      results: mod.results,
     };
   }
 

--- a/langchain/src/chains/tests/openai_moderation.int.test.ts
+++ b/langchain/src/chains/tests/openai_moderation.int.test.ts
@@ -22,3 +22,30 @@ test("OpenAI Moderation Test", async () => {
     "The cat (Felis catus) is a domestic species of small carnivorous mammal."
   );
 });
+
+test("OpenAI Moderation Test in non-english language", async () => {
+  const badString =
+    "Vi devus mortigi vin nun! Kaj donu al ĉiuj aliaj pecon da oksigeno kaj ozono, kovru ĝin, por ke ni povu spiri ene de ĉi tiu blua veziko. Ĉar por kio vi estas ĉi tie? Venu por adori min? Mortigu vin mem. Mi volas diri, cent procento. Mil procentoj."; // Written in Esperanto. It's LTG's most famous quote and it's extremely crass, and as such it should not pass, but it does. However, we can check category_scores to see that, indeed, it detected some sort self-harm language in the text, albeit it's non-conclusive.
+  const goodString =
+    "La kato ( Felis catus ) estas hejma specio de malgranda karnovora mamulo.";
+
+  const moderation = new OpenAIModerationChain();
+  const { output: badResult, results } = await moderation.call({
+    input: badString,
+  });
+
+  const { output: goodResult } = await moderation.call({
+    input: goodString,
+  });
+
+  expect(badResult).toEqual(
+    "Vi devus mortigi vin nun! Kaj donu al ĉiuj aliaj pecon da oksigeno kaj ozono, kovru ĝin, por ke ni povu spiri ene de ĉi tiu blua veziko. Ĉar por kio vi estas ĉi tie? Venu por adori min? Mortigu vin mem. Mi volas diri, cent procento. Mil procentoj."
+  );
+  expect(goodResult).toEqual(
+    "La kato ( Felis catus ) estas hejma specio de malgranda karnovora mamulo."
+  );
+
+  console.log(results[0].category_scores);
+
+  expect(results[0].category_scores["self-harm"]).toBeGreaterThan(0.01); // We can have a more granular control over moderation this way. It's not conclusive, but it's better than nothing if the language is not english.
+});


### PR DESCRIPTION
This is very useful for handling non-english language moderation inputs, as OpenAI moderation can sometimes result in false negatives but still detects the usage of some sort of abusive language. So this pull request allows users to set the boundary themselves by filtering by category_scores (see [OpenAI moderation doc](https://platform.openai.com/docs/guides/moderation/quickstart)).