### PR TITLE
Add Ollama embeddings support

### DIFF
--- a/docs/extras/modules/data_connection/text_embedding/integrations/ollama.mdx
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/ollama.mdx
@@ -1,0 +1,56 @@
+# Ollama
+
+The `OllamaEmbeddings` class uses the `/api/embeddings` route of a locally hosted [Ollama](ollama.ai) server to generate embeddings for given texts.
+
+# Setup
+
+Follow [these instructions](https://github.com/jmorganca/ollama) to set up and run a local Ollama instance.
+
+# Usage
+
+Basic usage:
+
+```typescript
+import { OllamaEmbeddings } from "langchain/embeddings/ollama";
+
+const embeddings = new OllamaEmbeddings({
+  model: "llama2", // default value
+  baseUrl: "http://localhost:11434", // default value
+});
+```
+
+Ollama [model parameters](https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values) are also supported:
+
+```typescript
+import { OllamaEmbeddings } from "langchain/embeddings/ollama";
+
+const embeddings = new OllamaEmbeddings({
+  model: "llama2", // default value
+  baseUrl: "http://localhost:11434", // default value
+  requestOptions: {
+    useMMap: true, // use_mmap 1
+    numThreads: 6, // num_thread 6
+    numGpu: 1, // num_gpu 1
+  },
+});
+```
+
+# Example usage:
+
+```typescript
+import { OllamaEmbeddings } from "langchain/embeddings/ollama";
+
+const embeddings = new OllamaEmbeddings({
+  model: "llama2", // default value
+  baseUrl: "http://localhost:11434", // default value
+  requestOptions: {
+    useMMap: true,
+    numThreads: 6,
+    numGpu: 1,
+  },
+});
+
+const documents = ["Hello World!", "Bye Bye"];
+
+const documentEmbeddings = await embeddings.embedDocuments(documents);
+```

--- a/docs/extras/modules/data_connection/text_embedding/integrations/ollama.mdx
+++ b/docs/extras/modules/data_connection/text_embedding/integrations/ollama.mdx
@@ -1,6 +1,6 @@
 # Ollama
 
-The `OllamaEmbeddings` class uses the `/api/embeddings` route of a locally hosted [Ollama](ollama.ai) server to generate embeddings for given texts.
+The `OllamaEmbeddings` class uses the `/api/embeddings` route of a locally hosted [Ollama](https://ollama.ai) server to generate embeddings for given texts.
 
 # Setup
 

--- a/langchain/.gitignore
+++ b/langchain/.gitignore
@@ -70,6 +70,9 @@ embeddings/cache_backed.d.ts
 embeddings/fake.cjs
 embeddings/fake.js
 embeddings/fake.d.ts
+embeddings/ollama.cjs
+embeddings/ollama.js
+embeddings/ollama.d.ts
 embeddings/openai.cjs
 embeddings/openai.js
 embeddings/openai.d.ts

--- a/langchain/package.json
+++ b/langchain/package.json
@@ -82,6 +82,9 @@
     "embeddings/fake.cjs",
     "embeddings/fake.js",
     "embeddings/fake.d.ts",
+    "embeddings/ollama.cjs",
+    "embeddings/ollama.js",
+    "embeddings/ollama.d.ts",
     "embeddings/openai.cjs",
     "embeddings/openai.js",
     "embeddings/openai.d.ts",
@@ -1213,6 +1216,11 @@
       "types": "./embeddings/fake.d.ts",
       "import": "./embeddings/fake.js",
       "require": "./embeddings/fake.cjs"
+    },
+    "./embeddings/ollama": {
+      "types": "./embeddings/ollama.d.ts",
+      "import": "./embeddings/ollama.js",
+      "require": "./embeddings/ollama.cjs"
     },
     "./embeddings/openai": {
       "types": "./embeddings/openai.d.ts",

--- a/langchain/scripts/create-entrypoints.js
+++ b/langchain/scripts/create-entrypoints.js
@@ -37,6 +37,7 @@ const entrypoints = {
   "embeddings/base": "embeddings/base",
   "embeddings/cache_backed": "embeddings/cache_backed",
   "embeddings/fake": "embeddings/fake",
+  "embeddings/ollama": "embeddings/ollama",
   "embeddings/openai": "embeddings/openai",
   "embeddings/cohere": "embeddings/cohere",
   "embeddings/tensorflow": "embeddings/tensorflow",
@@ -222,7 +223,7 @@ const entrypoints = {
   "storage/in_memory": "storage/in_memory",
   "storage/ioredis": "storage/ioredis",
   // hub
-  "hub": "hub",
+  hub: "hub",
   // utilities
   "util/math": "util/math",
   // experimental
@@ -232,7 +233,8 @@ const entrypoints = {
   "experimental/plan_and_execute": "experimental/plan_and_execute/index",
   "experimental/multimodal_embeddings/googlevertexai":
     "experimental/multimodal_embeddings/googlevertexai",
-  "experimental/chat_models/anthropic_functions": "experimental/chat_models/anthropic_functions",
+  "experimental/chat_models/anthropic_functions":
+    "experimental/chat_models/anthropic_functions",
   // evaluation
   evaluation: "evaluation/index",
 };

--- a/langchain/src/embeddings/ollama.ts
+++ b/langchain/src/embeddings/ollama.ts
@@ -28,18 +28,18 @@ export class OllamaEmbeddings extends Embeddings {
 
   requestOptions?: OllamaRequestParams["options"];
 
-  constructor(params: OllamaEmbeddingsParams) {
-    super(params);
+  constructor(params?: OllamaEmbeddingsParams) {
+    super(params || {});
 
-    if (params.model) {
+    if (params?.model) {
       this.model = params.model;
     }
 
-    if (params.url) {
+    if (params?.url) {
       this.baseUrl = params.url;
     }
 
-    if (params.requestOptions) {
+    if (params?.requestOptions) {
       this.requestOptions = this._convertOptions(params.requestOptions);
     }
   }

--- a/langchain/src/embeddings/ollama.ts
+++ b/langchain/src/embeddings/ollama.ts
@@ -24,9 +24,9 @@ interface OllamaEmbeddingsParams extends EmbeddingsParams {
 export class OllamaEmbeddings extends Embeddings {
   model: string;
 
-  requestOptions?: OllamaRequestParams["options"];
-
   baseUrl = "http://localhost:11434";
+
+  requestOptions?: OllamaRequestParams["options"];
 
   constructor(params: OllamaEmbeddingsParams) {
     super(params);

--- a/langchain/src/embeddings/ollama.ts
+++ b/langchain/src/embeddings/ollama.ts
@@ -12,7 +12,7 @@ interface OllamaEmbeddingsParams extends EmbeddingsParams {
   model?: string;
 
   /** Base URL of the Ollama server, defaults to "http://localhost:11434" */
-  url?: string;
+  baseUrl?: string;
 
   /** Advanced Ollama API request parameters in camelCase, see
    * https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
@@ -35,8 +35,8 @@ export class OllamaEmbeddings extends Embeddings {
       this.model = params.model;
     }
 
-    if (params?.url) {
-      this.baseUrl = params.url;
+    if (params?.baseUrl) {
+      this.baseUrl = params.baseUrl;
     }
 
     if (params?.requestOptions) {

--- a/langchain/src/embeddings/ollama.ts
+++ b/langchain/src/embeddings/ollama.ts
@@ -1,0 +1,132 @@
+import { OllamaInput, OllamaRequestParams } from "../util/ollama.js";
+import { Embeddings, EmbeddingsParams } from "./base.js";
+
+type BaseUrl = {
+  url?: string;
+};
+
+type Model = {
+  model: string;
+};
+
+type CamelCasedRequestOptions = Omit<OllamaInput, "baseUrl" | "model">;
+
+type OllamaRequestOptions = {
+  requestOptions?: CamelCasedRequestOptions;
+};
+
+export default class OllamaEmbeddings extends Embeddings {
+  // Embeddings model to use, example: "llama2:13b".
+  model: string;
+
+  // Other model api options, see https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
+  requestOptions?: OllamaRequestParams["options"];
+
+  // base url of the ollama server, defaults to "http://localhost:11434"
+  baseUrl = "http://localhost:11434";
+
+  constructor(
+    params: EmbeddingsParams & Model & BaseUrl & OllamaRequestOptions
+  ) {
+    super(params);
+
+    this.model = params.model;
+
+    if (params.url) {
+      this.baseUrl = params.url;
+    }
+
+    if (params.requestOptions) {
+      this.requestOptions = this._convertOptions(params.requestOptions);
+    }
+  }
+
+  // convert camelCased Ollama request options like "useMMap" to
+  // the snake_cased equivalent which the ollama API actually uses.
+  // Used only for consistency with the llms/Ollama and chatModels/Ollama classes
+  _convertOptions(requestOptions?: CamelCasedRequestOptions) {
+    if (!requestOptions) {
+      return;
+    }
+
+    const snakeCasedOptions: Record<string, unknown> = {};
+    const mapping: Record<keyof CamelCasedRequestOptions, string> = {
+      embeddingOnly: "embedding_only",
+      f16KV: "f16_kv",
+      frequencyPenalty: "frequency_penalty",
+      logitsAll: "logits_all",
+      lowVram: "low_vram",
+      mainGpu: "main_gpu",
+      mirostat: "mirostat",
+      mirostatEta: "mirostat_eta",
+      mirostatTau: "mirostat_tau",
+      numBatch: "num_batch",
+      numCtx: "num_ctx",
+      numGpu: "num_gpu",
+      numGqa: "num_gqa",
+      numKeep: "num_keep",
+      numThread: "num_thread",
+      penalizeNewline: "penalize_newline",
+      presencePenalty: "presence_penalty",
+      repeatLastN: "repeat_last_n",
+      repeatPenalty: "repeat_penalty",
+      ropeFrequencyBase: "rope_frequency_base",
+      ropeFrequencyScale: "rope_frequency_scale",
+      temperature: "temperature",
+      stop: "stop",
+      tfsZ: "tfs_z",
+      topK: "top_k",
+      topP: "top_p",
+      typicalP: "typical_p",
+      useMLock: "use_mlock",
+      useMMap: "use_mmap",
+      vocabOnly: "vocab_only",
+    };
+
+    for (const [key, value] of Object.entries(requestOptions)) {
+      const snakeCasedOption = mapping[key as keyof CamelCasedRequestOptions];
+      if (snakeCasedOption) {
+        snakeCasedOptions[snakeCasedOption] = value;
+      }
+    }
+    return snakeCasedOptions;
+  }
+
+  async _request(prompt: string): Promise<number[]> {
+    const { model, baseUrl, requestOptions } = this;
+
+    const response = await fetch(`${baseUrl}/api/embeddings`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt,
+        model,
+        options: requestOptions,
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Request to Ollama server failed: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const json = await response.json();
+    return json.embedding;
+  }
+
+  async _embed(strings: string[]): Promise<number[][]> {
+    const embeddings: number[][] = [];
+
+    for await (const prompt of strings) {
+      const embedding = await this._request(prompt);
+      embeddings.push(embedding);
+    }
+
+    return embeddings;
+  }
+
+  embedDocuments = async (documents: string[]) => this._embed(documents);
+
+  embedQuery = async (document: string) =>
+    (await this.embedDocuments([document]))[0];
+}

--- a/langchain/src/embeddings/ollama.ts
+++ b/langchain/src/embeddings/ollama.ts
@@ -1,5 +1,5 @@
 import { OllamaInput, OllamaRequestParams } from "../util/ollama.js";
-import { Embeddings } from "./base.js";
+import { Embeddings, EmbeddingsParams } from "./base.js";
 
 type CamelCasedRequestOptions = Omit<OllamaInput, "baseUrl" | "model">;
 
@@ -7,7 +7,7 @@ type CamelCasedRequestOptions = Omit<OllamaInput, "baseUrl" | "model">;
  * Interface for OllamaEmbeddings parameters. Extends EmbeddingsParams and
  * defines additional parameters specific to the OllamaEmbeddings class.
  */
-interface OllamaEmbeddingsParams {
+interface OllamaEmbeddingsParams extends EmbeddingsParams {
   /** The Ollama model to use, e.g: "llama2:13b" */
   model: string;
 

--- a/langchain/src/embeddings/ollama.ts
+++ b/langchain/src/embeddings/ollama.ts
@@ -1,33 +1,34 @@
 import { OllamaInput, OllamaRequestParams } from "../util/ollama.js";
-import { Embeddings, EmbeddingsParams } from "./base.js";
-
-type BaseUrl = {
-  url?: string;
-};
-
-type Model = {
-  model: string;
-};
+import { Embeddings } from "./base.js";
 
 type CamelCasedRequestOptions = Omit<OllamaInput, "baseUrl" | "model">;
 
-type OllamaRequestOptions = {
-  requestOptions?: CamelCasedRequestOptions;
-};
-
-export default class OllamaEmbeddings extends Embeddings {
-  // Embeddings model to use, example: "llama2:13b".
+/**
+ * Interface for OllamaEmbeddings parameters. Extends EmbeddingsParams and
+ * defines additional parameters specific to the OllamaEmbeddings class.
+ */
+interface OllamaEmbeddingsParams {
+  /** The Ollama model to use, e.g: "llama2:13b" */
   model: string;
 
-  // Other model api options, see https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
+  /** Base URL of the Ollama server, defaults to "http://localhost:11434" */
+  url?: string;
+
+  /** Advanced Ollama API request parameters in camelCase, see
+   * https://github.com/jmorganca/ollama/blob/main/docs/modelfile.md#valid-parameters-and-values
+   * for details of the available parameters.
+   */
+  requestOptions?: CamelCasedRequestOptions;
+}
+
+export class OllamaEmbeddings extends Embeddings {
+  model: string;
+
   requestOptions?: OllamaRequestParams["options"];
 
-  // base url of the ollama server, defaults to "http://localhost:11434"
   baseUrl = "http://localhost:11434";
 
-  constructor(
-    params: EmbeddingsParams & Model & BaseUrl & OllamaRequestOptions
-  ) {
+  constructor(params: OllamaEmbeddingsParams) {
     super(params);
 
     this.model = params.model;
@@ -41,9 +42,10 @@ export default class OllamaEmbeddings extends Embeddings {
     }
   }
 
-  // convert camelCased Ollama request options like "useMMap" to
-  // the snake_cased equivalent which the ollama API actually uses.
-  // Used only for consistency with the llms/Ollama and chatModels/Ollama classes
+  /** convert camelCased Ollama request options like "useMMap" to
+   * the snake_cased equivalent which the ollama API actually uses.
+   * Used only for consistency with the llms/Ollama and chatModels/Ollama classes
+   */
   _convertOptions(requestOptions?: CamelCasedRequestOptions) {
     if (!requestOptions) {
       return;

--- a/langchain/src/embeddings/tests/ollama.int.test.ts
+++ b/langchain/src/embeddings/tests/ollama.int.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@jest/globals";
+import { OllamaEmbeddings } from "../ollama.js";
+
+test("Test OllamaEmbeddings.embedQuery", async () => {
+  const embeddings = new OllamaEmbeddings({ model: "llama2" });
+  const res = await embeddings.embedQuery("Hello world");
+  expect(typeof res[0]).toBe("number");
+});
+
+test("Test OllamaEmbeddings.embedDocuments", async () => {
+  const embeddings = new OllamaEmbeddings({ model: "llama2" });
+  const res = await embeddings.embedDocuments(["Hello world", "Bye bye"]);
+  expect(res).toHaveLength(2);
+  expect(typeof res[0][0]).toBe("number");
+  expect(typeof res[1][0]).toBe("number");
+});

--- a/langchain/src/embeddings/tests/ollama.int.test.ts
+++ b/langchain/src/embeddings/tests/ollama.int.test.ts
@@ -2,13 +2,13 @@ import { test, expect } from "@jest/globals";
 import { OllamaEmbeddings } from "../ollama.js";
 
 test("Test OllamaEmbeddings.embedQuery", async () => {
-  const embeddings = new OllamaEmbeddings({ model: "llama2" });
+  const embeddings = new OllamaEmbeddings();
   const res = await embeddings.embedQuery("Hello world");
   expect(typeof res[0]).toBe("number");
 });
 
 test("Test OllamaEmbeddings.embedDocuments", async () => {
-  const embeddings = new OllamaEmbeddings({ model: "llama2" });
+  const embeddings = new OllamaEmbeddings();
   const res = await embeddings.embedDocuments(["Hello world", "Bye bye"]);
   expect(res).toHaveLength(2);
   expect(typeof res[0][0]).toBe("number");

--- a/langchain/src/load/import_map.ts
+++ b/langchain/src/load/import_map.ts
@@ -10,6 +10,7 @@ export * as chains__openai_functions from "../chains/openai_functions/index.js";
 export * as embeddings__base from "../embeddings/base.js";
 export * as embeddings__cache_backed from "../embeddings/cache_backed.js";
 export * as embeddings__fake from "../embeddings/fake.js";
+export * as embeddings__ollama from "../embeddings/ollama.js";
 export * as embeddings__openai from "../embeddings/openai.js";
 export * as embeddings__minimax from "../embeddings/minimax.js";
 export * as llms__base from "../llms/base.js";

--- a/langchain/tsconfig.json
+++ b/langchain/tsconfig.json
@@ -4,11 +4,7 @@
     "outDir": "../dist",
     "rootDir": "./src",
     "target": "ES2021",
-    "lib": [
-      "ES2021",
-      "ES2022.Object",
-      "DOM"
-    ],
+    "lib": ["ES2021", "ES2022.Object", "DOM"],
     "module": "ES2020",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
@@ -22,14 +18,8 @@
     "allowJs": true,
     "strict": true
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "docs"
-  ],
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "docs"],
   "typedocOptions": {
     "entryPoints": [
       "src/load/index.ts",
@@ -55,6 +45,7 @@
       "src/embeddings/base.ts",
       "src/embeddings/cache_backed.ts",
       "src/embeddings/fake.ts",
+      "src/embeddings/ollama.ts",
       "src/embeddings/openai.ts",
       "src/embeddings/cohere.ts",
       "src/embeddings/tensorflow.ts",


### PR DESCRIPTION
Based on the recent [PR](https://github.com/langchain-ai/langchain/pull/10124) by herrjemand in the Langchain python repository I have implemented a class for embeddings using Ollama.

I have only added a little bit of documentation and two simple test cases. This PR might very well not be production ready yet, feedback is much appreciated.

Current problems I see with the implementation:

1. The default optional constructor params "maxConcurrency" and "maxRetries" have to exist in order to extend the base Embeddings class, but are unused by the OllamaEmbeddings class.

2. In order to be consistent with the llms/ollama and chatModels/ollama classes, the api request params are supplied in camelCase ("useMMap") and are then converted to the snake_case format used by the ollama API ("use_mmap").
This is rather awkward, imo.
