### PR TITLE
Loosen outputParser regex to allow lack of space

### DIFF
--- a/langchain/src/agents/mrkl/outputParser.test.ts
+++ b/langchain/src/agents/mrkl/outputParser.test.ts
@@ -1,0 +1,25 @@
+import { ZeroShotAgentOutputParser } from "./outputParser.js";
+
+describe("ZeroShotAgentOutputParser", () => {
+  describe("when action and action input are separated by a space", () => {
+    const TEXT = "Observation: Xyz\n\nAction: ToolX\nAction Input: what is your name?";
+
+    it("parses agent action", async () => {
+      const parser = new ZeroShotAgentOutputParser();
+      const result = await parser.parse(TEXT);
+      expect(result.tool).toBe("ToolX");
+      expect(result.toolInput).toBe("what is your name?");
+    });
+  });
+
+  describe("when action and action input are not separated by a space", () => {
+    const TEXT = "Observation:Xyz\n\nAction:ToolX\nAction Input:what is your name?";
+
+    it("parses agent action", async () => {
+      const parser = new ZeroShotAgentOutputParser();
+      const result = await parser.parse(TEXT);
+      expect(result.tool).toBe("ToolX");
+      expect(result.toolInput).toBe("what is your name?");
+    });
+  });
+});

--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -35,9 +35,7 @@ export class ZeroShotAgentOutputParser extends AgentActionOutputParser {
       };
     }
 
-    const match = /Action:([\s\S]*?)(?:\nAction Input:([\s\S]*?))?$/.exec(
-      text
-    );
+    const match = /Action:([\s\S]*?)(?:\nAction Input:([\s\S]*?))?$/.exec(text);
     if (!match) {
       throw new OutputParserException(`Could not parse LLM output: ${text}`);
     }

--- a/langchain/src/agents/mrkl/outputParser.ts
+++ b/langchain/src/agents/mrkl/outputParser.ts
@@ -35,7 +35,7 @@ export class ZeroShotAgentOutputParser extends AgentActionOutputParser {
       };
     }
 
-    const match = /Action: ([\s\S]*?)(?:\nAction Input: ([\s\S]*?))?$/.exec(
+    const match = /Action:([\s\S]*?)(?:\nAction Input:([\s\S]*?))?$/.exec(
       text
     );
     if (!match) {

--- a/langchain/src/agents/tests/mrkl_agent_output_parser.test.ts
+++ b/langchain/src/agents/tests/mrkl_agent_output_parser.test.ts
@@ -1,8 +1,9 @@
-import { ZeroShotAgentOutputParser } from "./outputParser.js";
+import { ZeroShotAgentOutputParser } from "../mrkl/outputParser.js";
 
 describe("ZeroShotAgentOutputParser", () => {
   describe("when action and action input are separated by a space", () => {
-    const TEXT = "Observation: Xyz\n\nAction: ToolX\nAction Input: what is your name?";
+    const TEXT =
+      "Observation: Xyz\n\nAction: ToolX\nAction Input: what is your name?";
 
     it("parses agent action", async () => {
       const parser = new ZeroShotAgentOutputParser();
@@ -13,7 +14,8 @@ describe("ZeroShotAgentOutputParser", () => {
   });
 
   describe("when action and action input are not separated by a space", () => {
-    const TEXT = "Observation:Xyz\n\nAction:ToolX\nAction Input:what is your name?";
+    const TEXT =
+      "Observation:Xyz\n\nAction:ToolX\nAction Input:what is your name?";
 
     it("parses agent action", async () => {
       const parser = new ZeroShotAgentOutputParser();


### PR DESCRIPTION
Sometimes the LLM won't put spaces between key and value, which causes an error with the current regex. With the update, it works.