### PR TITLE
Switch to `wrangler deploy` because `wrangler publish` is deprecated.

### DIFF
--- a/test-exports-cf/package.json
+++ b/test-exports-cf/package.json
@@ -13,8 +13,8 @@
   "private": true,
   "scripts": {
     "start": "wrangler dev",
-    "deploy": "wrangler publish",
-    "build": "wrangler publish --dry-run --outdir=dist",
+    "deploy": "wrangler deploy",
+    "build": "wrangler deploy --dry-run --outdir=dist",
     "test": "vitest run **/*.unit.test.ts",
     "test:integration": "vitest run **/*.int.test.ts"
   }

--- a/test-exports-cf/src/index.ts
+++ b/test-exports-cf/src/index.ts
@@ -3,7 +3,7 @@
  *
  * - Run `wrangler dev src/index.ts` in your terminal to start a development server
  * - Open a browser tab at http://localhost:8787/ to see your worker in action
- * - Run `wrangler publish src/index.ts --name my-worker` to publish your worker
+ * - Run `wrangler deploy src/index.ts --name my-worker` to publish your worker
  *
  * Learn more at https://developers.cloudflare.com/workers/
  */
@@ -37,16 +37,16 @@ export default {
     ctx: ExecutionContext
   ): Promise<Response> {
 
-    const constructorParameters
-      = env.AZURE_OPENAI_API_KEY ? {
-        azureOpenAIApiKey: env.AZURE_OPENAI_API_KEY,
-        azureOpenAIApiInstanceName: env.AZURE_OPENAI_API_INSTANCE_NAME,
-        azureOpenAIApiDeploymentName: env.AZURE_OPENAI_API_DEPLOYMENT_NAME,
-        azureOpenAIApiVersion: env.AZURE_OPENAI_API_VERSION,
-      } 
+    const constructorParameters = env.AZURE_OPENAI_API_KEY
+      ? {
+          azureOpenAIApiKey: env.AZURE_OPENAI_API_KEY,
+          azureOpenAIApiInstanceName: env.AZURE_OPENAI_API_INSTANCE_NAME,
+          azureOpenAIApiDeploymentName: env.AZURE_OPENAI_API_DEPLOYMENT_NAME,
+          azureOpenAIApiVersion: env.AZURE_OPENAI_API_VERSION,
+        }
       : {
-        openAIApiKey: env.OPENAI_API_KEY,
-      }
+          openAIApiKey: env.OPENAI_API_KEY,
+        };
 
     // Intantiate a few things to test the exports
     new OpenAI(constructorParameters);

--- a/test-exports-cf/src/index.ts
+++ b/test-exports-cf/src/index.ts
@@ -37,16 +37,16 @@ export default {
     ctx: ExecutionContext
   ): Promise<Response> {
 
-    const constructorParameters = env.AZURE_OPENAI_API_KEY
-      ? {
-          azureOpenAIApiKey: env.AZURE_OPENAI_API_KEY,
-          azureOpenAIApiInstanceName: env.AZURE_OPENAI_API_INSTANCE_NAME,
-          azureOpenAIApiDeploymentName: env.AZURE_OPENAI_API_DEPLOYMENT_NAME,
-          azureOpenAIApiVersion: env.AZURE_OPENAI_API_VERSION,
-        }
+    const constructorParameters
+      = env.AZURE_OPENAI_API_KEY ? {
+        azureOpenAIApiKey: env.AZURE_OPENAI_API_KEY,
+        azureOpenAIApiInstanceName: env.AZURE_OPENAI_API_INSTANCE_NAME,
+        azureOpenAIApiDeploymentName: env.AZURE_OPENAI_API_DEPLOYMENT_NAME,
+        azureOpenAIApiVersion: env.AZURE_OPENAI_API_VERSION,
+      }
       : {
-          openAIApiKey: env.OPENAI_API_KEY,
-        };
+        openAIApiKey: env.OPENAI_API_KEY,
+      }
 
     // Intantiate a few things to test the exports
     new OpenAI(constructorParameters);


### PR DESCRIPTION
CI said so:
![image](https://github.com/hwchase17/langchainjs/assets/2348618/3243d297-a029-4372-8615-300a28cae5d5)
