### PR TITLE
`test-exports-*` are built in docker, don't build them globally too.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "packageManager": "yarn@3.4.1",
   "scripts": {
-    "build": "turbo run build --filter=\"!docs_skeleton\"",
+    "build": "turbo run build --filter=\"!docs_skeleton\" --filter=\"!test-exports-*\"",
     "format": "turbo run format",
     "format:check": "turbo run format:check",
     "lint": "turbo run lint --filter=\"!docs_skeleton\"",


### PR DESCRIPTION
The `docker-ci-entrypoint.sh` script that runs inside all export containers contains a `yarn build`, so we don't need the CI `yarn build` to build them too.

If you'd prefer `yarn build` to build everything, I can instead make CI use a different build command — perhaps `yarn build:ci`?