### PR TITLE
Remove docs build since Vercel is doing it, and don't run code tests on docs-only changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Check linting
         run: yarn run lint
 
-  build:
-    name: Build and check types
+  build-docs:
+    name: Build and check docs
     runs-on: ubuntu-latest
     env:
       PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -54,8 +54,8 @@ jobs:
           cache: "yarn"
       - name: Install dependencies
         run: yarn install --immutable
-      - name: Build and check types
-        run: yarn run build
+      - name: Build and check docs
+        run: yarn docs
 
   test:
     name: Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    # Do not run this workflow if only docs changed.
+    paths-ignore:
+      - 'docs/**'
+  workflow_dispatch:  # Allows triggering the workflow manually in GitHub UI
 
 jobs:
   format:
@@ -38,24 +42,6 @@ jobs:
         run: yarn install --immutable --mode=skip-build
       - name: Check linting
         run: yarn run lint
-
-  build-docs:
-    name: Build and check docs
-    runs-on: ubuntu-latest
-    env:
-      PUPPETEER_SKIP_DOWNLOAD: "true"
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "true"
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-          cache: "yarn"
-      - name: Install dependencies
-        run: yarn install --immutable
-      - name: Build and check docs
-        run: yarn docs
 
   test:
     name: Unit Tests


### PR DESCRIPTION
Vercel is already building the docs, so we don't need to do it too:
- Don't run `yarn build` as a separate step, since that only builds docs, examples, and langchain — and the latter two are already tested in unit tests.
- Skip the CI workflow if *only* docs were changed: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths